### PR TITLE
Ignore maven-remote-resources-plugin:bundle goal

### DIFF
--- a/org.eclipse.m2e.lifecyclemapping.defaults/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.m2e.lifecyclemapping.defaults/lifecycle-mapping-metadata.xml
@@ -79,12 +79,13 @@
         <artifactId>maven-remote-resources-plugin</artifactId>
         <versionRange>[1.0,)</versionRange>
         <goals>
+          <goal>bundle</goal>
           <goal>process</goal>
         </goals>
       </pluginExecutionFilter>
       <action>
         <ignore>
-          <message>maven-remote-resources-plugin (goal "process") is ignored by m2e.</message>
+          <message>maven-remote-resources-plugin is ignored by m2e.</message>
         </ignore>
       </action>
     </pluginExecution>


### PR DESCRIPTION
m2eclipse does not know how to map the maven-remote-resources-plugin:bundle goal, which causes a warning on project import

Since the more common "process" goal is already ignored, it would seem useful to ignore this goal too.