### PR TITLE
Bug 564787 - NPE when resolving remote Filesystem project with Eclips…

### DIFF
--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.core.ui/pom.xml
+++ b/org.eclipse.m2e.core.ui/pom.xml
@@ -17,5 +17,6 @@
 
   <artifactId>org.eclipse.m2e.core.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.16.1-SNAPSHOT</version>
   <name>Maven Integration for Eclipse UI Plug-in</name>
 </project>

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizardParentPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizardParentPage.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.core.ui.internal.wizards;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -217,11 +219,11 @@ public class MavenModuleWizardParentPage extends AbstractMavenWizardPage {
       parentObject = pom;
       parentContainer = pom.getParent();
 
-      try {
-        parentModel = MavenPlugin.getMavenModelManager().readMavenModel(pom);
+      try (InputStream pomStream = pom.getContents()) {
+        parentModel = MavenPlugin.getMavenModelManager().readMavenModel(pomStream);
         validateParent();
         parentProjectText.setText(parentModel.getArtifactId());
-      } catch(CoreException e) {
+      } catch(CoreException | IOException e) {
         log.error("Error loading POM: " + e.getMessage(), e); //$NON-NLS-1$
       }
     }

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.10.0",
  org.eclipse.m2e.workspace.cli;bundle-version="0.1.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources;bundle-version="3.9.0",
+ org.eclipse.core.filesystem;bundle-version="1.7.700",
  com.google.guava;bundle-version="[27.1,28.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.1.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -17,6 +17,7 @@
 
   <artifactId>org.eclipse.m2e.core</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.16.1-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse Core Plug-in</name>
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -20,7 +20,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import org.apache.maven.artifact.Artifact;
@@ -67,6 +69,14 @@ public interface IMaven {
 
   public Model readModel(InputStream in) throws CoreException;
 
+  /**
+   * Using {@link File} representations in Eclipse workspaces is prone to errors, since remote filesystems must be
+   * cached via {@link IFileStore#toLocalFile}. Simple transformations via {@link IPath#toFile()} do not work for remote
+   * files.
+   * 
+   * @deprecated use {@link #readModel(InputStream)} instead.
+   */
+  @Deprecated
   public Model readModel(File pomFile) throws CoreException;
 
   public void writeModel(Model model, OutputStream out) throws CoreException;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
@@ -16,6 +16,7 @@ package org.eclipse.m2e.core.embedder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
@@ -93,12 +94,25 @@ public class MavenModelManager {
     return maven.readModel(reader);
   }
 
+  /**
+   * @deprecated use {@link #readMavenModel(InputStream)} instead.
+   */
+  @SuppressWarnings("deprecation")
+  @Deprecated
   public org.apache.maven.model.Model readMavenModel(File pomFile) throws CoreException {
     return maven.readModel(pomFile);
   }
 
+  /**
+   * @deprecated use {@link #readMavenModel(InputStream)} instead.
+   */
+  @Deprecated
   public org.apache.maven.model.Model readMavenModel(IFile pomFile) throws CoreException {
-    return maven.readModel(pomFile.getLocation().toFile());
+    try (InputStream is = pomFile.getContents()) {
+      return maven.readModel(is);
+    } catch(IOException ex) {
+      throw new CoreException(new Status(IStatus.ERROR, IMavenConstants.PLUGIN_ID, -1, null, ex));
+    }
   }
 
   public void createMavenModel(IFile pomFile, org.apache.maven.model.Model model) throws CoreException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -562,6 +562,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public Model readModel(File pomFile) throws CoreException {
     try {
       BufferedInputStream is = new BufferedInputStream(new FileInputStream(pomFile));

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -15,6 +15,8 @@ package org.eclipse.m2e.core.internal.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -939,7 +941,11 @@ public class ProjectConfigurationManager implements IProjectConfigurationManager
     File pomFile = projectInfo.getPomFile();
     Model model = projectInfo.getModel();
     if(model == null) {
-      model = maven.readModel(pomFile);
+      try (InputStream pomStream = Files.newInputStream(pomFile.toPath())) {
+        model = maven.readModel(pomStream);
+      } catch(IOException ex) {
+        log.error(Messages.MavenImpl_error_read_pom, ex);
+      }
       projectInfo.setModel(model);
     }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/EclipseWorkspaceArtifactRepository.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/EclipseWorkspaceArtifactRepository.java
@@ -76,6 +76,9 @@ public final class EclipseWorkspaceArtifactRepository extends LocalArtifactRepos
     if(context.resolverConfiguration.shouldResolveWorkspaceProjects()) {
       IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
       IPath file = pom.getLocation();
+      if(file == null) {
+        return ProjectRegistryManager.toJavaIoFile(pom);
+      }
       if(!"pom".equals(extension)) { //$NON-NLS-1$
         MavenProjectFacade facade = context.state.getProjectFacade(pom);
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -109,8 +109,7 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
       ResolverConfiguration resolverConfiguration) {
     this.manager = manager;
     this.pom = pom;
-    IPath location = pom.getLocation();
-    this.pomFile = location == null ? null : location.toFile(); // save pom file
+    this.pomFile = ProjectRegistryManager.toJavaIoFile(pom);
     this.resolverConfiguration = resolverConfiguration;
 
     this.artifactKey = new ArtifactKey(mavenProject.getArtifact());

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
@@ -15,6 +15,8 @@ package org.eclipse.m2e.core.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -142,7 +144,10 @@ public class LocalProjectScanner extends AbstractProjectScanner<MavenProjectInfo
         return null;
       }
 
-      Model model = modelManager.readMavenModel(pomFile);
+      Model model = null;
+      try (InputStream pomStream = Files.newInputStream(pomFile.toPath())) {
+        model = modelManager.readMavenModel(pomStream);
+      }
 
       String pomName = modulePath + "/" + IMavenConstants.POM_FILE_NAME; //$NON-NLS-1$
 
@@ -193,9 +198,7 @@ public class LocalProjectScanner extends AbstractProjectScanner<MavenProjectInfo
 
       return projectInfo;
 
-    } catch(CoreException ex) {
-      addError(ex);
-    } catch(IOException ex) {
+    } catch(CoreException | IOException ex) {
       addError(ex);
     }
 
@@ -210,7 +213,7 @@ public class LocalProjectScanner extends AbstractProjectScanner<MavenProjectInfo
     return folders.toString();
   }
 
-  private int getBasedirRename(MavenProjectInfo mavenProjectInfo) throws IOException {
+  private int getBasedirRename(MavenProjectInfo mavenProjectInfo) {
 
     if(basedirRemameRequired) {
       return MavenProjectInfo.RENAME_REQUIRED;


### PR DESCRIPTION
…eWorkspaceArtifactRepository

- Use EFS cache to create real local java.io.File representations of remotely available POM.xml files
- Avoid conversion to java.io.File at all and prefer InputStream reading since that works also for remote FS.

Change-Id: I0000000000000000000000000000000000000000
Signed-off-by: Reguel Wermelinger <reguel.wermelinger@ivyteam.ch>