### PR TITLE
Bug 566822 - NullPointerException in SourceLocationHelper.findLocation

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.16.2.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -17,7 +17,7 @@
 
   <artifactId>org.eclipse.m2e.core</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.16.2-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse Core Plug-in</name>
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
@@ -97,7 +97,7 @@ public class SourceLocationHelper {
   public static SourceLocation findLocation(MavenProject mavenProject, MojoExecutionKey mojoExecutionKey) {
     Plugin plugin = mavenProject.getPlugin(mojoExecutionKey.getGroupId() + ":" + mojoExecutionKey.getArtifactId());
 
-    InputLocation inputLocation = plugin.getLocation(SELF);
+    InputLocation inputLocation = plugin != null ? plugin.getLocation(SELF) : null;
     if(inputLocation == null || inputLocation.getLineNumber() < 0) {
       // Plugin is specified in the maven lifecycle definition, not explicit in current pom or parent pom
       inputLocation = mavenProject.getModel().getLocation(PACKAGING);

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.16.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.feature/pom.xml
+++ b/org.eclipse.m2e.feature/pom.xml
@@ -19,7 +19,7 @@
 
   <artifactId>org.eclipse.m2e.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.16.2-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse</name>
 

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.16.2.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -19,8 +19,6 @@
       %license
    </license>
 
-  <!-- common test helper bundles and their sources -->
-
    <plugin
          id="org.eclipse.m2e.tests.common"
          download-size="0"
@@ -35,8 +33,6 @@
          version="0.0.0"
          unpack="false"/>
 
-   <!-- source bundles from main feature -->
-   
    <plugin
          id="org.eclipse.m2e.model.edit.source"
          download-size="0"
@@ -71,7 +67,7 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="org.eclipse.m2e.editor.source"
          download-size="0"
@@ -120,15 +116,13 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="org.eclipse.m2e.profiles.core.source"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-
-   <!-- source bundles of logback integration -->
 
    <plugin
          id="org.eclipse.m2e.logback.configuration.source"

--- a/org.eclipse.m2e.sdk.feature/pom.xml
+++ b/org.eclipse.m2e.sdk.feature/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>org.eclipse.m2e.sdk.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.16.2-SNAPSHOT</version>
 
   <name>m2e extensions development support (Optional)</name>
 


### PR DESCRIPTION
If the Maven plugin has uncovered lifecycle SourceLocationHelper tries
to find the best location to show the error message.
If the plugin is defined with variable as groupId current Maven fails to
find the plugin when using the resolved groupId.
