### PR TITLE
Bug 567014 - Avoid newPlexusContainer(..) at startup

### DIFF
--- a/org.eclipse.m2e.binaryproject.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.tests/META-INF/MANIFEST.MF
@@ -4,14 +4,14 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject.tests;singleton:=true
 Bundle-Version: 1.16.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.binaryproject;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.tests.common;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.binaryproject;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.junit;bundle-version="4.0.0",
  org.eclipse.equinox.common;bundle-version="3.6.100",
  org.eclipse.core.resources;bundle-version="3.8.0",
- org.eclipse.m2e.jdt;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.jdt.core;bundle-version="3.8.1",
  org.eclipse.core.runtime;bundle-version="3.8.0"
 Import-Package: org.slf4j;version="1.6.2"

--- a/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
@@ -1,17 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject.ui;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.binaryproject.ui.internal.BinaryprojectUIActivator
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Name: %Bundle-Name
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.binaryproject;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.binaryproject;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.m2e.binaryproject.ui

--- a/org.eclipse.m2e.binaryproject.ui/pom.xml
+++ b/org.eclipse.m2e.binaryproject.ui/pom.xml
@@ -20,4 +20,5 @@
 
   <artifactId>org.eclipse.m2e.binaryproject.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
@@ -1,14 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Name: %Bundle-Name
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.sourcelookup;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.sourcelookup;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.7.0",
  org.eclipse.jdt.core;bundle-version="3.7.0",

--- a/org.eclipse.m2e.binaryproject/pom.xml
+++ b/org.eclipse.m2e.binaryproject/pom.xml
@@ -20,4 +20,5 @@
 
   <artifactId>org.eclipse.m2e.binaryproject</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.tests/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Version: 1.16.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.tests.common;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.junit;bundle-version="4.12.0",
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
@@ -22,13 +22,13 @@ Export-Package: org.eclipse.m2e.core.ui.internal;x-internal:=true,
  org.eclipse.m2e.core.ui.internal.wizards;x-friends:="org.eclipse.m2e.editor"
 Bundle-Activator: org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.resources;bundle-version="3.5.2",
  org.eclipse.core.runtime;bundle-version="3.5.0",
- org.eclipse.m2e.model.edit;bundle-version="[1.16.0,1.17.0)";visibility:=reexport,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.archetype.common;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.indexer;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.model.edit;bundle-version="[1.16.0,2.0.0)";visibility:=reexport,
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.archetype.common;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.indexer;bundle-version="[1.16.0,2.0.0)",
  com.ibm.icu;bundle-version="4.0.1",
  org.eclipse.ui.console;bundle-version="3.4.0",
  org.eclipse.ui.ide;bundle-version="3.5.2",

--- a/org.eclipse.m2e.core.ui/pom.xml
+++ b/org.eclipse.m2e.core.ui/pom.xml
@@ -17,6 +17,6 @@
 
   <artifactId>org.eclipse.m2e.core.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
   <name>Maven Integration for Eclipse UI Plug-in</name>
 </project>

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 1.16.2.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.osgi;bundle-version="3.10.0",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.archetype.common;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.indexer;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.archetype.common;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.indexer;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.m2e.workspace.cli;bundle-version="0.1.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources;bundle-version="3.9.0",

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -17,7 +17,7 @@
 
   <artifactId>org.eclipse.m2e.core</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.16.2-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse Core Plug-in</name>
 

--- a/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.discovery;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .
@@ -12,9 +12,9 @@ Require-Bundle: org.eclipse.equinox.p2.ui.discovery,
  org.eclipse.equinox.p2.discovery.compatibility,
  org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.equinox.p2.operations,

--- a/org.eclipse.m2e.discovery/pom.xml
+++ b/org.eclipse.m2e.discovery/pom.xml
@@ -19,6 +19,7 @@
 
   <artifactId>org.eclipse.m2e.discovery</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>m2e Marketplace</name>
 

--- a/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor.xml;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.xml.MvnIndexPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,
@@ -15,10 +15,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.xml.core,
  org.eclipse.wst.xsd.core,
  org.eclipse.wst.common.uriresolver,
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.discovery;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.discovery;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.core.filesystem,

--- a/org.eclipse.m2e.editor.xml/pom.xml
+++ b/org.eclipse.m2e.editor.xml/pom.xml
@@ -18,7 +18,7 @@
   </parent>
 
   <artifactId>org.eclipse.m2e.editor.xml</artifactId>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <name>Maven POM XML Editor</name>

--- a/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.MavenEditorPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
@@ -13,9 +13,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.sse.core,
  org.eclipse.wst.xml.core,
  org.eclipse.ui.workbench,
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.wst.sse.core,
  org.eclipse.wst.common.emf,
  org.eclipse.swt,

--- a/org.eclipse.m2e.editor/pom.xml
+++ b/org.eclipse.m2e.editor/pom.xml
@@ -19,7 +19,7 @@
 
   <artifactId>org.eclipse.m2e.editor</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven POM Editor</name>
 

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="1.16.2.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.feature/pom.xml
+++ b/org.eclipse.m2e.feature/pom.xml
@@ -19,7 +19,7 @@
 
   <artifactId>org.eclipse.m2e.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.16.2-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse</name>
 

--- a/org.eclipse.m2e.importer.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.importer.tests/META-INF/MANIFEST.MF
@@ -6,9 +6,9 @@ Bundle-Version: 1.16.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.m2e.importer;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.tests.common;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.importer;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.ui.ide,
  org.junit;bundle-version="4.12.0",
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.importer/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.importer/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.importer;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide,
  org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.importer.internal.Activator

--- a/org.eclipse.m2e.importer/pom.xml
+++ b/org.eclipse.m2e.importer/pom.xml
@@ -11,6 +11,7 @@
 
   <artifactId>org.eclipse.m2e.importer</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse Importer framework</name>
 

--- a/org.eclipse.m2e.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt.ui/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt.ui;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: fragment
 Export-Package: org.eclipse.m2e.jdt.ui.internal;x-internal:=true,
  org.eclipse.m2e.jdt.ui.internal.actions;x-internal:=true,
  org.eclipse.m2e.jdt.ui.internal.filter;x-internal:=true
-Fragment-Host: org.eclipse.m2e.jdt;bundle-version="[1.16.0,1.17.0)"
+Fragment-Host: org.eclipse.m2e.jdt;bundle-version="[1.16.0,2.0.0)"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.debug.core,
@@ -16,9 +16,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.ui,
  org.eclipse.ui.workbench,
  org.eclipse.core.resources,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Import-Package: org.slf4j;version="1.6.2"

--- a/org.eclipse.m2e.jdt.ui/pom.xml
+++ b/org.eclipse.m2e.jdt.ui/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.jdt.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse JDT UI</name>
 

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-internal:=true,
@@ -12,8 +12,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core;bundle-version="3.18.0",
  org.eclipse.jdt.launching,
  org.eclipse.core.resources,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.jdt.MavenJdtPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.m2e.jdt/pom.xml
+++ b/org.eclipse.m2e.jdt/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.jdt</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse JDT</name>
 

--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables,
@@ -17,9 +17,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.jdt.launching,
  org.eclipse.jdt.debug.ui,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.jdt.debug,
  org.eclipse.core.resources,
  org.eclipse.debug.core,

--- a/org.eclipse.m2e.launching/pom.xml
+++ b/org.eclipse.m2e.launching/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.launching</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse Launching</name>
 

--- a/org.eclipse.m2e.lifecyclemapping.defaults/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.lifecyclemapping.defaults/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.lifecyclemapping.defaults;singleton:=true
-Bundle-Version: 1.16.0.qualifier
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.16.0,1.17.0)"
+Bundle-Version: 1.17.0.qualifier
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.16.0,2.0.0)"
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.m2e.lifecyclemapping.defaults/pom.xml
+++ b/org.eclipse.m2e.lifecyclemapping.defaults/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.lifecyclemapping.defaults</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
   
   <build>
     <plugins>

--- a/org.eclipse.m2e.logback.appender/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback.appender/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.logback.appender;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -10,4 +10,4 @@ Export-Package: org.eclipse.m2e.logback.appender;x-internal:=true
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.ui.console,
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"

--- a/org.eclipse.m2e.logback.appender/pom.xml
+++ b/org.eclipse.m2e.logback.appender/pom.xml
@@ -19,4 +19,5 @@
 
   <artifactId>org.eclipse.m2e.logback.appender</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.logback.feature"
       label="%featureName"
-      version="1.16.0.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.logback.configuration"
       license-feature="org.eclipse.license"
@@ -15,17 +15,19 @@
    <copyright>
       %copyright
    </copyright>
-   
+
    <plugin
          id="org.eclipse.m2e.logback.configuration"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
    <plugin
          id="org.eclipse.m2e.logback.appender"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
 </feature>

--- a/org.eclipse.m2e.logback.feature/pom.xml
+++ b/org.eclipse.m2e.logback.feature/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.logback.feature</artifactId>
   <packaging>eclipse-feature</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse slf4j over logback logging (Optional)</name>
 </project>

--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.m2e.profiles.core.internal.MavenProfilesCoreActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.profiles.core/pom.xml
+++ b/org.eclipse.m2e.profiles.core/pom.xml
@@ -8,10 +8,10 @@
 	    <artifactId>m2e-core</artifactId>
 	    <version>1.16.0-SNAPSHOT</version>
 	</parent>
-	  
+
 	<artifactId>org.eclipse.m2e.profiles.core</artifactId>
-	
+	<version>1.17.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
-	
+
 	<name>Maven Profile Manager Core</name>
 </project>

--- a/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
+++ b/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
@@ -248,9 +248,13 @@ public class ProfileManager implements IProfileManager {
   private RepositorySystem getRepositorySystem() {
     try {
       //TODO find an alternative way to get the Maven RepositorySystem, or use Aether directly to resolve models??
-      return MavenPluginActivator.getDefault().getPlexusContainer().lookup(RepositorySystem.class);
-    } catch(ComponentLookupException e) {
-      throw new NoSuchComponentException(e);
+      return MavenPluginActivator.getDefault().getMaven().lookup(RepositorySystem.class);
+    } catch(CoreException e) {
+      if(e.getStatus().getException() instanceof ComponentLookupException) {
+        throw new NoSuchComponentException((ComponentLookupException) e.getStatus().getException());
+      }
+      MavenProfilesCoreActivator.log(e.getStatus().getException());
+      throw new NoSuchComponentException(null);
     }
   }
 

--- a/org.eclipse.m2e.profiles.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.ui/META-INF/MANIFEST.MF
@@ -2,17 +2,17 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.profiles.ui;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.m2e.profiles.ui.internal.MavenProfilesUIActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.ui.ide,
  org.eclipse.jface.text,
- org.eclipse.m2e.profiles.core;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.profiles.core;bundle-version="[1.16.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.profiles.ui/pom.xml
+++ b/org.eclipse.m2e.profiles.ui/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 	  	
 	<artifactId>org.eclipse.m2e.profiles.ui</artifactId>
+	<version>1.17.0-SNAPSHOT</version>
 	
 	<name>Maven Profile Manager UI</name>
 

--- a/org.eclipse.m2e.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.refactoring/META-INF/MANIFEST.MF
@@ -3,11 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.m2e.refactoring;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.refactoring.internal.Activator
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.model.edit;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.model.edit;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.core.filebuffers,
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
  org.eclipse.ui.ide,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ltk.ui.refactoring;visibility:=reexport,
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)"
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.m2e.refactoring.exclude;x-internal:=true

--- a/org.eclipse.m2e.refactoring/pom.xml
+++ b/org.eclipse.m2e.refactoring/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.refactoring</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>Maven POM Refactoring</name>
 

--- a/org.eclipse.m2e.scm/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.scm/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.scm;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
@@ -14,14 +14,14 @@ Export-Package: org.eclipse.m2e.scm;x-internal:=true,
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.5.2",
  org.eclipse.equinox.common;bundle-version="3.5.1",
  org.eclipse.osgi;bundle-version="3.5.2",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.jobs;bundle-version="3.4.100",
  org.eclipse.equinox.registry;bundle-version="3.4.100",
  org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.swt;bundle-version="3.5.2",
  org.eclipse.jface;bundle-version="3.5.2",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.ui.workbench;bundle-version="3.5.2",
  org.eclipse.ui.ide;bundle-version="3.5.1",
  org.eclipse.jdt.core;bundle-version="3.5.2";resolution:=optional

--- a/org.eclipse.m2e.scm/pom.xml
+++ b/org.eclipse.m2e.scm/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.scm</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.16.2.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.sdk.feature/pom.xml
+++ b/org.eclipse.m2e.sdk.feature/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>org.eclipse.m2e.sdk.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.16.2-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>m2e extensions development support (Optional)</name>
 

--- a/org.eclipse.m2e.sourcelookup.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.sourcelookup.ui;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.sourcelookup.ui.internal.SourceLookupUIActivator
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
@@ -10,13 +10,13 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.debug.ui;bundle-version="3.7.0",
  org.eclipse.jdt.debug.ui;bundle-version="3.6.0",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.jdt.debug;bundle-version="3.7.0",
- org.eclipse.m2e.sourcelookup;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core.ui;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.sourcelookup;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.ui.ide;bundle-version="3.7.0",
- org.eclipse.m2e.binaryproject;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.binaryproject;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.expressions,
  org.eclipse.jdt.launching;bundle-version="3.10.0",
  org.eclipse.jdt.core;bundle-version="3.9.0",

--- a/org.eclipse.m2e.sourcelookup.ui/pom.xml
+++ b/org.eclipse.m2e.sourcelookup.ui/pom.xml
@@ -20,4 +20,5 @@
 
   <artifactId>org.eclipse.m2e.sourcelookup.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
@@ -1,13 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.sourcelookup;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Name: %Bundle-Name
-Require-Bundle: org.eclipse.m2e.launching;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
+Require-Bundle: org.eclipse.m2e.launching;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.jdt.core;bundle-version="3.7.0",
  org.eclipse.jdt.debug;bundle-version="3.8.0",
  org.eclipse.jdt.launching;bundle-version="3.9.0",

--- a/org.eclipse.m2e.sourcelookup/pom.xml
+++ b/org.eclipse.m2e.sourcelookup/pom.xml
@@ -20,4 +20,5 @@
 
   <artifactId>org.eclipse.m2e.sourcelookup</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.sse.ui.feature/feature.xml
+++ b/org.eclipse.m2e.sse.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sse.ui.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.sse.ui.feature/pom.xml
+++ b/org.eclipse.m2e.sse.ui.feature/pom.xml
@@ -18,6 +18,6 @@
   </parent>
 
   <artifactId>org.eclipse.m2e.sse.ui.feature</artifactId>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.17.0.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
- org.eclipse.m2e.core;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.16.0,1.17.0)",
- org.eclipse.m2e.lifecyclemapping.defaults;bundle-version="[1.16.0,1.17.0)",
+ org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.16.0,2.0.0)",
+ org.eclipse.m2e.lifecyclemapping.defaults;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.debug.core,

--- a/org.eclipse.m2e.tests.common/pom.xml
+++ b/org.eclipse.m2e.tests.common/pom.xml
@@ -20,6 +20,7 @@
 
   <artifactId>org.eclipse.m2e.tests.common</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.17.0-SNAPSHOT</version>
 
   <name>M2E Testing Helpers</name>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,14 @@
 
     <!-- Current target version of m2e, used to deduce some URL at verify and publish.
     This should usually be sync'd with the main feature version -->
-    <m2e.version>1.16.2</m2e.version>
+    <m2e.version>1.17.0</m2e.version>
     <m2e-maven-runtime.version>1.16.0-SNAPSHOT</m2e-maven-runtime.version>
 
     <tycho-version>2.0.0</tycho-version>
 
     <!-- eclipse version m2e is built against -->
-    <eclipse.stream>2020-06</eclipse.stream>
-    <eclipse-repo.url>https://download.eclipse.org/eclipse/updates/4.16/</eclipse-repo.url>
+    <eclipse.stream>2020-09</eclipse.stream>
+    <eclipse-repo.url>https://download.eclipse.org/eclipse/updates/4.17/</eclipse-repo.url>
     <eclipse-simrel.url>https://download.eclipse.org/releases/${eclipse.stream}</eclipse-simrel.url>
 
     <tycho.testArgLine>-Xmx800m</tycho.testArgLine>
@@ -84,9 +84,9 @@
       <url>https://download.eclipse.org/cbi/updates/license</url>
     </repository>
     <repository>
-      <id>Orbit 2020-06</id>
+      <id>Orbit 2020-09</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository</url>
+      <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository</url>
     </repository>
     <repository>
     <id>Wild Web Developer</id>


### PR DESCRIPTION
Delay creation of container (which is expensive) later in m2e lifecycle,
only when it's necessary.

Change-Id: I00f3bc645e0b962bf5c914293b001869ae73e928
Signed-off-by: Mickael Istria <mistria@redhat.com>