### PR TITLE
Guard about null pointer access if image was never created

### DIFF
--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/provider/MavenTargetLocationLabelProvider.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/provider/MavenTargetLocationLabelProvider.java
@@ -47,8 +47,9 @@ public class MavenTargetLocationLabelProvider implements ILabelProvider {
 
 	@Override
 	public void dispose() {
-		image.dispose();
-
+		if (image != null) {
+			image.dispose();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
On shutdown an NPE can occur if the image was never created.

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>