### PR TITLE
[m2e-pde] Fix race-condition by using a synchronized + file locking CacheManager

### DIFF
--- a/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
@@ -12,3 +12,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.m2e.maven.runtime,
  org.eclipse.m2e.core
 Export-Package: org.eclipse.m2e.pde
+Bundle-Activator: org.eclipse.m2e.pde.Activator
+Bundle-ActivationPolicy: lazy
+Import-Package: org.apache.commons.codec.digest;version="1.14.0",
+ org.apache.commons.io;version="2.6.0"

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/Activator.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/Activator.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Christoph Läubrich
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde;
+
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class Activator implements BundleActivator {
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		CacheManager.setBasedir(context.getBundle().getDataFile(""));
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		// clear all locations older than 14 days, this can be improved by
+		// 1) watch for changes in the workspace -> if target is deleted/removed from
+		// workspace we can clear the cache
+		// 2) we can add a preference page where the user can force clearing the cache
+		// or set the cache days
+		CacheManager.clearFilesOlderThan(14, TimeUnit.DAYS);
+		CacheManager.setBasedir(null);
+	}
+
+}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Christoph Läubrich
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.pde.core.target.ITargetHandle;
+import org.eclipse.pde.core.target.TargetBundle;
+
+public class CacheManager {
+
+	private static final String LASTACCESS_MARKER = ".lastaccess";
+
+	private static File baseDir;
+
+	private static final Map<String, CacheManager> MANAGERS = new HashMap<>();
+
+	private volatile boolean invalidated;
+
+	private File folder;
+
+	public CacheManager(File folder) {
+		this.folder = folder;
+		try {
+			FileUtils.touch(new File(LASTACCESS_MARKER));
+		} catch (IOException e) {
+			// can't mark last access then...
+		}
+	}
+
+	public synchronized <R> R accessArtifactFile(Artifact artifact, CacheConsumer<R> consumer) throws Exception {
+		File gavFolder = new File(folder,
+				artifact.getGroupId() + "/" + artifact.getArtifactId() + "/" + artifact.getBaseVersion());
+		FileUtils.forceMkdir(gavFolder);
+		File file = new File(gavFolder, artifact.getFile().getName());
+		File lockFile = new File(gavFolder, artifact.getFile().getName() + ".lock");
+		lockFile.deleteOnExit();
+		try (RandomAccessFile raf = new RandomAccessFile(lockFile, "rw"); FileChannel channel = raf.getChannel()) {
+			FileLock lock = channel.lock();
+			try {
+				return consumer.consume(file);
+			} finally {
+				lock.release();
+			}
+		}
+	}
+
+	public TargetBundle getTargetBundle(Artifact artifact, MissingMetadataMode metadataMode) {
+		if (invalidated) {
+			throw new IllegalStateException("invalidated location");
+		}
+		return new MavenTargetBundle(artifact, this, metadataMode);
+	}
+
+	public static synchronized CacheManager forTargetHandle(ITargetHandle handle) {
+		if (baseDir == null) {
+			throw new IllegalStateException("bundle not active");
+		}
+		String targetId;
+		try {
+			targetId = DigestUtils.sha1Hex(handle.getMemento());
+		} catch (CoreException e) {
+			throw new RuntimeException("creating CacheManager failed due to internal error", e);
+		}
+		return MANAGERS.computeIfAbsent(targetId, key -> {
+
+			File folder = new File(baseDir, key);
+			return new CacheManager(folder);
+		});
+	}
+
+	public static synchronized void clearFilesOlderThan(long amount, TimeUnit unit) {
+		if (baseDir == null) {
+			throw new IllegalStateException("bundle not active");
+		}
+		File[] listFiles = baseDir.listFiles();
+		long deleteStamp = System.currentTimeMillis() - unit.toMillis(amount);
+		if (listFiles != null) {
+			for (File folder : listFiles) {
+				if (folder.isDirectory() && !MANAGERS.containsKey(folder.getName())) {
+					File marker = new File(folder, LASTACCESS_MARKER);
+
+					if (marker.isFile() && FileUtils.isFileOlder(marker, deleteStamp)) {
+						try {
+							FileUtils.deleteDirectory(folder);
+						} catch (IOException e) {
+						}
+					}
+				}
+			}
+		}
+	}
+
+	public static synchronized void setBasedir(File baseDir) {
+		CacheManager.baseDir = baseDir;
+		for (CacheManager m : MANAGERS.values()) {
+			m.invalidated = true;
+		}
+		MANAGERS.clear();
+	}
+
+	public static interface CacheConsumer<T> {
+		T consume(File file) throws Exception;
+	}
+
+}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -28,6 +28,20 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.pde.core.target.ITargetHandle;
 import org.eclipse.pde.core.target.TargetBundle;
 
+/**
+ * 
+ * The cache manager serves the following purpose:
+ * <ul>
+ * <li>adding a synchronization point for code working on the same (effective)
+ * target model (e.g. active target in eclipse and a target editor opened)</li>
+ * <li>prevent different processes/jvm to access the same file using
+ * file-locks</li>
+ * <li>providing a storage area for each target for example if different targets
+ * reference the same maven artifact but with different properties</li>
+ * <li>allows to remove target content that has not been used for a long
+ * time</li>
+ * </ul>
+ */
 public class CacheManager {
 
 	private static final String LASTACCESS_MARKER = ".lastaccess";
@@ -40,7 +54,7 @@ public class CacheManager {
 
 	private File folder;
 
-	public CacheManager(File folder) {
+	private CacheManager(File folder) {
 		this.folder = folder;
 		try {
 			FileUtils.touch(new File(LASTACCESS_MARKER));
@@ -49,6 +63,22 @@ public class CacheManager {
 		}
 	}
 
+	/**
+	 * Allows synchronized and locked access to the given artifact, the consumer is
+	 * called with the file that represents the artifact at this cache location
+	 * (what might not exits).
+	 * 
+	 * @param <R>      the return value type
+	 * @param artifact the artifact identifier to be used
+	 * @param consumer the consumer that is handed over control of the file for the
+	 *                 time of the invocation of the
+	 *                 {@link CacheConsumer#consume(File)} method
+	 * @return the value that is returned from the consumers call to
+	 *         {@link CacheConsumer#consume(File)}
+	 * @throws Exception if either there is an error while acquiring necessary
+	 *                   system-resources locks or any exception thrown by the
+	 *                   consumer itself
+	 */
 	public synchronized <R> R accessArtifactFile(Artifact artifact, CacheConsumer<R> consumer) throws Exception {
 		File gavFolder = new File(folder,
 				artifact.getGroupId() + "/" + artifact.getArtifactId() + "/" + artifact.getBaseVersion());
@@ -66,6 +96,14 @@ public class CacheManager {
 		}
 	}
 
+	/**
+	 * Get the requested Artifact as a {@link TargetBundle}, might wrap the content
+	 * as indicated by the {@link MissingMetadataMode}
+	 * 
+	 * @param artifact     the artifact to acquire
+	 * @param metadataMode the mode to use if this artifact is not a bundle
+	 * @return
+	 */
 	public TargetBundle getTargetBundle(Artifact artifact, MissingMetadataMode metadataMode) {
 		if (invalidated) {
 			throw new IllegalStateException("invalidated location");
@@ -73,16 +111,22 @@ public class CacheManager {
 		return new MavenTargetBundle(artifact, this, metadataMode);
 	}
 
-	public static synchronized CacheManager forTargetHandle(ITargetHandle handle) {
+	/**
+	 * Gives access to the {@link CacheManager} for the given {@link ITargetHandle},
+	 * the handle must support the {@link ITargetHandle#getMemento()} for this to
+	 * work
+	 * 
+	 * @param handle the handle for what a {@link CacheManager} is requested
+	 * @return the {@link CacheManager} that should be used to access files from
+	 *         this location
+	 * @throws CoreException if unable to generate a memento from the given
+	 *                       {@link ITargetHandle}
+	 */
+	public static synchronized CacheManager forTargetHandle(ITargetHandle handle) throws CoreException {
 		if (baseDir == null) {
 			throw new IllegalStateException("bundle not active");
 		}
-		String targetId;
-		try {
-			targetId = DigestUtils.sha1Hex(handle.getMemento());
-		} catch (CoreException e) {
-			throw new RuntimeException("creating CacheManager failed due to internal error", e);
-		}
+		String targetId = DigestUtils.sha1Hex(handle.getMemento());
 		return MANAGERS.computeIfAbsent(targetId, key -> {
 
 			File folder = new File(baseDir, key);
@@ -90,6 +134,12 @@ public class CacheManager {
 		});
 	}
 
+	/**
+	 * Clears all inactive cache locations that are older than the given time
+	 * 
+	 * @param amount the amount of time to use
+	 * @param unit   the unit of time to use
+	 */
 	public static synchronized void clearFilesOlderThan(long amount, TimeUnit unit) {
 		if (baseDir == null) {
 			throw new IllegalStateException("bundle not active");
@@ -100,7 +150,6 @@ public class CacheManager {
 			for (File folder : listFiles) {
 				if (folder.isDirectory() && !MANAGERS.containsKey(folder.getName())) {
 					File marker = new File(folder, LASTACCESS_MARKER);
-
 					if (marker.isFile() && FileUtils.isFileOlder(marker, deleteStamp)) {
 						try {
 							FileUtils.deleteDirectory(folder);
@@ -112,7 +161,12 @@ public class CacheManager {
 		}
 	}
 
-	public static synchronized void setBasedir(File baseDir) {
+	/**
+	 * Set the basedir to use, purge all existing managers and invalidate them
+	 * 
+	 * @param baseDir
+	 */
+	static synchronized void setBasedir(File baseDir) {
 		CacheManager.baseDir = baseDir;
 		for (CacheManager m : MANAGERS.values()) {
 			m.invalidated = true;
@@ -120,6 +174,12 @@ public class CacheManager {
 		MANAGERS.clear();
 	}
 
+	/**
+	 * Consumer for a cache location that allows to throw checked exceptions and
+	 * return a value
+	 *
+	 * @param <T> the return type
+	 */
 	public static interface CacheConsumer<T> {
 		T consume(File file) throws Exception;
 	}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
@@ -68,7 +68,6 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	private Set<Artifact> ignoredArtifacts = new HashSet<>();
 
 	private Set<Artifact> failedArtifacts = new HashSet<>();
-	private CacheManager cacheManager;
 
 	public MavenTargetLocation(String groupId, String artifactId, String version, String artifactType,
 			MissingMetadataMode metadataMode, String dependencyScope) {
@@ -84,6 +83,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	protected TargetBundle[] resolveBundles(ITargetDefinition definition, IProgressMonitor monitor)
 			throws CoreException {
 		if (targetBundles == null) {
+			CacheManager cacheManager = CacheManager.forTargetHandle(definition.getHandle());
 			ignoredArtifacts.clear();
 			targetBundles = new ArrayList<>();
 			IMaven maven = MavenPlugin.getMaven();
@@ -128,18 +128,18 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 					}, monitor);
 
 					for (Artifact a : dependecies.getArtifacts(true)) {
-						addBundleForArtifact(a);
+						addBundleForArtifact(a, cacheManager);
 					}
 					dependencyNodes = dependecies.getNodes();
 				} else {
-					addBundleForArtifact(artifact);
+					addBundleForArtifact(artifact, cacheManager);
 				}
 			}
 		}
 		return targetBundles.toArray(new TargetBundle[0]);
 	}
 
-	private void addBundleForArtifact(Artifact artifact) {
+	private void addBundleForArtifact(Artifact artifact, CacheManager cacheManager) {
 		TargetBundle bundle = cacheManager.getTargetBundle(artifact, metadataMode);
 		IStatus status = bundle.getStatus();
 		if (status.isOK()) {
@@ -170,11 +170,6 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		// XXX it would be possible to deploy features as maven artifacts, are there any
 		// examples?
 		return new TargetFeature[] {};
-	}
-
-	@Override
-	protected void associateWithTarget(ITargetDefinition target) {
-		cacheManager = CacheManager.forTargetHandle(target.getHandle());
 	}
 
 	@Override

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
@@ -68,6 +68,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	private Set<Artifact> ignoredArtifacts = new HashSet<>();
 
 	private Set<Artifact> failedArtifacts = new HashSet<>();
+	private CacheManager cacheManager;
 
 	public MavenTargetLocation(String groupId, String artifactId, String version, String artifactType,
 			MissingMetadataMode metadataMode, String dependencyScope) {
@@ -139,7 +140,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	}
 
 	private void addBundleForArtifact(Artifact artifact) {
-		TargetBundle bundle = createTargetBundle(artifact);
+		TargetBundle bundle = cacheManager.getTargetBundle(artifact, metadataMode);
 		IStatus status = bundle.getStatus();
 		if (status.isOK()) {
 			targetBundles.add(bundle);
@@ -159,10 +160,6 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		return targetBundles.size() - 1;
 	}
 
-	private TargetBundle createTargetBundle(Artifact artifact) {
-		return new MavenTargetBundle(artifact, metadataMode);
-	}
-
 	public List<DependencyNode> getDependencyNodes() {
 		return dependencyNodes;
 	}
@@ -173,6 +170,11 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		// XXX it would be possible to deploy features as maven artifacts, are there any
 		// examples?
 		return new TargetFeature[] {};
+	}
+
+	@Override
+	protected void associateWithTarget(ITargetDefinition target) {
+		cacheManager = CacheManager.forTargetHandle(target.getHandle());
 	}
 
 	@Override


### PR DESCRIPTION
When creating wrapped artifacts these are currently stored at the
original location of the artifact (e.g. the current maven local repository) independent from the target context, this can lead to
the following race-conditions:
- different eclipse installations using the same target file
- different target files are referencing the same artifact

This can then lead to strange intermediate errors (bundle can't be
wrapped or similar errors).

This commit proposes a solution using a CacheManager that provides
target aware locations, is synchronized to prevent concurrent access to
cached files and using filelocks to prevent other eclipse instances to
access the file at the same time.

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>