### PR TITLE
Add support for the user to influence the generated manifest.

### DIFF
--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenArtifactInstructionsWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenArtifactInstructionsWizard.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Christoph Läubrich
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde.ui.editor;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.window.Window;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.m2e.pde.BNDInstructions;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+import aQute.bnd.osgi.Analyzer;
+
+public class MavenArtifactInstructionsWizard extends Wizard {
+
+	private String instructions;
+	private boolean usedefaults;
+
+	public MavenArtifactInstructionsWizard(BNDInstructions bndInstructions) {
+		this.instructions = bndInstructions.getInstructions();
+		this.usedefaults = instructions == null || instructions.isBlank();
+		setWindowTitle("Maven Artifact Instructions");
+		WizardPage page = new WizardPage("Edit Instructions") {
+
+			@Override
+			public void createControl(Composite parent) {
+				Composite composite = new Composite(parent, SWT.NONE);
+				composite.setLayout(new GridLayout(1, true));
+				Button buttonInherit = new Button(composite, SWT.CHECK);
+				buttonInherit.setText("Use defaults");
+				Text textField = new Text(composite, SWT.MULTI | SWT.BORDER | SWT.WRAP | SWT.V_SCROLL);
+				textField.setFont(JFaceResources.getTextFont());
+				GridData layoutData = new GridData(GridData.FILL_BOTH);
+				textField.setLayoutData(layoutData);
+				layoutData.heightHint = 100;
+				Link link = new Link(composite, SWT.NONE);
+				link.setText(
+						"Go to <a href=\"https://bnd.bndtools.org\">bnd.bndtools.org</a> to learn more about BND instructions and syntax.");
+				link.addSelectionListener(new SelectionListener() {
+					
+					@Override
+					public void widgetSelected(SelectionEvent e) {
+						Program.launch(e.text);
+					}
+					
+					@Override
+					public void widgetDefaultSelected(SelectionEvent e) {
+						
+					}
+				});
+				if (usedefaults) {
+					textField.setText(BNDInstructions.getDefaultInstructions().getInstructions());
+				} else {
+					textField.setText(instructions);
+				}
+				buttonInherit.addSelectionListener(new SelectionListener() {
+
+					@Override
+					public void widgetSelected(SelectionEvent e) {
+						boolean selection = buttonInherit.getSelection();
+						usedefaults = selection;
+						textField.setEnabled(!selection);
+						link.setEnabled(!selection);
+					}
+
+					@Override
+					public void widgetDefaultSelected(SelectionEvent e) {
+
+					}
+				});
+				textField.addModifyListener(new ModifyListener() {
+
+					@Override
+					public void modifyText(ModifyEvent e) {
+						instructions = textField.getText();
+					}
+				});
+				buttonInherit.setSelection(usedefaults);
+				textField.setEnabled(!buttonInherit.getSelection());
+				link.setEnabled(!buttonInherit.getSelection());
+				setControl(composite);
+			}
+		};
+		addPage(page);
+		page.setImageDescriptor(ImageDescriptor.createFromURL(Analyzer.class.getResource("/img/bnd-64.png")));
+		page.setTitle(page.getName());
+		page.setDescription("Edit the BND Instructions to be used when wrapping this artifact is necessary");
+	}
+
+	@Override
+	public boolean performFinish() {
+		return true;
+	}
+
+	/**
+	 * Open a wizard to edit the given instructions
+	 * 
+	 * @param shell        parent shell for the wizard dialog
+	 * @param instructions the instructions to edit
+	 * @return the new instructions instance or <code>null</code> if the user
+	 *         canceled the wizard
+	 */
+	public static BNDInstructions openWizard(Shell shell, BNDInstructions instructions) {
+		MavenArtifactInstructionsWizard wizard = new MavenArtifactInstructionsWizard(instructions);
+		WizardDialog dialog = new WizardDialog(shell, wizard);
+		dialog.setMinimumPageSize(800, 600);
+		if (dialog.open() == Window.OK) {
+			if (wizard.usedefaults) {
+				return new BNDInstructions(instructions.getKey(), null);
+			}
+			return new BNDInstructions(instructions.getKey(), wizard.instructions);
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
@@ -30,13 +30,15 @@ import org.eclipse.pde.core.target.ITargetLocation;
 import org.eclipse.pde.ui.target.ITargetLocationWizard;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 
 public class MavenTargetLocationWizard extends Wizard implements ITargetLocationWizard {
@@ -57,35 +59,32 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 
 	public MavenTargetLocationWizard(MavenTargetLocation targetLocation) {
 		this.targetLocation = targetLocation;
-		setWindowTitle("Maven Artifact Target Entry");
+		setWindowTitle(Messages.MavenTargetLocationWizard_0);
 		WizardPage page = new WizardPage(
-				targetLocation == null ? "Add a new Maven dependency" : "Edit Maven Dependency") {
+				targetLocation == null ? Messages.MavenTargetLocationWizard_1 : Messages.MavenTargetLocationWizard_2) {
 
-			private Button editInstructionsButton;
+			private Link editInstructionsButton;
+			private Label scopeLabel;
 
 			@Override
 			public void createControl(Composite parent) {
 				Composite composite = new Composite(parent, SWT.NONE);
 				setControl(composite);
 				composite.setLayout(new GridLayout(2, false));
-				new Label(composite, SWT.NONE).setText("Group Id");
+				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_3);
 				groupId = fill(new Text(composite, SWT.BORDER));
-				new Label(composite, SWT.NONE).setText("Artifact Id");
+				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_4);
 				artifactId = fill(new Text(composite, SWT.BORDER));
-				new Label(composite, SWT.NONE).setText("Version");
+				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_5);
 				version = fill(new Text(composite, SWT.BORDER));
-				new Label(composite, SWT.NONE).setText("Type");
-				type = new CCombo(composite, SWT.BORDER);
-				type.add("jar");
-				type.add("bundle");
-				new Label(composite, SWT.NONE).setText("Missing OSGi-Manifest");
+				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_6);
+				type = combo(new CCombo(composite, SWT.BORDER));
+				type.add("jar"); //$NON-NLS-1$
+				type.add("bundle"); //$NON-NLS-1$
+				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_9);
 				createMetadataCombo(composite);
-				new Label(composite, SWT.NONE).setText("Dependencies scope");
-				scope = new CCombo(composite, SWT.BORDER);
-				scope.add("");
-				scope.add("compile");
-				scope.add("test");
-				scope.add("provided");
+				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_10);
+				createScopeCombo(composite);
 				if (targetLocation != null) {
 					artifactId.setText(targetLocation.getArtifactId());
 					groupId.setText(targetLocation.getGroupId());
@@ -95,21 +94,48 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 					metadata.setSelection(new StructuredSelection(targetLocation.getMetadataMode()));
 					bndInstructions = targetLocation.getInstructions(null);
 				} else {
-					artifactId.setText("");
-					groupId.setText("");
-					version.setText("");
+					artifactId.setText(""); //$NON-NLS-1$
+					groupId.setText(""); //$NON-NLS-1$
+					version.setText(""); //$NON-NLS-1$
 					type.setText(MavenTargetLocation.DEFAULT_PACKAGE_TYPE);
 					scope.setText(MavenTargetLocation.DEFAULT_DEPENDENCY_SCOPE);
 					metadata.setSelection(new StructuredSelection(MavenTargetLocation.DEFAULT_METADATA_MODE));
-					bndInstructions = new BNDInstructions("", null);
+					bndInstructions = new BNDInstructions("", null); //$NON-NLS-1$
 				}
-				updateButton();
+				updateUI();
+			}
+
+			private void createScopeCombo(Composite parent) {
+				Composite composite = new Composite(parent, SWT.NONE);
+				GridLayout layout = new GridLayout(2, false);
+				layout.horizontalSpacing = 20;
+				layout.marginWidth = 0;
+				layout.marginHeight = 0;
+				composite.setLayout(layout);
+				scope = combo(new CCombo(composite, SWT.BORDER));
+				scopeLabel = new Label(composite, SWT.NONE);
+				scopeLabel.setText(Messages.MavenTargetLocationWizard_15);
+				scope.add(""); //$NON-NLS-1$
+				scope.add("compile"); //$NON-NLS-1$
+				scope.add("test"); //$NON-NLS-1$
+				scope.add("provided"); //$NON-NLS-1$
+				scope.addModifyListener(new ModifyListener() {
+
+					@Override
+					public void modifyText(ModifyEvent e) {
+						updateUI();
+					}
+				});
 			}
 
 			private void createMetadataCombo(Composite parent) {
 				Composite composite = new Composite(parent, SWT.NONE);
-				composite.setLayout(new GridLayout(2, false));
-				metadata = new ComboViewer(composite);
+				GridLayout layout = new GridLayout(2, false);
+				layout.horizontalSpacing = 20;
+				layout.marginWidth = 0;
+				layout.marginHeight = 0;
+				composite.setLayout(layout);
+				metadata = new ComboViewer(combo(new CCombo(composite, SWT.READ_ONLY | SWT.BORDER)));
 				metadata.setContentProvider(ArrayContentProvider.getInstance());
 				metadata.setLabelProvider(new ColumnLabelProvider() {
 					@Override
@@ -121,10 +147,9 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 					}
 
 				});
-				editInstructionsButton = new Button(composite, SWT.PUSH);
-				editInstructionsButton.setText("edit manifest generation instructions");
-				editInstructionsButton
-						.setToolTipText("Edit the default instructions used in case of necessary manifest generation");
+				editInstructionsButton = new Link(composite, SWT.PUSH);
+				editInstructionsButton.setText(Messages.MavenTargetLocationWizard_20);
+				editInstructionsButton.setToolTipText(Messages.MavenTargetLocationWizard_21);
 				editInstructionsButton.addSelectionListener(new SelectionListener() {
 
 					@Override
@@ -143,13 +168,14 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 				});
 				metadata.setInput(MissingMetadataMode.values());
 				metadata.addSelectionChangedListener(e -> {
-					updateButton();
+					updateUI();
 				});
 			}
 
-			private void updateButton() {
+			private void updateUI() {
 				editInstructionsButton.setVisible(
 						metadata.getStructuredSelection().getFirstElement() == MissingMetadataMode.GENERATE);
+				scopeLabel.setVisible(scope.getText().isBlank());
 			}
 
 			private Text fill(Text text) {
@@ -158,11 +184,18 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 				text.setLayoutData(data);
 				return text;
 			}
+
+			private CCombo combo(CCombo combo) {
+				GridData data = new GridData();
+				data.widthHint = 100;
+				combo.setLayoutData(data);
+				return combo;
+			}
 		};
 		page.setImageDescriptor(ImageDescriptor
-				.createFromURL(MavenTargetLocationWizard.class.getResource("/icons/new_m2_project_wizard.gif")));
+				.createFromURL(MavenTargetLocationWizard.class.getResource("/icons/new_m2_project_wizard.gif"))); //$NON-NLS-1$
 		page.setTitle(page.getName());
-		page.setDescription("Enter the desired maven artifact to add to the target platform");
+		page.setDescription(Messages.MavenTargetLocationWizard_23);
 		addPage(page);
 
 	}

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/Messages.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/Messages.java
@@ -1,0 +1,33 @@
+package org.eclipse.m2e.pde.ui.editor;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+	private static final String BUNDLE_NAME = "org.eclipse.m2e.pde.ui.editor.messages"; //$NON-NLS-1$
+	public static String MavenArtifactInstructionsWizard_0;
+	public static String MavenArtifactInstructionsWizard_1;
+	public static String MavenArtifactInstructionsWizard_2;
+	public static String MavenArtifactInstructionsWizard_3;
+	public static String MavenArtifactInstructionsWizard_4;
+	public static String MavenArtifactInstructionsWizard_6;
+	public static String MavenTargetLocationWizard_0;
+	public static String MavenTargetLocationWizard_1;
+	public static String MavenTargetLocationWizard_10;
+	public static String MavenTargetLocationWizard_15;
+	public static String MavenTargetLocationWizard_2;
+	public static String MavenTargetLocationWizard_20;
+	public static String MavenTargetLocationWizard_21;
+	public static String MavenTargetLocationWizard_23;
+	public static String MavenTargetLocationWizard_3;
+	public static String MavenTargetLocationWizard_4;
+	public static String MavenTargetLocationWizard_5;
+	public static String MavenTargetLocationWizard_6;
+	public static String MavenTargetLocationWizard_9;
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+	}
+}

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/messages.properties
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/messages.properties
@@ -1,0 +1,19 @@
+MavenArtifactInstructionsWizard_0=https://bnd.bndtools.org
+MavenArtifactInstructionsWizard_1=Maven Artifact Instructions
+MavenArtifactInstructionsWizard_2=Edit Instructions
+MavenArtifactInstructionsWizard_3=Use defaults
+MavenArtifactInstructionsWizard_4=Go to <a href="%s">bnd.bndtools.org</a> or click on the help button to learn more about BND instructions and syntax.
+MavenArtifactInstructionsWizard_6=Edit the BND Instructions to be used when wrapping this artifact is necessary
+MavenTargetLocationWizard_0=Maven Artifact Target Entry
+MavenTargetLocationWizard_1=Add a new Maven dependency
+MavenTargetLocationWizard_10=Dependencies scope
+MavenTargetLocationWizard_15=Specify a scope to include dependencies
+MavenTargetLocationWizard_2=Edit Maven Dependency
+MavenTargetLocationWizard_20=<a>Edit instructions</a>
+MavenTargetLocationWizard_21=Edit the default instructions used in case of necessary manifest generation
+MavenTargetLocationWizard_23=Enter the desired maven artifact to add to the target platform
+MavenTargetLocationWizard_3=Group Id
+MavenTargetLocationWizard_4=Artifact Id
+MavenTargetLocationWizard_5=Version
+MavenTargetLocationWizard_6=Type
+MavenTargetLocationWizard_9=Missing OSGi-Manifest

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Christoph Läubrich
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.apache.commons.io.IOUtils;
+
+public class BNDInstructions {
+
+	private static final String BND_DEFAULT_PROPERTIES_PATH = "bnd-default.properties";
+	private String key;
+	private String instructions;
+
+	public BNDInstructions(String key, String instructions) {
+		this.key = key;
+		this.instructions = instructions;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getInstructions() {
+		return instructions;
+	}
+
+	public static BNDInstructions getDefaultInstructions() {
+		InputStream input = MavenTargetLocation.class.getResourceAsStream(BND_DEFAULT_PROPERTIES_PATH);
+		try {
+			return new BNDInstructions("", IOUtils.toString(input, StandardCharsets.ISO_8859_1));
+		} catch (IOException e) {
+			throw new RuntimeException("load default properties failed", e);
+		}
+	}
+
+	public Properties asProperties() {
+		Reader reader;
+		if (instructions == null || instructions.isBlank()) {
+			reader = new InputStreamReader(MavenTargetLocation.class.getResourceAsStream(BND_DEFAULT_PROPERTIES_PATH),
+					StandardCharsets.ISO_8859_1);
+		} else {
+			reader = new StringReader(instructions);
+		}
+		Properties properties = new Properties();
+		try {
+			properties.load(reader);
+		} catch (IOException e) {
+			throw new RuntimeException("conversion to properties failed", e);
+		}
+		return properties;
+	}
+}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -19,6 +19,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -100,15 +101,23 @@ public class CacheManager {
 	 * Get the requested Artifact as a {@link TargetBundle}, might wrap the content
 	 * as indicated by the {@link MissingMetadataMode}
 	 * 
-	 * @param artifact     the artifact to acquire
-	 * @param metadataMode the mode to use if this artifact is not a bundle
+	 * @param artifact        the artifact to acquire
+	 * @param bndInstructions
+	 * @param metadataMode    the mode to use if this artifact is not a bundle
 	 * @return
 	 */
-	public TargetBundle getTargetBundle(Artifact artifact, MissingMetadataMode metadataMode) {
+	public TargetBundle getTargetBundle(Artifact artifact, BNDInstructions bndInstructions,
+			MissingMetadataMode metadataMode) {
 		if (invalidated) {
 			throw new IllegalStateException("invalidated location");
 		}
-		return new MavenTargetBundle(artifact, this, metadataMode);
+		Properties prop;
+		if (bndInstructions == null) {
+			prop = BNDInstructions.getDefaultInstructions().asProperties();
+		} else {
+			prop = bndInstructions.asProperties();
+		}
+		return new MavenTargetBundle(artifact, prop, this, metadataMode);
 	}
 
 	/**

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocationFactory.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocationFactory.java
@@ -14,6 +14,8 @@ package org.eclipse.m2e.pde;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -25,6 +27,7 @@ import org.eclipse.pde.core.target.ITargetLocation;
 import org.eclipse.pde.core.target.ITargetLocationFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class MavenTargetLocationFactory implements ITargetLocationFactory {
@@ -49,7 +52,19 @@ public class MavenTargetLocationFactory implements ITargetLocationFactory {
 			String groupId = getText(MavenTargetLocation.ELEMENT_GROUP_ID, location);
 			String version = getText(MavenTargetLocation.ELEMENT_VERSION, location);
 			String artifactType = getText(MavenTargetLocation.ELEMENT_TYPE, location);
-			return new MavenTargetLocation(groupId, artifactId, version, artifactType, mode, dependencyScope);
+			NodeList nodeList = location.getElementsByTagName(MavenTargetLocation.ELEMENT_INSTRUCTIONS);
+			List<BNDInstructions> list = new ArrayList<>();
+			int length = nodeList.getLength();
+			for (int i = 0; i < length; i++) {
+				Node item = nodeList.item(i);
+				if (item instanceof Element) {
+					Element instructionElement = (Element) item;
+					list.add(new BNDInstructions(
+							instructionElement.getAttribute(MavenTargetLocation.ATTRIBUTE_INSTRUCTIONS_REFERENCE),
+							instructionElement.getTextContent()));
+				}
+			}
+			return new MavenTargetLocation(groupId, artifactId, version, artifactType, mode, dependencyScope, list);
 		} catch (Exception e) {
 			throw new CoreException(new Status(IStatus.ERROR, MavenTargetLocationFactory.class.getPackage().getName(),
 					e.getMessage(), e));

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/bnd-default.properties
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/bnd-default.properties
@@ -1,0 +1,7 @@
+Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+version:               ${version_cleanup;${mvnVersion}}
+Bundle-SymbolicName:   wrapped.${mvnGroupId}.${mvnArtifactId}
+Bundle-Version:        ${version}
+Import-Package:        *;resolution:=optional
+Export-Package:        *;version="${version}";-noimport:=true
+DynamicImport-Package: *


### PR DESCRIPTION
Currently there is no way for the user to influence the generated
manifest. With this change a user can edit the template that is used to generate
manifest headers from maven artifacts.

If the "generate" mode is chosen, a new button is displayed
![grafik](https://user-images.githubusercontent.com/1331477/99495037-4c6aa480-2972-11eb-8757-62412aa2305e.png)

A dialog pops up that allows to either use the defaults, or edit the BND template
![grafik](https://user-images.githubusercontent.com/1331477/99495140-7de37000-2972-11eb-9058-55b9d50ee0a0.png)

The instructions are then stored inside the target and will be used to generate missing manifests.

**Just a note** because one might wonder why the code allows multiple templates while the UI only allows one per location: due to [current PDE limitations](https://bugs.eclipse.org/bugs/show_bug.cgi?id=568865) it is not possible to edit individual dependent items but that is planned when this feature hopefully is available in the 2021-03 release.