### PR TITLE
provide url-handler to support maven depolyed updatesites

### DIFF
--- a/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Bundle-Activator: org.eclipse.m2e.pde.Activator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.codec.digest;version="1.14.0",
  org.apache.commons.io;version="2.6.0"
+Service-Component: META-INF/urlhandler.xml

--- a/org.eclipse.m2e.pde/META-INF/urlhandler.xml
+++ b/org.eclipse.m2e.pde/META-INF/urlhandler.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.m2e.pde.MvnProtocolHandlerService">
+   <implementation class="org.eclipse.m2e.pde.MvnProtocolHandlerService"/>
+   <property name="url.handler.protocol" type="String" value="mvn"/>
+   <service>
+      <provide interface="org.osgi.service.url.URLStreamHandlerService"/>
+   </service>
+</scr:component>

--- a/org.eclipse.m2e.pde/build.properties
+++ b/org.eclipse.m2e.pde/build.properties
@@ -1,5 +1,6 @@
-source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               META-INF/urlhandler.xml
+source.. = src/

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MvnProtocolHandlerService.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MvnProtocolHandlerService.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.pde;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.ICallable;
+import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
+import org.osgi.service.url.AbstractURLStreamHandlerService;
+
+public class MvnProtocolHandlerService extends AbstractURLStreamHandlerService {
+
+	public MvnProtocolHandlerService() {
+		System.out.println("register service");
+	}
+
+	@Override
+	public URLConnection openConnection(URL url) {
+		return new MavenURLConnection(url);
+	}
+
+	private static final class MavenURLConnection extends URLConnection {
+
+		private String subPath;
+		private ArtifactResult artifactResult;
+
+		protected MavenURLConnection(URL url) {
+			super(url);
+		}
+
+		@SuppressWarnings("restriction")
+		@Override
+		public void connect() throws IOException {
+			if (artifactResult != null) {
+				return;
+			}
+			String path = url.getPath();
+			if (path == null) {
+				throw new IOException("maven coordinates are missing");
+			}
+			int subPathIndex = path.indexOf('/');
+			
+			String[] coordinates;
+            if (subPathIndex > -1) {
+                subPath = path.substring(subPathIndex);
+                coordinates = path.substring(0, subPathIndex).split(":");
+            } else {
+                coordinates = path.split(":");
+            }
+            if (coordinates.length < 3) {
+                throw new IOException(
+                        "required format is groupId:artifactId:version or groupId:artifactId:version:type");
+            }
+            String type;
+            if (coordinates.length > 3) {
+                type = coordinates[3];
+            } else {
+                type = "jar";
+            }
+			Artifact artifact = new DefaultArtifact(coordinates[0], coordinates[1], type, coordinates[2]);
+			try {
+				IMaven maven = MavenPlugin.getMaven();
+				RepositorySystem repoSystem = org.eclipse.m2e.core.internal.MavenPluginActivator.getDefault()
+						.getRepositorySystem();
+				IMavenExecutionContext context = maven.createExecutionContext();
+				List<ArtifactRepository> artifactRepositories = maven.getArtifactRepositories();
+				List<RemoteRepository> remoteRepositories = RepositoryUtils.toRepos(artifactRepositories);
+				artifactResult = context.execute(new ICallable<ArtifactResult>() {
+
+					@Override
+					public ArtifactResult call(IMavenExecutionContext context, IProgressMonitor monitor)
+							throws CoreException {
+						ArtifactRequest artifactRequest = new ArtifactRequest(artifact, remoteRepositories, null);
+						RepositorySystemSession session = context.getRepositorySession();
+						try {
+							return repoSystem.resolveArtifact(session, artifactRequest);
+						} catch (ArtifactResolutionException e) {
+							throw new CoreException(
+									new Status(IStatus.ERROR, MvnProtocolHandlerService.class.getPackage().getName(),
+											"Resolving artifact failed", e));
+						}
+					}
+				}, new NullProgressMonitor());
+			} catch (CoreException e) {
+				throw new IOException("resolving artifact " + artifact + " failed", e);
+			}
+		}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+			connect();
+			if (artifactResult == null || artifactResult.isMissing()) {
+				throw new FileNotFoundException();
+			}
+			File location = artifactResult.getArtifact().getFile();
+			if (subPath == null) {
+				return new FileInputStream(location);
+			}
+			String urlSpec = "jar:" + location.toURI() + "!" + subPath;
+			return new URL(urlSpec).openStream();
+		}
+	}
+
+}


### PR DESCRIPTION
Currently maven deployed update-sites can not be used in target-files because PDE requires that an udpate-site is an URL with individual files to query data.

This adds an URLHandler that allows to use URLs in the format: `mvn:<groupId>:<artifactId>:<version>[:type]`.

![grafik](https://user-images.githubusercontent.com/1331477/100237251-f4faa480-2f2e-11eb-8b24-fa80d372a608.png)
