### PR TITLE
Add suitable description/license information to PDE feature

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.properties
+++ b/org.eclipse.m2e.pde.feature/feature.properties
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright (c) 2020 Christoph Läubrich and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0# 
+# Contributors:
+#     Christoph Läubrich - initial API and implementation
+###############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=m2e PDE - Maven Integration for Eclipse Plugin Development
+
+# "providerName" property - name of the company that provides the feature
+providerName=Eclipse.org - m2e
+
+# "description" property - description of the feature
+description=m2e PDE - Maven Integration for Eclipse Plugin Development adds maven integration to PDE for a more seamless integration.
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=\
+Copyright (c) 2020 Christoph Läubrich.\n\
+All rights reserved. This program and the accompanying materials\n\
+are made available under the terms of the Eclipse Public License 2.0\n\
+which accompanies this distribution, and is available at\n\
+https://www.eclipse.org/legal/epl-2.0/\n\
+\n\
+  SPDX-License-Identifier: EPL-2.0\n\
+\n\
+Contributors:\n\
+     Christoph Läubrich - initial API and implementation\n
+################ end of copyright property ####################################

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.m2e.pde.feature"
-      label="m2e PDE Integration"
-      version="1.17.0.qualifier">
+      label="%featureName"
+      version="1.17.1.qualifier"
+      provider-name="%providerName"
+      plugin="org.eclipse.m2e.core"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
 
-   <description url="http://www.example.com/description">
-      [Enter Feature Description here.]
+   <description>
+      %description
    </description>
 
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+   <copyright>
+      %copyright
    </copyright>
 
    <license url="http://www.example.com/license">

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="1.17.1.qualifier"
+      version="1.17.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.feature/pom.xml
+++ b/org.eclipse.m2e.pde.feature/pom.xml
@@ -19,5 +19,5 @@
 
   <artifactId>org.eclipse.m2e.pde.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.17.0-SNAPSHOT</version>
+  <version>1.17.1-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.pde.feature/pom.xml
+++ b/org.eclipse.m2e.pde.feature/pom.xml
@@ -19,5 +19,5 @@
 
   <artifactId>org.eclipse.m2e.pde.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.17.1-SNAPSHOT</version>
+  <version>1.17.2-SNAPSHOT</version>
 </project>

--- a/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde;singleton:=true
-Bundle-Version: 1.17.0.qualifier
+Bundle-Version: 1.17.2.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",

--- a/org.eclipse.m2e.pde/pom.xml
+++ b/org.eclipse.m2e.pde/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.pde</artifactId>
-	<version>1.17.0-SNAPSHOT</version>
+	<version>1.17.2-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven PDE Integration</name>


### PR DESCRIPTION
I noticed that the feature does not include appropriate copyright information, this is updated now.

beside this, it seems that the update for the new version (1.17.1-SNAPSHOT) did not happened, do I need to add this feature somewhere for this to take place automatically?