### PR TITLE
Bug 570080 - Setting module name for launch config from test folder

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenLaunchConfigurationListener.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenLaunchConfigurationListener.java
@@ -17,10 +17,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationListener;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IModuleDescription;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.JavaRuntime;
 
@@ -49,16 +55,68 @@ public class MavenLaunchConfigurationListener implements ILaunchConfigurationLis
       if(!MavenRuntimeClasspathProvider.isSupportedType(configuration.getType().getIdentifier())) {
         return;
       }
-      if(configuration.getAttributes().containsKey(IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER)) {
-        return;
-      }
+
       IJavaProject javaProject = JavaRuntime.getJavaProject(configuration);
       if(javaProject != null && javaProject.getProject().hasNature(IMavenConstants.NATURE_ID)) {
-        MavenRuntimeClasspathProvider.enable(configuration);
+        if(!configuration.getAttributes().containsKey(IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER)) {
+          MavenRuntimeClasspathProvider.enable(configuration);
+        }
+
+        setModuleNameForLaunchersFromTestFolder(javaProject, configuration);
       }
     } catch(CoreException ex) {
       log.error(ex.getMessage(), ex);
     }
+  }
+
+  /**
+   * As the test source folder can't have a second module-info.java in its package fragment root all launch
+   * configurations with a main class in the source folder won't find the module definition. Thus the module name
+   * derived from the project is set here for the launch configuration.
+   * 
+   * @param javaProject
+   * @param configuration
+   * @throws CoreException
+   */
+  private void setModuleNameForLaunchersFromTestFolder(IJavaProject javaProject, ILaunchConfiguration config)
+      throws CoreException {
+    if(isLaunchConfigWithMainFromTestFolder(javaProject, config)) {
+      IModuleDescription module = javaProject.getModuleDescription();
+      String modName = module == null ? null : module.getElementName();
+
+      String currentModuleName = config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MODULE_NAME, (String) null);
+      if(modName != null && modName.length() > 0 && !modName.equals(currentModuleName)) {
+        if(config instanceof ILaunchConfigurationWorkingCopy) {
+          ((ILaunchConfigurationWorkingCopy) config).setAttribute(IJavaLaunchConfigurationConstants.ATTR_MODULE_NAME,
+              modName);
+        } else {
+          ILaunchConfigurationWorkingCopy wc = config.getWorkingCopy();
+          wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MODULE_NAME, modName);
+          wc.doSave();
+        }
+      }
+    }
+  }
+
+  private boolean isLaunchConfigWithMainFromTestFolder(IJavaProject javaProject, ILaunchConfiguration config)
+      throws CoreException {
+    String mainType = config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, (String) null);
+    if(mainType == null) {
+      return false;
+    }
+
+    IType findType = javaProject.findType(mainType);
+    if(findType == null) {
+      return false;
+    }
+
+    IJavaElement javaElement = findType.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+    if(javaElement instanceof IPackageFragmentRoot) {
+      IPath path = javaElement.getPath();
+      return "test".equals(path.segment(path.segmentCount() - 2));
+    }
+
+    return true;
   }
 
   public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {


### PR DESCRIPTION
Hi,

to be able to launch applications from the test folder in a modularized project the given modification could be applied.

This is probably a corner case as those applications are not picked up by maven. My use case are some evaluations not intended to be part of the main application. I guess those could just be moved to another project and probably the visibility of the classes used must be changed but if felt weird that you can not launch an application from the test folder as this was previously (without modules) possible.

Anyway the change sets the IJavaLaunchConfigurationConstants.ATTR_MODULE_NAME attribute of the launch configuration for those running a main-class from the test folder to the module name derived from the project. It does this on any launch-config change and thus needs a safeguard against stack overflow by recursion implemented by the equals in line 88.

So when org.eclipse.jdt.debug.ui.launchConfigurations.JavaApplicationLaunchShortcut sets the same attribute to " " as the test folder has no module-info, this code overrides it.