### PR TITLE
Bug 563742 - Cache finalName

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -88,6 +88,8 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
 
   private final IPath testOutputLocation;
 
+  private final String finalName;
+
   private final Set<ArtifactRepositoryRef> artifactRepositories;
 
   private final Set<ArtifactRepositoryRef> pluginArtifactRepositories;
@@ -131,6 +133,8 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     path = getProjectRelativePath(mavenProject.getBuild().getTestOutputDirectory());
     this.testOutputLocation = path != null ? fullPath.append(path) : null;
 
+    this.finalName = mavenProject.getBuild().getFinalName();
+
     this.artifactRepositories = new LinkedHashSet<ArtifactRepositoryRef>();
     for(ArtifactRepository repository : mavenProject.getRemoteArtifactRepositories()) {
       this.artifactRepositories.add(new ArtifactRepositoryRef(repository));
@@ -170,8 +174,8 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     this.testCompileSourceLocations = arrayCopy(other.testCompileSourceLocations);
 
     this.outputLocation = other.outputLocation;
-
     this.testOutputLocation = other.testOutputLocation;
+    this.finalName = other.finalName;
 
     this.artifactRepositories = new LinkedHashSet<ArtifactRepositoryRef>(other.artifactRepositories);
 
@@ -230,6 +234,10 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
    */
   public IPath getTestOutputLocation() {
     return testOutputLocation;
+  }
+
+  public String getFinalName() {
+    return finalName;
   }
 
   public IPath getFullPath() {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -76,6 +76,8 @@ public interface IMavenProjectFacade {
    */
   IPath getTestOutputLocation();
 
+  String getFinalName();
+
   IPath getFullPath();
 
   /**

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ModuleSupport.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ModuleSupport.java
@@ -51,8 +51,6 @@ import org.eclipse.jdt.internal.launching.RuntimeClasspathEntry;
 import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
 import org.eclipse.jdt.launching.JavaRuntime;
 
-import org.apache.maven.project.MavenProject;
-
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -206,10 +204,7 @@ public class ModuleSupport {
         String buildName = null;
         IMavenProjectFacade facade = MavenPlugin.getMavenProjectRegistry().getProject(project.getProject());
         if(facade != null) {
-          MavenProject mavenProject = facade.getMavenProject(monitor);
-          if(mavenProject != null) {
-            buildName = mavenProject.getBuild().getFinalName();
-          }
+          buildName = facade.getFinalName();
         }
         if(buildName == null || buildName.isEmpty()) {
           buildName = project.getElementName();


### PR DESCRIPTION
To improve performance of classpath configuration with modules, which
otherwise need to read all pom files of projects in the classpath.

Signed-off-by: Vivien TINTILLIER <vivien.tintillier@sap.com>