### PR TITLE
Bug 570372 - NullPointerException when trying to edit instructions in

### DIFF
--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenArtifactInstructionsWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenArtifactInstructionsWizard.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.editor;
 
+import java.util.Objects;
+
 import org.eclipse.jface.dialogs.DialogTray;
 import org.eclipse.jface.dialogs.TrayDialog;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -47,7 +49,7 @@ public class MavenArtifactInstructionsWizard extends Wizard {
 	private boolean usedefaults;
 
 	public MavenArtifactInstructionsWizard(BNDInstructions bndInstructions) {
-		this.instructions = bndInstructions == null ? null : bndInstructions.getInstructions();
+		this.instructions = bndInstructions.getInstructions();
 		this.usedefaults = instructions == null || instructions.isBlank();
 		setWindowTitle(Messages.MavenArtifactInstructionsWizard_1);
 		WizardPage page = new WizardPage(Messages.MavenArtifactInstructionsWizard_2) {
@@ -144,6 +146,7 @@ public class MavenArtifactInstructionsWizard extends Wizard {
 	 *         canceled the wizard
 	 */
 	public static BNDInstructions openWizard(Shell shell, BNDInstructions instructions) {
+		Objects.requireNonNull(instructions, "BNDInstructions can't be null");
 		MavenArtifactInstructionsWizard wizard = new MavenArtifactInstructionsWizard(instructions);
 		WizardDialog dialog = new WizardDialog(shell, wizard);
 		dialog.setMinimumPageSize(800, 600);

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
@@ -14,6 +14,7 @@ package org.eclipse.m2e.pde.ui.editor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -172,7 +173,7 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 					@Override
 					public void widgetSelected(SelectionEvent e) {
 						BNDInstructions edited = MavenArtifactInstructionsWizard.openWizard(getShell(),
-								bndInstructions);
+								Objects.requireNonNullElse(bndInstructions, BNDInstructions.EMPTY));
 						if (edited != null) {
 							bndInstructions = edited;
 						}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.IOUtils;
 public class BNDInstructions {
 
 	private static final String BND_DEFAULT_PROPERTIES_PATH = "bnd-default.properties";
+	public static final BNDInstructions EMPTY = new BNDInstructions("", null);
 	private String key;
 	private String instructions;
 


### PR DESCRIPTION
target definition editor

- add checks for non-null editor object
- use empty object if current instructions are null

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>