### PR TITLE
Bug 570456 - m2e PDE integration clipboard integration does not work if scope is also copied

### DIFF
--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/ClipboardParser.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/ClipboardParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich
+ * Copyright (c) 2020, 2021 Christoph Läubrich
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Objects;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.eclipse.m2e.pde.MavenTargetLocation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -28,9 +29,11 @@ public class ClipboardParser {
 	private String artifactId;
 	private String version;
 	private String classifier;
+	private String error;
+	private String scope;
 
 	public ClipboardParser(String text) {
-		if (text != null) {
+		if (text != null && text.trim().startsWith("<")) {
 			try {
 				DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 				DocumentBuilder builder = factory.newDocumentBuilder();
@@ -40,8 +43,10 @@ public class ClipboardParser {
 				artifactId = getTextFor("artifactId", doc);
 				version = getTextFor("version", doc);
 				classifier = getTextFor("classifier", doc);
+				scope = getTextFor("scope", doc);
 			} catch (Exception e) {
 				// we can't use the clipboard content then...
+				this.error = e.getMessage();
 			}
 		}
 	}
@@ -53,6 +58,14 @@ public class ClipboardParser {
 			return item.getTextContent();
 		}
 		return null;
+	}
+
+	public String getError() {
+		return error;
+	}
+
+	public String getScope() {
+		return Objects.requireNonNullElse(scope, MavenTargetLocation.DEFAULT_DEPENDENCY_SCOPE);
 	}
 
 	public String getGroupId() {

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/ClipboardParser.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/ClipboardParser.java
@@ -29,7 +29,7 @@ public class ClipboardParser {
 	private String artifactId;
 	private String version;
 	private String classifier;
-	private String error;
+	private Exception error;
 	private String scope;
 
 	public ClipboardParser(String text) {
@@ -46,7 +46,7 @@ public class ClipboardParser {
 				scope = getTextFor("scope", doc);
 			} catch (Exception e) {
 				// we can't use the clipboard content then...
-				this.error = e.getMessage();
+				this.error = e;
 			}
 		}
 	}
@@ -60,7 +60,7 @@ public class ClipboardParser {
 		return null;
 	}
 
-	public String getError() {
+	public Exception getError() {
 		return error;
 	}
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Christoph Läubrich
+ * Copyright (c) 2018, 2021 Christoph Läubrich
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,11 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.editor;
 
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -115,10 +117,18 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 					version.setText(clipboardParser.getVersion());
 					classifier.setText(clipboardParser.getClassifier());
 					type.setText(MavenTargetLocation.DEFAULT_PACKAGE_TYPE);
-					scope.setText(MavenTargetLocation.DEFAULT_DEPENDENCY_SCOPE);
+					scope.setText(clipboardParser.getScope());
 					metadata.setSelection(new StructuredSelection(MavenTargetLocation.DEFAULT_METADATA_MODE));
 					bndInstructions = new BNDInstructions("", null); //$NON-NLS-1$
 					includeSource.setSelection(true);
+					String clipboardError = clipboardParser.getError();
+					if (clipboardError != null) {
+						setMessage(MessageFormat.format(Messages.MavenTargetLocationWizard_11, clipboardError),
+								WARNING);
+						parent.getDisplay().timerExec((int) TimeUnit.SECONDS.toMillis(10), () -> {
+							setMessage(null);
+						});
+					}
 				}
 				updateUI();
 			}

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/MavenTargetLocationWizard.java
@@ -16,8 +16,8 @@ import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
@@ -121,13 +121,10 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 					metadata.setSelection(new StructuredSelection(MavenTargetLocation.DEFAULT_METADATA_MODE));
 					bndInstructions = new BNDInstructions("", null); //$NON-NLS-1$
 					includeSource.setSelection(true);
-					String clipboardError = clipboardParser.getError();
+					Exception clipboardError = clipboardParser.getError();
 					if (clipboardError != null) {
-						setMessage(MessageFormat.format(Messages.MavenTargetLocationWizard_11, clipboardError),
-								WARNING);
-						parent.getDisplay().timerExec((int) TimeUnit.SECONDS.toMillis(10), () -> {
-							setMessage(null);
-						});
+						Platform.getLog(MavenTargetLocationWizard.class).warn(MessageFormat
+								.format(Messages.MavenTargetLocationWizard_11, clipboardError.getMessage()));
 					}
 				}
 				updateUI();

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/Messages.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/Messages.java
@@ -21,6 +21,7 @@ public class Messages extends NLS {
 	public static String MavenTargetLocationWizard_8;
 	public static String MavenTargetLocationWizard_9;
 	public static String MavenTargetLocationWizard_10;
+	public static String MavenTargetLocationWizard_11;
 	public static String MavenTargetLocationWizard_15;
 	public static String MavenTargetLocationWizard_20;
 	public static String MavenTargetLocationWizard_21;

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/messages.properties
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/editor/messages.properties
@@ -15,6 +15,7 @@ MavenTargetLocationWizard_7=Classifier
 MavenTargetLocationWizard_8=Include Artifact Sources
 MavenTargetLocationWizard_9=Missing OSGi-Manifest
 MavenTargetLocationWizard_10=Dependencies scope
+MavenTargetLocationWizard_11=Clipboard content was ignored: {0}
 MavenTargetLocationWizard_15=Specify a scope to include dependencies
 MavenTargetLocationWizard_20=<a>Edit instructions</a>
 MavenTargetLocationWizard_21=Edit the default instructions used in case of necessary manifest generation


### PR DESCRIPTION
Scope is now considered and filled, if the xml can't be parsed a warning is displayed for 10 seconds
![grafik](https://user-images.githubusercontent.com/1331477/105366423-9e90a600-5bff-11eb-92bc-743238417bec.png)


Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>