### PR TITLE
Bug 570582 - Guava 30.1-jre

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -51,6 +51,12 @@
           <groupId>com.google.inject</groupId>
           <artifactId>guice</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- as of version 1.3.9 includes LGPL'ed sources, can't ship with an EPL project  -->
+          <!--  http://dev.eclipse.org/ipzilla/show_bug.cgi?id=7302 -->
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -69,6 +75,14 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- as of version 1.3.9 includes LGPL'ed sources, can't ship with an EPL project  -->
+          <!--  http://dev.eclipse.org/ipzilla/show_bug.cgi?id=7302 -->
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -24,6 +24,10 @@
 
   <name>Nexus Indexer Bundle</name>
 
+  <properties>
+    <guava.version>30.1-jre</guava.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.indexer</groupId>
@@ -60,6 +64,11 @@
       <artifactId>archetype-common</artifactId>
       <version>${archetype-common.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -34,6 +34,7 @@
     <!-- below are m2e-specific addons -->
     <plexus-build-api.version>0.0.7</plexus-build-api.version>
     <okhttp-connector.version>0.17.8</okhttp-connector.version>
+    <guava.version>30.1-jre</guava.version>
   </properties>
   <dependencies>
     <dependency>
@@ -109,6 +110,11 @@
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
* exclude guava from indexer
* add guava 30.1-jre to runtime
* the above changes are intended to prevent transitive resolution of a vulnerable version of guava

Change-Id: I95d3a0c47570c5279e42032249fb3e8a22c24cc1
Signed-off-by: Tony Homer <tony.homer@intel.com>