### PR TITLE
Bug 570315 - The latest contribution of m2e to SimRel 2021-03 M1 has bad licenses and unsigned bundles

### DIFF
--- a/org.eclipse.m2e.site/pom.xml
+++ b/org.eclipse.m2e.site/pom.xml
@@ -36,6 +36,62 @@
   </build>
 
   <profiles>
+  	<!-- Eclipse SimRel requires all artifacts to be jar-signed. So we sign the (non eclipse) artifacts and update the p2 metadata accordingly -->
+	<profile>
+		<id>eclipse-sign</id>
+		<pluginRepositories>
+			<pluginRepository>
+				<id>cbi-snapshots</id>
+				<url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</url>
+			</pluginRepository>
+		</pluginRepositories>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.cbi.maven.plugins</groupId>
+					<artifactId>eclipse-jarsigner-plugin</artifactId>
+					<version>1.3.0-SNAPSHOT</version>
+					<executions>
+						<execution>
+							<id>sign</id>
+							<goals>
+								<goal>sign</goal>
+							</goals>
+							<phase>prepare-package</phase>
+						</execution>
+					</executions>
+					<configuration>
+						<excludeInnerJars>true</excludeInnerJars>
+						<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
+						<archiveDirectory>${project.build.directory}/repository/plugins/</archiveDirectory>
+						<processMainArtifact>false</processMainArtifact>
+						<processAttachedArtifacts>false</processAttachedArtifacts>
+					</configuration>
+				</plugin>
+				<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>update</id>
+						<goals>
+							<goal>fix-artifacts-metadata</goal>
+						</goals>
+						<phase>prepare-package</phase>
+					</execution>
+					<execution>
+						<id>verify</id>
+						<goals>
+							<goal>verify-repository</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			</plugins>
+		</build>
+	</profile>
+  
     <profile>
       <id>publish-site</id>
 


### PR DESCRIPTION
This should sign all unsigned artifacts thanks to the change in cbi https://github.com/eclipse-cbi/org.eclipse.cbi/pull/3 but needs verification on the actual build server (do PR get signed/build the site and can we get access to these artifacts of the build without a deploy?)

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>