### PR TITLE
[cleanup] erefactor/EclipseJdt - Evaluate without null check

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
@@ -357,7 +357,7 @@ public class PomEdits {
     }
     if(!hasChilds) {
       Node parent = el.getParentNode();
-      if(parent != null && parent instanceof Element) {
+      if(parent instanceof Element) {
         removeChild((Element) parent, el);
         removeIfNoChildElement((Element) parent);
       }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -650,7 +650,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
       int start = off.getStartOffset();
       while(reg != null && start < lineend) {
         reg = reg.getNextSibling();
-        if(reg != null && reg instanceof Comment) {
+        if(reg instanceof Comment) {
           Comment comm = (Comment) reg;
           String data = comm.getData();
           if(data != null && data.contains(ignoreString)) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/XmlUtils.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/XmlUtils.java
@@ -114,7 +114,7 @@ public class XmlUtils {
     }
     while(path.segmentCount() > 1) {
       IResource ires = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
-      if(ires != null && ires instanceof IFile) {
+      if(ires instanceof IFile) {
         stack.push((IFile) ires);
       }
       path = path.removeFirstSegments(1);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
@@ -581,7 +581,7 @@ public class MavenRepositoryView extends ViewPart {
       AbstractIndexedRepositoryNode node = getSelectedRepositoryNode(selection);
       updateIndexDetails(node);
       setText(getActionText());
-      boolean enabled = (node != null && node instanceof RepositoryNode);
+      boolean enabled = (node instanceof RepositoryNode);
       this.setEnabled(enabled);
     }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomSelectionComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomSelectionComponent.java
@@ -230,7 +230,7 @@ public class MavenPomSelectionComponent extends Composite {
   }
 
   protected boolean showClassifiers() {
-    return (queryType != null && IIndex.SEARCH_ARTIFACT.equals(queryType));
+    return (IIndex.SEARCH_ARTIFACT.equals(queryType));
   }
 
   public void init(String queryText, String queryType, IProject project, Set<ArtifactKey> artifacts,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
@@ -127,7 +127,7 @@ public class M2EUtils {
     }
     while(path.segmentCount() > 1) {
       IResource ires = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
-      if(ires != null && ires instanceof IFile) {
+      if(ires instanceof IFile) {
         stack.push((IFile) ires);
       }
       path = path.removeFirstSegments(1);

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/operation/RestartInstallOperation.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/operation/RestartInstallOperation.java
@@ -63,7 +63,7 @@ public class RestartInstallOperation extends InstallOperation {
   @Override
   public ProvisioningJob getProvisioningJob(IProgressMonitor monitor) {
     ProvisioningJob job = super.getProvisioningJob(monitor);
-    if(job != null && job instanceof ProfileModificationJob) {
+    if(job instanceof ProfileModificationJob) {
       ((ProfileModificationJob) job).setRestartPolicy(restartPolicy);
       UpdateMavenConfigurationProvisioningJob ucJob = new UpdateMavenConfigurationProvisioningJob(
           ((ProfileModificationJob) job), session, postInstallHook, projectsToConfigure);

--- a/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/PomContentAssistProcessor.java
+++ b/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/PomContentAssistProcessor.java
@@ -253,7 +253,7 @@ public class PomContentAssistProcessor extends DefaultXMLCompletionProposalCompu
     if(context == PomTemplateContext.PROJECT) {
       //check if we have a parent defined..
       Node project = node;
-      if(project != null && project instanceof Element) {
+      if(project instanceof Element) {
         Element parent = XmlUtils.findChild((Element) project, "parent"); //$NON-NLS-1$
         if(parent == null) {
           //now add the proposal for parent inclusion

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
@@ -392,7 +392,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
     }
     // a workaround for editor pages not returned 
     IEditorActionBarContributor contributor = getEditorSite().getActionBarContributor();
-    if(contributor != null && contributor instanceof MultiPageEditorActionBarContributor) {
+    if(contributor instanceof MultiPageEditorActionBarContributor) {
       IEditorPart activeEditor = getActivePageInstance();
       ((MultiPageEditorActionBarContributor) contributor).setActivePage(activeEditor);
     }

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
@@ -301,7 +301,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
   }
 
   static ExpressionRegion findExpressionRegion(Node current, ITextViewer viewer, int offset) {
-    if(current != null && current instanceof Text) {
+    if(current instanceof Text) {
       Text node = (Text) current;
       String value = node.getNodeValue();
       if(value != null) {


### PR DESCRIPTION
EclipseJdt cleanup 'EvaluateNullable' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>