### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unused imports

### DIFF
--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PomPackageImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PomPackageImpl.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.m2e.model.edit.pom.impl;
 
-import static org.eclipse.m2e.model.edit.pom.PomPackage.RESOURCE;
-
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnusedImport' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>