### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant semicolons

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
@@ -152,14 +152,14 @@ class LifecycleMappingsViewer {
         MavenImages.EXPANDALL) {
       public void run() {
         mappingsTreeViewer.expandAll();
-      };
+      }
     };
     actExpandAll.setEnabled(showPhases);
     final Action actCollapseAll = new Action(Messages.LifecycleMappingPropertyPage_mntmCollapseAll_text,
         MavenImages.COLLAPSEALL) {
       public void run() {
         mappingsTreeViewer.collapseAll();
-      };
+      }
     };
     actCollapseAll.setEnabled(showPhases);
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
@@ -547,7 +547,7 @@ public class MavenRepositoryView extends ViewPart {
         }
       }
     });
-  };
+  }
 
   /**
    * Base Selection Listener does not allow the style (radio button/check) to be set. This base class listens to

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -1182,7 +1182,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     MavenExecutionRequest request = createExecutionRequest(new NullProgressMonitor());
     populateDefaults(request);
     return lookup(RepositorySystem.class).getMirror(repo, request.getMirrors());
-  };
+  }
 
   public void populateDefaults(MavenExecutionRequest request) throws CoreException {
     try {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/MatchTyped.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/MatchTyped.java
@@ -22,7 +22,7 @@ public interface MatchTyped {
     EXACT,
     /** Partial match wanted, like prefix, contains, etc. */
     PARTIAL;
-  };
+  }
 
   MatchType getMatchType();
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/EclipseExtensionRealmCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/EclipseExtensionRealmCache.java
@@ -44,7 +44,7 @@ public class EclipseExtensionRealmCache extends DefaultExtensionRealmCache imple
   @Override
   public void register(MavenProject project, Key key, CacheRecord record) {
     plunger.register(project, key);
-  };
+  }
 
   @Override
   public Set<File> removeProject(File pom, ArtifactKey mavenProject, boolean forceDependencyUpdate) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/EclipsePluginArtifactsCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/EclipsePluginArtifactsCache.java
@@ -42,7 +42,7 @@ public class EclipsePluginArtifactsCache extends DefaultPluginArtifactsCache imp
   @Override
   public Set<File> removeProject(File pom, ArtifactKey mavenProject, boolean forceDependencyUpdate) {
     return plunger.removeProject(pom, forceDependencyUpdate);
-  };
+  }
 
   @Override
   public void flush() {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryReader.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryReader.java
@@ -98,7 +98,7 @@ public class ProjectRegistryReader {
                   + " required to load class " + desc.getName()); //$NON-NLS-1$
             }
             return bundles[0].loadClass(desc.getName());
-          };
+          }
         };
         return (ProjectRegistry) is.readObject();
       } catch(Exception ex) {
@@ -165,7 +165,7 @@ public class ProjectRegistryReader {
           }
 
           // TODO this will likely fail during desirialization
-        };
+        }
       };
       synchronized(state) { // see MNGECLIPSE-860
         os.writeObject(state);

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/DependencyTreePage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/DependencyTreePage.java
@@ -687,7 +687,6 @@ public class DependencyTreePage extends FormPage implements IMavenProjectChanged
               return true;
             }
           }
-          ;
 
           ChildMatcher childMatcher = new ChildMatcher();
           node.accept(childMatcher);

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
@@ -209,7 +209,6 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
         return true;
       }
     }
-    ;
 
     try {
       RemovedResourceDeltaVisitor visitor = new RemovedResourceDeltaVisitor();
@@ -279,7 +278,6 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
         }
       }
     }
-    ;
 
     try {
       ChangedResourceDeltaVisitor visitor = new ChangedResourceDeltaVisitor();

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClassifierManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClassifierManager.java
@@ -99,7 +99,7 @@ public class MavenClassifierManager implements IMavenClassifierManager {
     public String toString() {
       return "Delegates to IWorkspaceClassifierResolver";
     }
-  };
+  }
 
   private Map<String, List<IClassifierClasspathProvider>> classifierClasspathProvidersMap;
 


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveRedundantSemicolons' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>