### PR TITLE
[cleanup] erefactor/EclipseJdt - Add missing Annotations - '@deprecated'

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomSelectionComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomSelectionComponent.java
@@ -119,16 +119,19 @@ public class MavenPomSelectionComponent extends Composite {
   /**
    * @deprecated
    */
+  @Deprecated
   public static final String P_SEARCH_INCLUDE_JAVADOC = "searchIncludesJavadoc"; //$NON-NLS-1$
 
   /**
    * @deprecated
    */
+  @Deprecated
   public static final String P_SEARCH_INCLUDE_SOURCES = "searchIncludesSources"; //$NON-NLS-1$
 
   /**
    * @deprecated
    */
+  @Deprecated
   public static final String P_SEARCH_INCLUDE_TESTS = "searchIncludesTests"; //$NON-NLS-1$
 
   private static final long SHORT_DELAY = 150L;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/MavenPlugin.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/MavenPlugin.java
@@ -37,6 +37,7 @@ public final class MavenPlugin {
   /**
    * @deprecated Use static getCOMPONENT methods instead
    */
+  @Deprecated
   public static MavenPlugin getDefault() {
     return INSTANCE;
   }
@@ -68,6 +69,7 @@ public final class MavenPlugin {
   /**
    * @deprecated as of version 1.5, m2e does not provide API to access or configure Maven Installations
    */
+  @Deprecated
   @SuppressWarnings("deprecation")
   public static MavenRuntimeManager getMavenRuntimeManager() {
     return new MavenRuntimeManager(MavenPluginActivator.getDefault().getMavenRuntimeManager());

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -63,6 +63,7 @@ public interface IMaven {
    * 
    * @deprecated see {@link IMavenExecutionContext}.
    */
+  @Deprecated
   public MavenExecutionRequest createExecutionRequest(IProgressMonitor monitor) throws CoreException;
 
   // POM Model read/write operations
@@ -114,6 +115,7 @@ public interface IMaven {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #readMavenProject(File, IProgressMonitor)} instead.
    */
+  @Deprecated
   public MavenExecutionResult readProject(MavenExecutionRequest request, IProgressMonitor monitor) throws CoreException;
 
   /**
@@ -145,6 +147,7 @@ public interface IMaven {
    *             {@link #resolveParentProject(MavenProject, IProgressMonitor)} instead.
    * @TODO Currently returns null in case of resolution error, consider if it should throw CoreException instead
    */
+  @Deprecated
   public MavenProject resolveParentProject(MavenExecutionRequest request, MavenProject project, IProgressMonitor monitor)
       throws CoreException;
 
@@ -155,17 +158,20 @@ public interface IMaven {
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}
    */
+  @Deprecated
   public MavenExecutionResult execute(MavenExecutionRequest request, IProgressMonitor monitor);
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}
    */
+  @Deprecated
   public MavenSession createSession(MavenExecutionRequest request, MavenProject project);
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #execute(MojoExecution, IProgressMonitor)} instead.
    */
+  @Deprecated
   public void execute(MavenSession session, MojoExecution execution, IProgressMonitor monitor);
 
   /**
@@ -177,6 +183,7 @@ public interface IMaven {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #calculateExecutionPlan(MavenProject, List, boolean, IProgressMonitor)} instead.
    */
+  @Deprecated
   public MavenExecutionPlan calculateExecutionPlan(MavenSession session, MavenProject project, List<String> goals,
       boolean setup, IProgressMonitor monitor) throws CoreException;
 
@@ -190,6 +197,7 @@ public interface IMaven {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #setupMojoExecution(MavenProject, MojoExecution)} instead.
    */
+  @Deprecated
   public MojoExecution setupMojoExecution(MavenSession session, MavenProject project, MojoExecution execution)
       throws CoreException;
 
@@ -203,6 +211,7 @@ public interface IMaven {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #getMojoParameterValue(MojoExecution, String, Class)} instead.
    */
+  @Deprecated
   public <T> T getMojoParameterValue(MavenSession session, MojoExecution mojoExecution, String parameter,
       Class<T> asType) throws CoreException;
 
@@ -216,6 +225,7 @@ public interface IMaven {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String)} instead.
    */
+  @Deprecated
   public <T> T getMojoParameterValue(String parameter, Class<T> type, MavenSession session, Plugin plugin,
       ConfigurationContainer configuration, String goal) throws CoreException;
 
@@ -287,6 +297,7 @@ public interface IMaven {
    * 
    * @deprecated IMaven API should not expose maven.repository.ArtifactTransferListener
    */
+  @Deprecated
   public TransferListener createTransferListener(IProgressMonitor monitor);
 
   public ProxyInfo getProxyInfo(String protocol) throws CoreException;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenLauncherConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenLauncherConfiguration.java
@@ -25,6 +25,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
  * @see MavenRuntime#createLauncherConfiguration
  * @deprecated as of version 1.5, m2e does not provide API to access or configure Maven Installations
  */
+@Deprecated
 public interface IMavenLauncherConfiguration {
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
@@ -177,6 +177,7 @@ public class MavenModelManager {
    * @deprecated use {@link #readDependencyTree(IMavenProjectFacade, MavenProject, String, IProgressMonitor)}, which
    *             supports workspace dependency resolution
    */
+  @Deprecated
   public synchronized DependencyNode readDependencyTree(IFile file, String classpath, IProgressMonitor monitor)
       throws CoreException {
     monitor.setTaskName(Messages.MavenModelManager_monitor_reading);
@@ -189,6 +190,7 @@ public class MavenModelManager {
    * @deprecated use {@link #readDependencyTree(IMavenProjectFacade, MavenProject, String, IProgressMonitor)}, which
    *             supports workspace dependency resolution
    */
+  @Deprecated
   public DependencyNode readDependencyTree(MavenProject mavenProject, String classpath, IProgressMonitor monitor)
       throws CoreException {
     return readDependencyTree(null, mavenProject, classpath, monitor);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntime.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * @noimplement This interface is not intended to be implemented by clients.
  * @deprecated as of version 1.5, m2e does not provide API to access or configure Maven Installations
  */
+@Deprecated
 @SuppressWarnings("deprecation")
 public interface MavenRuntime {
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntimeManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntimeManager.java
@@ -29,6 +29,7 @@ import org.eclipse.m2e.core.internal.launch.MavenRuntimeManagerImpl;
  * @author Eugene Kuleshov
  * @author Jason van Zyl
  */
+@Deprecated
 @SuppressWarnings("deprecation")
 public class MavenRuntimeManager {
 
@@ -47,12 +48,14 @@ public class MavenRuntimeManager {
   /**
    * @deprecated this method does nothing
    */
+  @Deprecated
   public void setEmbeddedRuntime(MavenRuntime embeddedRuntime) {
   }
 
   /**
    * @deprecated this method does nothing
    */
+  @Deprecated
   public void setWorkspaceRuntime(MavenRuntime workspaceRuntime) {
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
@@ -49,6 +49,7 @@ public class M2EUtils {
    * @throws CoreException if creating the given <code>folder</code> or any of its parents fails.
    * @deprecated use {@link #createFolder(IFolder, boolean, IProgressMonitor)}
    */
+  @Deprecated
   public static void createFolder(IFolder folder, boolean derived) throws CoreException {
     createFolder(folder, derived, new NullProgressMonitor());
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
@@ -455,6 +455,7 @@ public class MavenPluginActivator extends Plugin {
   /**
    * @deprecated use {@link ArchetypeManager#getArchetypeDataSource(String)}
    */
+  @Deprecated
   public ArchetypeDataSource getArchetypeDataSource(String hint) {
     return getArchetypeManager().getArchetypeDataSource(hint);
   }
@@ -462,6 +463,7 @@ public class MavenPluginActivator extends Plugin {
   /**
    * @deprecated use {@link ArchetypeManager#getArchetypeArtifactManager()}
    */
+  @Deprecated
   public ArchetypeArtifactManager getArchetypeArtifactManager() {
     return getArchetypeManager().getArchetypeArtifactManager();
   }
@@ -489,6 +491,7 @@ public class MavenPluginActivator extends Plugin {
   /**
    * @deprecated use {@link IMavenExecutionContext} instead.
    */
+  @Deprecated
   public MavenSession setSession(MavenSession session) {
     LegacySupport legacy = maven.lookupComponent(LegacySupport.class);
     MavenSession old = legacy.getSession();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver.java
@@ -52,6 +52,7 @@ public abstract class AbstractMavenDependencyResolver {
   /**
    * @deprecated implement {@link #resolveProjectDependencies(IMavenProjectFacade, Set, Set, IProgressMonitor)} instead
    */
+  @Deprecated
   public void resolveProjectDependencies(IMavenProjectFacade facade, MavenExecutionRequest mavenRequest,
       Set<Capability> capabilities, Set<RequiredCapability> requirements, IProgressMonitor monitor)
       throws CoreException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -285,6 +285,7 @@ public class ProjectRegistryManager {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #refresh(Set, IProgressMonitor)} instead.
    */
+  @Deprecated
   public void refresh(final MavenUpdateRequest request, final IProgressMonitor monitor) throws CoreException {
     getMaven().execute(request.isOffline(), request.isForceDependencyUpdate(), (context, pm) -> {
         refresh(request.getPomFiles(), monitor);
@@ -910,6 +911,7 @@ public class ProjectRegistryManager {
   /**
    * @deprecated This method does not properly join {@link IMavenExecutionContext}
    */
+  @Deprecated
   public MavenExecutionRequest createExecutionRequest(IFile pom, ResolverConfiguration resolverConfiguration,
       IProgressMonitor monitor) throws CoreException {
     MavenExecutionRequest request = getMaven().createExecutionRequest(monitor);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectRegistry.java
@@ -56,6 +56,7 @@ public interface IMavenProjectRegistry {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #refresh(Collection, IProgressMonitor)} instead.
    */
+  @Deprecated
   public void refresh(MavenUpdateRequest request, IProgressMonitor monitor) throws CoreException;
 
   /**
@@ -88,12 +89,14 @@ public interface IMavenProjectRegistry {
   /**
    * @deprecated This method does not properly join {@link IMavenExecutionContext}
    */
+  @Deprecated
   public MavenExecutionRequest createExecutionRequest(IFile pom, ResolverConfiguration resolverConfiguration,
       IProgressMonitor monitor) throws CoreException;
 
   /**
    * @deprecated This method does not properly join {@link IMavenExecutionContext}
    */
+  @Deprecated
   public MavenExecutionRequest createExecutionRequest(IMavenProjectFacade project, IProgressMonitor monitor)
       throws CoreException;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenProjectInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenProjectInfo.java
@@ -85,11 +85,13 @@ public class MavenProjectInfo {
   }
 
   /** @deprecated use set/get BasedirRename */
+  @Deprecated
   public void setNeedsRename(boolean needsRename) {
     setBasedirRename(needsRename ? RENAME_REQUIRED : RENAME_NO);
   }
 
   /** @deprecated use set/get BasedirRenamePolicy */
+  @Deprecated
   public boolean isNeedsRename() {
     return getBasedirRename() == RENAME_REQUIRED;
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ProjectImportConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ProjectImportConfiguration.java
@@ -79,6 +79,7 @@ public class ProjectImportConfiguration {
    * 
    * @deprecated This method does not take into account MavenProjectInfo.basedirRename
    */
+  @Deprecated
   public String getProjectName(Model model) {
     // XXX should use resolved MavenProject or Model
     if(projectNameTemplate.length() == 0) {
@@ -119,6 +120,7 @@ public class ProjectImportConfiguration {
    * @deprecated This method does not take into account MavenProjectInfo.basedirRename. Use
    *             IMavenProjectImportResult#getProject instead
    */
+  @Deprecated
   public IProject getProject(IWorkspaceRoot root, Model model) {
     return root.getProject(getProjectName(model));
   }
@@ -126,6 +128,7 @@ public class ProjectImportConfiguration {
   /**
    * @deprecated business logic does not belong to a value object
    */
+  @Deprecated
   public IStatus validateProjectName(Model model) {
     String projectName = getProjectName(model);
     IWorkspace workspace = ResourcesPlugin.getWorkspace();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
@@ -184,6 +184,7 @@ public abstract class AbstractProjectConfigurator implements IExecutableExtensio
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String)} instead.
    */
+  @Deprecated
   @SuppressWarnings("deprecation")
   protected <T> T getParameterValue(String parameter, Class<T> asType, MavenSession session, MojoExecution mojoExecution)
       throws CoreException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/ProjectConfigurationRequest.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/ProjectConfigurationRequest.java
@@ -50,6 +50,7 @@ public class ProjectConfigurationRequest {
   /**
    * @deprecated see {@link IMavenExecutionContext}.
    */
+  @Deprecated
   public MavenSession getMavenSession() {
     final IMavenExecutionContext context = MavenPlugin.getMaven().getExecutionContext();
     if(context == null) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/FormUtils.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/FormUtils.java
@@ -71,6 +71,7 @@ public abstract class FormUtils {
   /**
    * @deprecated use your own string.. this should not have been made ublic in the first place.
    */
+  @Deprecated
   public static final String MORE_DETAILS = ""; //$NON-NLS-1$
 
   public static void decorateHeader(FormToolkit toolkit, Form form) {
@@ -211,6 +212,7 @@ public abstract class FormUtils {
    * @deprecated so that you think hard before using it. Using it for disabling all controls is probably fine. Enabling
    *             all is NOT.
    */
+  @Deprecated
   public static void setReadonly(Composite composite, boolean readonly) {
     if(composite != null) {
       for(Control control : composite.getChildren()) {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractJavaProjectConfigurator.java
@@ -29,6 +29,7 @@ import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
 /**
  * @deprecated use {@link AbstractSourcesGenerationProjectConfigurator} instead.
  */
+@Deprecated
 public abstract class AbstractJavaProjectConfigurator extends AbstractProjectConfigurator implements
     IJavaProjectConfigurator {
   @Override

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClassifierClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClassifierClasspathProvider.java
@@ -45,6 +45,7 @@ public interface IClassifierClasspathProvider {
    * 
    * @deprecated replaced by {@link #setTestClasspath(Set, IMavenProjectFacade, IProgressMonitor, int)}
    */
+  @Deprecated
   void setTestClasspath(Set<IRuntimeClasspathEntry> testClasspath, IMavenProjectFacade mavenProjectFacade,
       IProgressMonitor monitor) throws CoreException;
 
@@ -61,6 +62,7 @@ public interface IClassifierClasspathProvider {
    * 
    * @deprecated replaced by {@link #setRuntimeClasspath(Set, IMavenProjectFacade, IProgressMonitor, int)}.
    */
+  @Deprecated
   void setRuntimeClasspath(Set<IRuntimeClasspathEntry> runtimeClasspath, IMavenProjectFacade mavenProjectFacade,
       IProgressMonitor monitor) throws CoreException;
 

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathDescriptor.java
@@ -118,6 +118,7 @@ public interface IClasspathDescriptor {
    * 
    * @deprecated this method exposes Maven core classes, which are not part of m2eclipse-jdt API
    */
+  @Deprecated
   public IClasspathEntryDescriptor addLibraryEntry(Artifact artifact, IPath srcPath, IPath srcRoot, String javaDocUrl);
 
   /**
@@ -125,5 +126,6 @@ public interface IClasspathDescriptor {
    * 
    * @deprecated this method exposes Maven core classes, which are not part of m2eclipse-jdt API
    */
+  @Deprecated
   public IClasspathEntryDescriptor addProjectEntry(Artifact artifact, IMavenProjectFacade projectFacade);
 }

--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 1.17.1.qualifier
+Bundle-Version: 1.17.2.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables,

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/MavenLaunchConstants.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/MavenLaunchConstants.java
@@ -25,6 +25,7 @@ public interface MavenLaunchConstants {
   /**
    * @deprecated this constant is not used by m2e
    */
+  @Deprecated
   public final String BUILDER_CONFIGURATION_TYPE_ID = "org.eclipse.m2e.Maven2BuilderConfigurationType"; //$NON-NLS-1$
 
   // pom directory automatically became working directory for maven embedder launch
@@ -35,21 +36,25 @@ public interface MavenLaunchConstants {
   /**
    * @deprecated this constant is not used by m2e
    */
+  @Deprecated
   public final String ATTR_GOALS_AUTO_BUILD = "M2_GOALS_AUTO_BUILD"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
+  @Deprecated
   public final String ATTR_GOALS_MANUAL_BUILD = "M2_GOALS_MANUAL_BUILD"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
+  @Deprecated
   public final String ATTR_GOALS_CLEAN = "M2_GOALS_CLEAN"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
+  @Deprecated
   public final String ATTR_GOALS_AFTER_CLEAN = "M2_GOALS_AFTER_CLEAN"; //$NON-NLS-1$
 
   public final String ATTR_PROFILES = "M2_PROFILES"; //$NON-NLS-1$


### PR DESCRIPTION
EclipseJdt cleanup 'AddMissingDeprecatedAnnotation' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Test with dumb version bumper.