### PR TITLE
[cleanup] erefactor/EclipseJdt - Make inner class static

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomHandler.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomHandler.java
@@ -41,7 +41,7 @@ public final class PomHandler extends DefaultHandler {
   /**
    * An exception indicating that the parsing should stop.
    */
-  private class StopParsingException extends SAXException {
+  private static class StopParsingException extends SAXException {
     /**
      * All serializable objects should have a stable serialVersionUID
      */

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
@@ -110,7 +110,7 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
     }
   }
 
-  private final class Attachments {
+  private static final class Attachments {
     public final File javadoc;
 
     public final File sources;


### PR DESCRIPTION
EclipseJdt cleanup 'MakeInnerClassStatic' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>