### PR TITLE
[cleanup] erefactor/EclipseJdt - Use diamond operator - 1

### DIFF
--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ModelImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ModelImpl.java
@@ -1233,7 +1233,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<MailingList> getMailingLists() {
     if(mailingLists == null) {
-      mailingLists = new EObjectContainmentEList.Unsettable<MailingList>(MailingList.class, this,
+      mailingLists = new EObjectContainmentEList.Unsettable<>(MailingList.class, this,
           PomPackage.MODEL__MAILING_LISTS);
     }
     return mailingLists;
@@ -1265,7 +1265,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<Developer> getDevelopers() {
     if(developers == null) {
-      developers = new EObjectContainmentEList.Unsettable<Developer>(Developer.class, this,
+      developers = new EObjectContainmentEList.Unsettable<>(Developer.class, this,
           PomPackage.MODEL__DEVELOPERS);
     }
     return developers;
@@ -1297,7 +1297,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<Contributor> getContributors() {
     if(contributors == null) {
-      contributors = new EObjectContainmentEList.Unsettable<Contributor>(Contributor.class, this,
+      contributors = new EObjectContainmentEList.Unsettable<>(Contributor.class, this,
           PomPackage.MODEL__CONTRIBUTORS);
     }
     return contributors;
@@ -1329,7 +1329,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<License> getLicenses() {
     if(licenses == null) {
-      licenses = new EObjectContainmentEList<License>(License.class, this, PomPackage.MODEL__LICENSES);
+      licenses = new EObjectContainmentEList<>(License.class, this, PomPackage.MODEL__LICENSES);
     }
     return licenses;
   }
@@ -1659,7 +1659,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<Profile> getProfiles() {
     if(profiles == null) {
-      profiles = new EObjectContainmentEList.Unsettable<Profile>(Profile.class, this, PomPackage.MODEL__PROFILES);
+      profiles = new EObjectContainmentEList.Unsettable<>(Profile.class, this, PomPackage.MODEL__PROFILES);
     }
     return profiles;
   }
@@ -1690,7 +1690,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<Repository> getRepositories() {
     if(repositories == null) {
-      repositories = new EObjectContainmentEList.Unsettable<Repository>(Repository.class, this,
+      repositories = new EObjectContainmentEList.Unsettable<>(Repository.class, this,
           PomPackage.MODEL__REPOSITORIES);
     }
     return repositories;
@@ -1722,7 +1722,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<Repository> getPluginRepositories() {
     if(pluginRepositories == null) {
-      pluginRepositories = new EObjectContainmentEList.Unsettable<Repository>(Repository.class, this,
+      pluginRepositories = new EObjectContainmentEList.Unsettable<>(Repository.class, this,
           PomPackage.MODEL__PLUGIN_REPOSITORIES);
     }
     return pluginRepositories;
@@ -1754,7 +1754,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<Dependency> getDependencies() {
     if(dependencies == null) {
-      dependencies = new EObjectContainmentEList.Unsettable<Dependency>(Dependency.class, this,
+      dependencies = new EObjectContainmentEList.Unsettable<>(Dependency.class, this,
           PomPackage.MODEL__DEPENDENCIES);
     }
     return dependencies;
@@ -2114,7 +2114,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<PropertyElement> getProperties() {
     if(properties == null) {
-      properties = new EObjectContainmentEList.Unsettable<PropertyElement>(PropertyElement.class, this,
+      properties = new EObjectContainmentEList.Unsettable<>(PropertyElement.class, this,
           PomPackage.MODEL__PROPERTIES);
     }
     return properties;
@@ -2146,7 +2146,7 @@ public class ModelImpl extends EObjectImpl implements Model {
    */
   public EList<String> getModules() {
     if(modules == null) {
-      modules = new EDataTypeEList<String>(String.class, this, PomPackage.MODEL__MODULES);
+      modules = new EDataTypeEList<>(String.class, this, PomPackage.MODEL__MODULES);
     }
     return modules;
   }

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/NotifierImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/NotifierImpl.java
@@ -503,7 +503,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
    */
   public EList<PropertyElement> getConfiguration() {
     if(configuration == null) {
-      configuration = new EObjectContainmentEList.Unsettable<PropertyElement>(PropertyElement.class, this,
+      configuration = new EObjectContainmentEList.Unsettable<>(PropertyElement.class, this,
           PomPackage.NOTIFIER__CONFIGURATION);
     }
     return configuration;

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginExecutionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginExecutionImpl.java
@@ -249,7 +249,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
    */
   public EList<String> getGoals() {
     if(goals == null) {
-      goals = new EDataTypeEList<String>(String.class, this, PomPackage.PLUGIN_EXECUTION__GOALS);
+      goals = new EDataTypeEList<>(String.class, this, PomPackage.PLUGIN_EXECUTION__GOALS);
     }
     return goals;
   }

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginImpl.java
@@ -361,7 +361,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
    */
   public EList<PluginExecution> getExecutions() {
     if(executions == null) {
-      executions = new EObjectContainmentEList.Unsettable<PluginExecution>(PluginExecution.class, this,
+      executions = new EObjectContainmentEList.Unsettable<>(PluginExecution.class, this,
           PomPackage.PLUGIN__EXECUTIONS);
     }
     return executions;
@@ -393,7 +393,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
    */
   public EList<Dependency> getDependencies() {
     if(dependencies == null) {
-      dependencies = new EObjectContainmentEList.Unsettable<Dependency>(Dependency.class, this,
+      dependencies = new EObjectContainmentEList.Unsettable<>(Dependency.class, this,
           PomPackage.PLUGIN__DEPENDENCIES);
     }
     return dependencies;


### PR DESCRIPTION
EclipseJdt cleanup 'UseDiamondOperator' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>