### PR TITLE
[cleanup] erefactor/EclipseJdt - Use diamond operator

### DIFF
--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginManagementImpl.java
@@ -77,7 +77,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
    */
   public EList<Plugin> getPlugins() {
     if(plugins == null) {
-      plugins = new EObjectContainmentEList<Plugin>(Plugin.class, this, PomPackage.PLUGIN_MANAGEMENT__PLUGINS);
+      plugins = new EObjectContainmentEList<>(Plugin.class, this, PomPackage.PLUGIN_MANAGEMENT__PLUGINS);
     }
     return plugins;
   }

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ProfileImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ProfileImpl.java
@@ -490,7 +490,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    */
   public EList<Repository> getRepositories() {
     if(repositories == null) {
-      repositories = new EObjectContainmentEList.Unsettable<Repository>(Repository.class, this,
+      repositories = new EObjectContainmentEList.Unsettable<>(Repository.class, this,
           PomPackage.PROFILE__REPOSITORIES);
     }
     return repositories;
@@ -522,7 +522,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    */
   public EList<Repository> getPluginRepositories() {
     if(pluginRepositories == null) {
-      pluginRepositories = new EObjectContainmentEList.Unsettable<Repository>(Repository.class, this,
+      pluginRepositories = new EObjectContainmentEList.Unsettable<>(Repository.class, this,
           PomPackage.PROFILE__PLUGIN_REPOSITORIES);
     }
     return pluginRepositories;
@@ -554,7 +554,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    */
   public EList<Dependency> getDependencies() {
     if(dependencies == null) {
-      dependencies = new EObjectContainmentEList.Unsettable<Dependency>(Dependency.class, this,
+      dependencies = new EObjectContainmentEList.Unsettable<>(Dependency.class, this,
           PomPackage.PROFILE__DEPENDENCIES);
     }
     return dependencies;
@@ -586,7 +586,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    */
   public EList<ReportPlugin> getReports() {
     if(reports == null) {
-      reports = new EObjectContainmentEList.Unsettable<ReportPlugin>(ReportPlugin.class, this,
+      reports = new EObjectContainmentEList.Unsettable<>(ReportPlugin.class, this,
           PomPackage.PROFILE__REPORTS);
     }
     return reports;
@@ -838,7 +838,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    */
   public EList<PropertyElement> getProperties() {
     if(properties == null) {
-      properties = new EObjectContainmentEList.Unsettable<PropertyElement>(PropertyElement.class, this,
+      properties = new EObjectContainmentEList.Unsettable<>(PropertyElement.class, this,
           PomPackage.PROFILE__PROPERTIES);
     }
     return properties;
@@ -870,7 +870,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    */
   public EList<String> getModules() {
     if(modules == null) {
-      modules = new EDataTypeEList<String>(String.class, this, PomPackage.PROFILE__MODULES);
+      modules = new EDataTypeEList<>(String.class, this, PomPackage.PROFILE__MODULES);
     }
     return modules;
   }

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportPluginImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportPluginImpl.java
@@ -296,7 +296,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
    */
   public EList<ReportSet> getReportSets() {
     if(reportSets == null) {
-      reportSets = new EObjectContainmentEList.Unsettable<ReportSet>(ReportSet.class, this,
+      reportSets = new EObjectContainmentEList.Unsettable<>(ReportSet.class, this,
           PomPackage.REPORT_PLUGIN__REPORT_SETS);
     }
     return reportSets;

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportSetImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportSetImpl.java
@@ -202,7 +202,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
    */
   public EList<String> getReports() {
     if(reports == null) {
-      reports = new EDataTypeEList<String>(String.class, this, PomPackage.REPORT_SET__REPORTS);
+      reports = new EDataTypeEList<>(String.class, this, PomPackage.REPORT_SET__REPORTS);
     }
     return reports;
   }


### PR DESCRIPTION
EclipseJdt cleanup 'UseDiamondOperator' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>