### PR TITLE
[cleanup] erefactor/EclipseJdt - Use diamond operator

### DIFF
--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/JobHelpers.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/JobHelpers.java
@@ -125,7 +125,7 @@ public class JobHelpers {
   }
 
   private static List<IBackgroundProcessingQueue> getProcessingQueues(IJobManager jobManager) {
-    ArrayList<IBackgroundProcessingQueue> queues = new ArrayList<IBackgroundProcessingQueue>();
+    ArrayList<IBackgroundProcessingQueue> queues = new ArrayList<>();
     for(Job job : jobManager.find(null)) {
       if(job instanceof IBackgroundProcessingQueue) {
         queues.add((IBackgroundProcessingQueue) job);

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/WorkspaceHelpers.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/WorkspaceHelpers.java
@@ -140,7 +140,7 @@ public class WorkspaceHelpers {
 
   public static List<IMarker> findMarkers(IProject project, int targetSeverity, String withAttribute)
       throws CoreException {
-    SortedMap<IMarker, IMarker> errors = new TreeMap<IMarker, IMarker>((o1, o2) -> {
+    SortedMap<IMarker, IMarker> errors = new TreeMap<>((o1, o2) -> {
       int lineNumber1 = o1.getAttribute(IMarker.LINE_NUMBER, -1);
       int lineNumber2 = o2.getAttribute(IMarker.LINE_NUMBER, -1);
       if(lineNumber1 < lineNumber2) {
@@ -167,7 +167,7 @@ public class WorkspaceHelpers {
       }
       errors.put(marker, marker);
     }
-    List<IMarker> result = new ArrayList<IMarker>();
+    List<IMarker> result = new ArrayList<>();
     result.addAll(errors.keySet());
     return result;
   }


### PR DESCRIPTION
EclipseJdt cleanup 'UseDiamondOperator' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>