### PR TITLE
[cleanup] erefactor/EclipseJdt - Use diamond operator

### DIFF
--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractLifecycleMappingTest.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractLifecycleMappingTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractLifecycleMappingTest extends AbstractMavenProjectT
   }
 
   protected List<MojoExecutionKey> getNotCoveredMojoExecutions(IMavenProjectFacade facade) {
-    List<MojoExecutionKey> result = new ArrayList<MojoExecutionKey>();
+    List<MojoExecutionKey> result = new ArrayList<>();
 
     Map<MojoExecutionKey, List<IPluginExecutionMetadata>> executionMapping = facade.getMojoExecutionMapping();
 

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -391,7 +391,7 @@ public abstract class AbstractMavenProjectTestCase {
     File dst = new File(root.getLocation().toFile(), src.getName());
     copyDir(src, dst);
 
-    final ArrayList<MavenProjectInfo> projectInfos = new ArrayList<MavenProjectInfo>();
+    final ArrayList<MavenProjectInfo> projectInfos = new ArrayList<>();
     for(String pomName : pomNames) {
       File pomFile = new File(dst, pomName);
       Model model = mavenModelManager.readMavenModel(pomFile);
@@ -402,7 +402,7 @@ public abstract class AbstractMavenProjectTestCase {
 
     final ProjectImportConfiguration importConfiguration = new ProjectImportConfiguration(configuration);
 
-    final ArrayList<IMavenProjectImportResult> importResults = new ArrayList<IMavenProjectImportResult>();
+    final ArrayList<IMavenProjectImportResult> importResults = new ArrayList<>();
 
     workspace.run(
         (IWorkspaceRunnable) monitor -> importResults.addAll(MavenPlugin.getProjectConfigurationManager()
@@ -553,7 +553,7 @@ public abstract class AbstractMavenProjectTestCase {
    * @since 1.6.0
    */
   protected static Set<IProject> getProjectsFromEvents(Collection<MavenProjectChangedEvent> events) {
-    Set<IProject> projects = new HashSet<IProject>();
+    Set<IProject> projects = new HashSet<>();
     for(MavenProjectChangedEvent event : events) {
       projects.add(event.getSource().getProject());
     }
@@ -567,7 +567,7 @@ public abstract class AbstractMavenProjectTestCase {
    */
   @SafeVarargs
   protected static <T> void assertContainsOnly(Set<? extends T> actual, T... expected) {
-    Set<T> expectedSet = new HashSet<T>();
+    Set<T> expectedSet = new HashSet<>();
     for(T item : expected) {
       expectedSet.add(item);
     }
@@ -578,7 +578,7 @@ public abstract class AbstractMavenProjectTestCase {
     PlexusContainer container = ((MavenImpl) MavenPlugin.getMaven()).getPlexusContainer();
     if(container.getContainerRealm().getResource(FilexWagon.class.getName().replace('.', '/') + ".class") == null) {
       container.getContainerRealm().importFrom(FilexWagon.class.getClassLoader(), FilexWagon.class.getName());
-      ComponentDescriptor<Wagon> descriptor = new ComponentDescriptor<Wagon>();
+      ComponentDescriptor<Wagon> descriptor = new ComponentDescriptor<>();
       descriptor.setRealm(container.getContainerRealm());
       descriptor.setRoleClass(Wagon.class);
       descriptor.setImplementationClass(FilexWagon.class);

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/FilexWagon.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/FilexWagon.java
@@ -36,7 +36,7 @@ import org.apache.maven.wagon.resource.Resource;
  */
 public class FilexWagon extends FileWagon {
 
-  private static List<String> requests = new ArrayList<String>();
+  private static List<String> requests = new ArrayList<>();
 
   private static String requestFilterPattern;
 

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
@@ -92,23 +92,23 @@ public class HttpServer {
 
   private long latency;
 
-  private Map<String, String> userPasswords = new HashMap<String, String>();
+  private Map<String, String> userPasswords = new HashMap<>();
 
-  private Map<String, String[]> userRoles = new HashMap<String, String[]>();
+  private Map<String, String[]> userRoles = new HashMap<>();
 
-  private Map<String, String[]> securedRealms = new HashMap<String, String[]>();
+  private Map<String, String[]> securedRealms = new HashMap<>();
 
-  private Map<String, File> resourceDirs = new TreeMap<String, File>(Collections.reverseOrder());
+  private Map<String, File> resourceDirs = new TreeMap<>(Collections.reverseOrder());
 
-  private Map<String, String[]> resourceFilters = new HashMap<String, String[]>();
+  private Map<String, String[]> resourceFilters = new HashMap<>();
 
-  private Map<String, String> filterTokens = new HashMap<String, String>();
+  private Map<String, String> filterTokens = new HashMap<>();
 
-  private Collection<String> recordedPatterns = new HashSet<String>();
+  private Collection<String> recordedPatterns = new HashSet<>();
 
-  private List<String> recordedRequests = new ArrayList<String>();
+  private List<String> recordedRequests = new ArrayList<>();
 
-  private Map<String, Map<String, String>> recordedHeaders = new HashMap<String, Map<String, String>>();
+  private Map<String, Map<String, String>> recordedHeaders = new HashMap<>();
 
   private String storePassword;
 
@@ -348,7 +348,7 @@ public class HttpServer {
   }
 
   protected SecurityHandler newSecurityHandler() {
-    List<ConstraintMapping> mappings = new ArrayList<ConstraintMapping>();
+    List<ConstraintMapping> mappings = new ArrayList<>();
 
     for(String pathSpec : securedRealms.keySet()) {
       String[] roles = securedRealms.get(pathSpec);
@@ -529,7 +529,7 @@ public class HttpServer {
 
     server = new Server();
 
-    List<Connector> connectors = new ArrayList<Connector>();
+    List<Connector> connectors = new ArrayList<>();
     if(httpPort >= 0) {
       connectors.add(newHttpConnector());
     }
@@ -578,7 +578,7 @@ public class HttpServer {
   protected void waitForConnectors() throws Exception {
     // for unknown reasons, the connectors occasionally don't start properly, this tries hard to ensure they are up
 
-    List<Connector> badConnectors = new ArrayList<Connector>(2);
+    List<Connector> badConnectors = new ArrayList<>(2);
 
     for(int r = 10; r > 0; r-- ) {
       // wait some seconds for the connectors to come up
@@ -746,7 +746,7 @@ public class HttpServer {
           String req = request.getMethod() + " " + uri;
           recordedRequests.add(req);
 
-          Map<String, String> headers = new HashMap<String, String>();
+          Map<String, String> headers = new HashMap<>();
           recordedHeaders.put(uri, headers);
           for(Enumeration<String> h = request.getHeaderNames(); h.hasMoreElements();) {
             String headername = h.nextElement();


### PR DESCRIPTION
EclipseJdt cleanup 'UseDiamondOperator' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>