### PR TITLE
[cleanup] erefactor/EclipseJdt - Use diamond operator - 2

### DIFF
--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportingImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportingImpl.java
@@ -200,7 +200,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
    */
   public EList<ReportPlugin> getPlugins() {
     if(plugins == null) {
-      plugins = new EObjectContainmentEList.Unsettable<ReportPlugin>(ReportPlugin.class, this,
+      plugins = new EObjectContainmentEList.Unsettable<>(ReportPlugin.class, this,
           PomPackage.REPORTING__PLUGINS);
     }
     return plugins;

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ResourceImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ResourceImpl.java
@@ -246,7 +246,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
    */
   public EList<String> getIncludes() {
     if(includes == null) {
-      includes = new EDataTypeEList<String>(String.class, this, PomPackage.RESOURCE__INCLUDES);
+      includes = new EDataTypeEList<>(String.class, this, PomPackage.RESOURCE__INCLUDES);
     }
     return includes;
   }
@@ -258,7 +258,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
    */
   public EList<String> getExcludes() {
     if(excludes == null) {
-      excludes = new EDataTypeEList<String>(String.class, this, PomPackage.RESOURCE__EXCLUDES);
+      excludes = new EDataTypeEList<>(String.class, this, PomPackage.RESOURCE__EXCLUDES);
     }
     return excludes;
   }

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PomItemProviderAdapterFactory.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PomItemProviderAdapterFactory.java
@@ -66,7 +66,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
    * 
    * @generated
    */
-  protected Collection<Object> supportedTypes = new ArrayList<Object>();
+  protected Collection<Object> supportedTypes = new ArrayList<>();
 
   /**
    * This constructs an instance. <!-- begin-user-doc --> <!-- end-user-doc -->

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ModelObjectAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ModelObjectAdapter.java
@@ -51,7 +51,7 @@ public class ModelObjectAdapter extends TranslatorAdapter implements Adapter, IN
 
   private Notifier target;
 
-  private Map<EStructuralFeature, TranslatorAdapter> childAdapters = new LinkedHashMap<EStructuralFeature, TranslatorAdapter>();
+  private Map<EStructuralFeature, TranslatorAdapter> childAdapters = new LinkedHashMap<>();
 
   public ModelObjectAdapter(SSESyncResource resource, EObject eobject, Element node) {
     super(resource);


### PR DESCRIPTION
EclipseJdt cleanup 'UseDiamondOperator' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>