### PR TITLE
[cleanup] erefactor/EclipseJdt - Exit loop earlier

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.m2e.core.ui.internal.console;
 
 import java.io.IOException;
 import java.text.DateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -189,14 +190,8 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
   }
 
   public void showConsole() {
-    boolean exists = false;
     IConsoleManager manager = ConsolePlugin.getDefault().getConsoleManager();
-    for(IConsole element : manager.getConsoles()) {
-      if(this == element) {
-        exists = true;
-      }
-    }
-    if(!exists) {
+    if(!Arrays.asList(manager.getConsoles()).contains(this)) {
       manager.addConsoles(new IConsole[] {this});
     }
     manager.showConsoleView(this);


### PR DESCRIPTION
EclipseJdt cleanup 'BreakLoopEarly' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor