### PR TITLE
[cleanup] erefactor/EclipseJdt - Use modifier 'final' where possible …

### DIFF
--- a/org.eclipse.m2e.importer.tests/pom.xml
+++ b/org.eclipse.m2e.importer.tests/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.importer.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
+  <version>1.16.0-SNAPSHOT</version>
 
   <name>Tests for Maven Integration for Eclipse Importer framework</name>
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/ExcludeArtifactRefactoring.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/ExcludeArtifactRefactoring.java
@@ -326,9 +326,9 @@ public class ExcludeArtifactRefactoring extends Refactoring {
   }
 
   private class Visitor implements DependencyVisitor {
-    private List<Dependency> dependencies;
+    private final List<Dependency> dependencies;
 
-    private Map<Dependency, Set<ArtifactKey>> sourceMap = new HashMap<>();
+    private final Map<Dependency, Set<ArtifactKey>> sourceMap = new HashMap<>();
 
     Visitor(ParentHierarchyEntry project) {
       dependencies = new ArrayList<>();

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/ExcludeWizardPage.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/ExcludeWizardPage.java
@@ -47,7 +47,7 @@ public class ExcludeWizardPage extends UserInputWizardPage implements SelectionL
 
   private Button hierarchy;
 
-  private IMavenProjectFacade facade;
+  private final IMavenProjectFacade facade;
 
   private CLabel status;
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/MavenExcludeWizard.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/MavenExcludeWizard.java
@@ -23,7 +23,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
  */
 public class MavenExcludeWizard extends RefactoringWizard {
 
-  private IMavenProjectFacade facade;
+  private final IMavenProjectFacade facade;
 
   private ExcludeWizardPage excludePage;
 

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
@@ -57,7 +57,7 @@ public class MavenProjectPomScanner<T> extends AbstractProjectScanner<MavenProje
 
   private final Dependency[] dependencies;
 
-  private IMaven maven;
+  private final IMaven maven;
 
   public MavenProjectPomScanner(boolean developer, Dependency[] dependencies) {
     this.developer = developer;

--- a/org.eclipse.m2e.sourcelookup.ui/src/org/eclipse/m2e/sourcelookup/ui/internal/SourceLookupInfoDialog.java
+++ b/org.eclipse.m2e.sourcelookup.ui/src/org/eclipse/m2e/sourcelookup/ui/internal/SourceLookupInfoDialog.java
@@ -59,7 +59,7 @@ public class SourceLookupInfoDialog extends Dialog {
   private Text textSourceContainer;
 
   // FIXME
-  private IProgressMonitor monitor = new NullProgressMonitor();
+  private final IProgressMonitor monitor = new NullProgressMonitor();
 
   public SourceLookupInfoDialog(Shell parentShell, Object debugElement, AdvancedSourceLookupParticipant sourceLookup) {
     super(parentShell);

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
@@ -92,23 +92,23 @@ public class HttpServer {
 
   private long latency;
 
-  private Map<String, String> userPasswords = new HashMap<>();
+  private final Map<String, String> userPasswords = new HashMap<>();
 
-  private Map<String, String[]> userRoles = new HashMap<>();
+  private final Map<String, String[]> userRoles = new HashMap<>();
 
-  private Map<String, String[]> securedRealms = new HashMap<>();
+  private final Map<String, String[]> securedRealms = new HashMap<>();
 
-  private Map<String, File> resourceDirs = new TreeMap<>(Collections.reverseOrder());
+  private final Map<String, File> resourceDirs = new TreeMap<>(Collections.reverseOrder());
 
-  private Map<String, String[]> resourceFilters = new HashMap<>();
+  private final Map<String, String[]> resourceFilters = new HashMap<>();
 
-  private Map<String, String> filterTokens = new HashMap<>();
+  private final Map<String, String> filterTokens = new HashMap<>();
 
-  private Collection<String> recordedPatterns = new HashSet<>();
+  private final Collection<String> recordedPatterns = new HashSet<>();
 
-  private List<String> recordedRequests = new ArrayList<>();
+  private final List<String> recordedRequests = new ArrayList<>();
 
-  private Map<String, Map<String, String>> recordedHeaders = new HashMap<>();
+  private final Map<String, Map<String, String>> recordedHeaders = new HashMap<>();
 
   private String storePassword;
 


### PR DESCRIPTION
…- Private fields

EclipseJdt cleanup 'MakePrivateFieldFinal' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor