### PR TITLE
[cleanup] erefactor/EclipseJdt - Use Arrays.fill() when possible

### DIFF
--- a/org.eclipse.m2e.importer.tests/pom.xml
+++ b/org.eclipse.m2e.importer.tests/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.importer.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
+  <version>1.16.0-SNAPSHOT</version>
 
   <name>Tests for Maven Integration for Eclipse Importer framework</name>
 

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ConfigurationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ConfigurationImpl.java
@@ -14,6 +14,7 @@
 package org.eclipse.m2e.model.edit.pom.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.w3c.dom.Element;
@@ -191,9 +192,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
 
   public void setNodeValues(String xpath, String name, String[] values) {
     String[] names = new String[values.length];
-    for(int i = 0; i < names.length; i++ ) {
-      names[i] = name;
-    }
+    Arrays.fill(names, name);
     setNodeValues(xpath, names, values);
   }
 


### PR DESCRIPTION
EclipseJdt cleanup 'UseArraysFill' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor