### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
@@ -22,7 +22,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 
 /**
  * IMavenConfiguration
- * 
+ *
  * @noimplement This interface is not intended to be implemented by clients.
  */
 public interface IMavenConfiguration {
@@ -31,7 +31,7 @@ public interface IMavenConfiguration {
 
   public void addConfigurationChangeListener(IMavenConfigurationChangeListener listener);
 
-  // remote dependency resolution 
+  // remote dependency resolution
 
   public boolean isOffline();
 
@@ -78,7 +78,7 @@ public interface IMavenConfiguration {
 
   /**
    * Returns {@link IMarker} severity of "out-of-date" project problem
-   * 
+   *
    * @return One of <code>ignore</code>, <code>warning</code> or <code>error</code>.
    * @since 1.5
    */
@@ -86,7 +86,7 @@ public interface IMavenConfiguration {
 
   /**
    * Returns the global checksum policy applied on {@link MavenExecutionRequest}s.
-   * 
+   *
    * @return <code>fail</code>, <code>warn</code> or <code>ignore</code> to override repositories specific checksum
    *         policies or <code>null</code> to follow default behavior.
    * @see {@link ArtifactRepositoryPolicy#CHECKSUM_POLICY_FAIL}
@@ -98,7 +98,7 @@ public interface IMavenConfiguration {
 
   /**
    * Returns {@link IMarker} severity of "Not Covered Mojo Execution" problem.
-   * 
+   *
    * @return One of <code>ignore</code>, <code>warning</code> or <code>error</code>.
    * @since 1.5
    */
@@ -106,7 +106,7 @@ public interface IMavenConfiguration {
 
   /**
    * Returns <code>true</code> if project configuration should be automatically updated when out-of-date.
-   * 
+   *
    * @return <code>true</code> if project configuration should be automatically updated when out-of-date.
    * @since 1.6
    */
@@ -114,7 +114,7 @@ public interface IMavenConfiguration {
 
   /**
    * Returns {@link IMarker} severity of "Overriding Managed version" problem.
-   * 
+   *
    * @return One of <code>ignore</code>, <code>warning</code> or <code>error</code>.
    * @since 1.7
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfigurationChangeListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfigurationChangeListener.java
@@ -18,7 +18,7 @@ import org.eclipse.core.runtime.CoreException;
 
 /**
  * IMavenConfigurationChangeListener
- * 
+ *
  * @author igor
  */
 public interface IMavenConfigurationChangeListener {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
@@ -40,10 +40,10 @@ import org.eclipse.m2e.core.project.IMavenProjectRegistry;
  * nested context's {@link #execute(ICallable, IProgressMonitor)} method.
  * <p>
  * Typical usage
- * 
+ *
  * <pre>
  * IMavenExecutionContext context = maven.createExecutionContext();
- * 
+ *
  * MavenProject project = context.execute(new ICallable&lt;MavenProject&gt;() {
  *   public MavenProject call(IMavenExecutionContext context, IProgressMonitor monitor) {
  *     return maven.readMavenProject(pom, monitor);
@@ -52,7 +52,7 @@ import org.eclipse.m2e.core.project.IMavenProjectRegistry;
  * </pre>
  * <p>
  * Maven execution context instances are not thread safe and cannot be used on other threads.
- * 
+ *
  * @see ICallable
  * @see IMaven#createExecutionContext()
  * @see IMaven#execute(ICallable, IProgressMonitor)
@@ -68,7 +68,7 @@ public interface IMavenExecutionContext {
    * nested contexts, invocation of this method triggers creation of new nested session. When called during
    * {@link #execute(MavenProject, ICallable, IProgressMonitor)}, only getter request methods are allowed and all
    * request setter or modifier will through {@link IllegalStateException}.
-   * 
+   *
    * @since 1.4
    */
   MavenExecutionRequest getExecutionRequest() throws CoreException;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenLauncherConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenLauncherConfiguration.java
@@ -20,7 +20,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 /**
  * Receive notification of content of plexus configuration.
- * 
+ *
  * @author Igor Fedorenko
  * @see MavenRuntime#createLauncherConfiguration
  * @deprecated as of version 1.5, m2e does not provide API to access or configure Maven Installations

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ISettingsChangeListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ISettingsChangeListener.java
@@ -20,7 +20,7 @@ import org.apache.maven.settings.Settings;
 
 /**
  * ISettingsChangeListener
- * 
+ *
  * @author igor
  */
 public interface ISettingsChangeListener {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenConfigurationChangeEvent.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenConfigurationChangeEvent.java
@@ -18,7 +18,7 @@ import org.eclipse.m2e.core.internal.preferences.MavenPreferenceConstants;
 
 /**
  * MavenConfigurationChangeEvent
- * 
+ *
  * @author igor
  */
 public class MavenConfigurationChangeEvent implements MavenPreferenceConstants {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
@@ -75,7 +75,7 @@ import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
 /**
  * Model manager used to read and and modify Maven models
- * 
+ *
  * @author Eugene Kuleshov XXX fix circular dependency
  */
 public class MavenModelManager {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntime.java
@@ -19,7 +19,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
  * Maven runtime
- * 
+ *
  * @author Eugene Kuleshov
  * @author Igor Fedorenko
  * @noimplement This interface is not intended to be implemented by clients.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntimeManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntimeManager.java
@@ -24,7 +24,7 @@ import org.eclipse.m2e.core.internal.launch.MavenRuntimeManagerImpl;
 
 /**
  * Maven runtime manager
- * 
+ *
  * @deprecated as of version 1.5, m2e does not provide API to access or configure Maven Installations
  * @author Eugene Kuleshov
  * @author Jason van Zyl

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/ExtensionReader.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/ExtensionReader.java
@@ -36,7 +36,7 @@ import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 
 /**
  * Extension reader
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class ExtensionReader {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.core.internal;
 
 /**
  * Maven Constants
- * 
+ *
  * @author Eugene Kuleshov
  */
 public interface IMavenConstants {
@@ -44,7 +44,7 @@ public interface IMavenConstants {
    * string that gets included in pom.xml file comments and makes the marker manager to ignore the managed version
    * override marker
    */
-  public static final String MARKER_IGNORE_MANAGED = "$NO-MVN-MAN-VER$";//$NON-NLS-1$ 
+  public static final String MARKER_IGNORE_MANAGED = "$NO-MVN-MAN-VER$";//$NON-NLS-1$
 
   public static final String MAVEN_COMPONENT_CONTRIBUTORS_XPT = PLUGIN_ID + ".mavenComponentContributors"; //$NON-NLS-1$
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
@@ -43,7 +43,7 @@ public class M2EUtils {
 
   /**
    * Helper method which creates a folder and, recursively, all its parent folders.
-   * 
+   *
    * @param folder The folder to create.
    * @param derived true if folder should be marked as derived
    * @throws CoreException if creating the given <code>folder</code> or any of its parents fails.
@@ -56,7 +56,7 @@ public class M2EUtils {
 
   /**
    * Helper method which creates a folder and, recursively, all its parent folders.
-   * 
+   *
    * @param folder The folder to create.
    * @param derived true if folder should be marked as derived
    * @param monitor the progress monitor
@@ -75,7 +75,7 @@ public class M2EUtils {
           folder.create(true, true, monitor);
         }
       } catch(CoreException ex) {
-        //Don't fail if the resource already exists, in case of a race condition 
+        //Don't fail if the resource already exists, in case of a race condition
         if(ex.getStatus().getCode() != IResourceStatus.RESOURCE_EXISTS) {
           throw ex;
         }
@@ -172,7 +172,7 @@ public class M2EUtils {
    * {@link Properties#entrySet()} iterator is not thread safe and fails with {@link ConcurrentModificationException} if
    * the source properties "is structurally modified at any time after the iterator is created". The solution is to use
    * thread-safe {@link Properties#stringPropertyNames()} enumerate and copy properties.
-   * 
+   *
    * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=440696
    * @since 1.6
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
@@ -394,7 +394,7 @@ public class MavenPluginActivator extends Plugin {
       if(this.archetypeManager == null) {
         try {
           PlexusContainer archetyperContainer = newPlexusContainer(ArchetypeGenerationRequest.class.getClassLoader());
-          // TODO this is broken, need to make it lazy, otherwise we'll deadlock or timeout... or both 
+          // TODO this is broken, need to make it lazy, otherwise we'll deadlock or timeout... or both
           this.archetypeManager = newArchetypeManager(archetyperContainer, getStateLocation().toFile());
           try {
             this.archetypeManager.readCatalogs();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Messages.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Messages.java
@@ -18,7 +18,7 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * Messages
- * 
+ *
  * @author mkleint
  */
 public class Messages extends NLS {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/NoSuchComponentException.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/NoSuchComponentException.java
@@ -18,7 +18,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 
 /**
  * NoSuchComponentException
- * 
+ *
  * @author igor
  */
 public class NoSuchComponentException extends IllegalArgumentException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/URLConnectionCaches.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/URLConnectionCaches.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Workaround for JDK bug http://bugs.java.com/view_bug.do?bug_id=6207022
- * 
+ *
  * @since 1.6
  * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=442524
  * @see http://bugs.java.com/view_bug.do?bug_id=6207022

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogsWriter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogsWriter.java
@@ -51,7 +51,7 @@ import org.eclipse.m2e.core.internal.archetype.ArchetypeCatalogFactory.RemoteCat
 
 /**
  * Archetype catalogs writer
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class ArchetypeCatalogsWriter {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeManager.java
@@ -48,7 +48,7 @@ import org.eclipse.m2e.core.internal.NoSuchComponentException;
 
 /**
  * Archetype Manager
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class ArchetypeManager {
@@ -126,7 +126,7 @@ public class ArchetypeManager {
    * Gets the remote {@link ArtifactRepository} of the given {@link Archetype}, or null if none is found. The repository
    * url is extracted from {@link Archetype#getRepository(). The {@link ArtifactRepository} id is set to
    * <strong>archetypeId+"-repo"</strong>, to enable authentication on that repository.
-   * 
+   *
    * @see <a
    *      href="http://maven.apache.org/archetype/maven-archetype-plugin/faq.html">http://maven.apache.org/archetype/maven-archetype-plugin/faq.html</a>
    * @param archetype
@@ -143,7 +143,7 @@ public class ArchetypeManager {
 
   /**
    * Gets the required properties of an {@link Archetype}.
-   * 
+   *
    * @param archetype the archetype possibly declaring required properties
    * @param remoteArchetypeRepository the remote archetype repository, can be null.
    * @param monitor the progress monitor, can be null.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
@@ -94,7 +94,7 @@ public class MavenBuilder extends IncrementalProjectBuilder implements DeltaProv
 
         MavenProject mavenProject;
         try {
-          // make sure projectFacade has MavenProject instance loaded 
+          // make sure projectFacade has MavenProject instance loaded
           mavenProject = projectFacade.getMavenProject(monitor2);
         } catch(CoreException ce) {
           //unable to read the project facade

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenNature.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenNature.java
@@ -26,7 +26,7 @@ public class MavenNature implements IProjectNature {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.eclipse.core.resources.IProjectNature#configure()
    */
   public void configure() throws CoreException {
@@ -37,7 +37,7 @@ public class MavenNature implements IProjectNature {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.eclipse.core.resources.IProjectNature#deconfigure()
    */
   public void deconfigure() throws CoreException {
@@ -47,7 +47,7 @@ public class MavenNature implements IProjectNature {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.eclipse.core.resources.IProjectNature#getProject()
    */
   public IProject getProject() {
@@ -56,7 +56,7 @@ public class MavenNature implements IProjectNature {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.eclipse.core.resources.IProjectNature#setProject(org.eclipse.core.resources.IProject)
    */
   public void setProject(IProject project) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/EclipseBuildContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/EclipseBuildContext.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.internal.builder.IIncrementalBuildFramework;
 
 /**
  * EclipseBuildContext
- * 
+ *
  * @author igor
  */
 public class EclipseBuildContext extends AbstractEclipseBuildContext {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/ResourceScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/ResourceScanner.java
@@ -27,7 +27,7 @@ import org.codehaus.plexus.util.AbstractScanner;
 
 /**
  * WorkspaceScanner
- * 
+ *
  * @author igor
  */
 public class ResourceScanner extends AbstractScanner {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomFileContentDescriber.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomFileContentDescriber.java
@@ -29,7 +29,7 @@ import org.eclipse.m2e.core.internal.Messages;
 
 /**
  * A content describer for POM files.
- * 
+ *
  * @see org.eclipse.ant.internal.core.contentDescriber.AntBuildfileContentDescriber
  * @author Herve Boutemy
  * @since 0.9.6
@@ -37,7 +37,7 @@ import org.eclipse.m2e.core.internal.Messages;
 public final class PomFileContentDescriber extends XMLContentDescriber {
   /**
    * Determines the validation status for the given contents.
-   * 
+   *
    * @param contents the contents to be evaluated
    * @return one of the following:
    *         <ul>
@@ -64,7 +64,7 @@ public final class PomFileContentDescriber extends XMLContentDescriber {
     // Check to see if we matched our criteria.
     if(pomHandler.hasRootProjectElement()) {
       if(pomHandler.hasArtifactIdElement()) {
-        //project and artifactId element 
+        //project and artifactId element
         return VALID;
       }
       //only a top level project element: maybe a POM file, but maybe an Ant buildfile, a site descriptor, ...
@@ -79,9 +79,9 @@ public final class PomFileContentDescriber extends XMLContentDescriber {
     if(super.describe(contents, description) == INVALID) {
       return INVALID;
     }
-    // super.describe will have consumed some chars, need to rewind   
+    // super.describe will have consumed some chars, need to rewind
     contents.reset();
-    // Check to see if we matched our criteria.   
+    // Check to see if we matched our criteria.
     return checkCriteria(new InputSource(contents));
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomHandler.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomHandler.java
@@ -32,7 +32,7 @@ import org.xml.sax.helpers.DefaultHandler;
 /**
  * An xml event handler for detecting the project top-level element in a POM file. Also records whether a default
  * attribute is present for the project and if any typical Maven elements are present.
- * 
+ *
  * @see org.eclipse.ant.internal.core.contentDescriber.AntHandler
  * @author Herve Boutemy
  * @since 0.9.6
@@ -73,7 +73,7 @@ public final class PomHandler extends DefaultHandler {
 
   /**
    * Creates a new SAX parser for use within this instance.
-   * 
+   *
    * @return The newly created parser.
    * @throws ParserConfigurationException If a parser of the given configuration cannot be created.
    * @throws SAXException If something in general goes wrong when creating the parser.
@@ -126,7 +126,7 @@ public final class PomHandler extends DefaultHandler {
 
   /*
    * Resolve external entity definitions to an empty string.  This is to speed
-   * up processing of files with external DTDs.  Not resolving the contents 
+   * up processing of files with external DTDs.  Not resolving the contents
    * of the DTD is ok, as only the System ID of the DTD declaration is used.
    * @see org.xml.sax.helpers.DefaultHandler#resolveEntity(java.lang.String, java.lang.String)
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/TextContentDescriber.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/TextContentDescriber.java
@@ -28,7 +28,7 @@ import org.eclipse.core.runtime.content.ITextContentDescriber;
  * <p>
  * Note: do not add protected/public members to this class if you don't intend to make them public API.
  * </p>
- * 
+ *
  * @see org.eclipse.core.runtime.content.XMLRootElementContentDescriber2
  * @since 3.0
  */
@@ -42,7 +42,7 @@ class TextContentDescriber implements ITextContentDescriber {
    */
   @SuppressWarnings("unused")
   public int describe(Reader contents, IContentDescription description) throws IOException {
-    // we want to be pretty loose on detecting the text content type  
+    // we want to be pretty loose on detecting the text content type
     return INDETERMINATE;
   }
 
@@ -56,7 +56,7 @@ class TextContentDescriber implements ITextContentDescriber {
     byte[] bom = getByteOrderMark(contents);
     if(bom != null)
       description.setProperty(IContentDescription.BYTE_ORDER_MARK, bom);
-    // we want to be pretty loose on detecting the text content type      
+    // we want to be pretty loose on detecting the text content type
     return INDETERMINATE;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/XMLContentDescriber.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/XMLContentDescriber.java
@@ -31,7 +31,7 @@ import org.eclipse.core.runtime.content.ITextContentDescriber;
  * <p>
  * Note: do not add protected/public members to this class if you don't intend to make them public API.
  * </p>
- * 
+ *
  * @see org.eclipse.core.runtime.content.XMLRootElementContentDescriber2
  * @see "http://www.w3.org/TR/REC-xml *"
  */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/AbstractTransferListenerAdapter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/AbstractTransferListenerAdapter.java
@@ -31,7 +31,7 @@ import org.eclipse.m2e.core.internal.Messages;
 
 /**
  * AbstractTransferListenerAdapter
- * 
+ *
  * @author igor
  */
 abstract class AbstractTransferListenerAdapter {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/ArtifactTransferListenerAdapter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/ArtifactTransferListenerAdapter.java
@@ -22,7 +22,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 
 /**
  * ArtifactTransferListenerAdapter
- * 
+ *
  * @author igor
  */
 public class ArtifactTransferListenerAdapter extends AbstractTransferListenerAdapter implements TransferListener {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseClassRealmManagerDelegate.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseClassRealmManagerDelegate.java
@@ -33,14 +33,14 @@ import org.apache.maven.classrealm.ClassRealmRequest;
 
 /**
  * EclipseArtifactFilterManager
- * 
+ *
  * @author igor
  */
 public class EclipseClassRealmManagerDelegate implements ClassRealmManagerDelegate {
 
   public static final String ROLE_HINT = EclipseClassRealmManagerDelegate.class.getName();
 
-  private static final String PLEXUSBUILDCONTEXT_PROPERTIES = "/org/sonatype/plexus/build/incremental/version.properties"; //$NON-NLS-1$ 
+  private static final String PLEXUSBUILDCONTEXT_PROPERTIES = "/org/sonatype/plexus/build/incremental/version.properties"; //$NON-NLS-1$
 
   private final PlexusContainer plexus;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseLoggerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseLoggerManager.java
@@ -21,7 +21,7 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 
 /**
  * EclipseLoggerManager
- * 
+ *
  * @author igor
  */
 public class EclipseLoggerManager extends AbstractLoggerManager {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/FilterRepositorySystemSession.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/FilterRepositorySystemSession.java
@@ -20,7 +20,7 @@ import org.eclipse.aether.transfer.TransferListener;
 
 /**
  * FilterRepositorySystemSession implementation that allows setting of some/relevant session attributes.
- * 
+ *
  * @since 1.4
  */
 class FilterRepositorySystemSession extends org.eclipse.aether.AbstractForwardingRepositorySystemSession {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -86,7 +86,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
     if(stack != null && !stack.isEmpty()) {
       MavenExecutionRequest parent = stack.peek().request;
       if(parent == null) {
-        throw new IllegalStateException(); // 
+        throw new IllegalStateException(); //
       }
       request = DefaultMavenExecutionRequest.copy(parent);
     }
@@ -257,7 +257,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
   /**
    * Suspends current Maven execution context, if any. Returns suspended context or {@code null} if there was no context
    * associated with the current thread.
-   * 
+   *
    * @see #resume(Deque)
    * @since 1.5
    */
@@ -269,7 +269,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
 
   /**
    * Resumes Maven execution context suspended with {@link #suspend()}.
-   * 
+   *
    * @see #resume(Deque)
    * @since 1.5
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -245,7 +245,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     request.setLocalRepository(localRepository);
     request.setLocalRepositoryPath(localRepository.getBasedir());
     request.setOffline(mavenConfiguration.isOffline());
-    
+
     request.getUserProperties().put("m2e.version", MavenPluginActivator.getVersion()); //$NON-NLS-1$
     request.getUserProperties().put(ConfigurationProperties.USER_AGENT, MavenPluginActivator.getUserAgent());
 
@@ -349,7 +349,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
       throws CoreException {
     try {
       MojoDescriptor mojoDescriptor = mojoExecution.getMojoDescriptor();
-      // getPluginRealm creates plugin realm and populates pluginDescriptor.classRealm field 
+      // getPluginRealm creates plugin realm and populates pluginDescriptor.classRealm field
       lookup(BuildPluginManager.class).getPluginRealm(session, mojoDescriptor.getPluginDescriptor());
       return clazz.cast(lookup(MavenPluginManager.class).getConfiguredMojo(Mojo.class, session, mojoExecution));
     } catch(PluginContainerException ex) {
@@ -876,7 +876,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     for(ArtifactRepository repository : remoteRepositories) {
       String timestamp = lastUpdated.getProperty(getLastUpdatedKey(repository, artifact));
       if(timestamp == null) {
-        // availability of the artifact from this repository has not been checked yet 
+        // availability of the artifact from this repository has not been checked yet
         return false;
       }
     }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
@@ -15,7 +15,7 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  * See https://github.com/apache/maven/blob/9ae008a67db18693d7debf99bf3742ab180cc016/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java
  */
 
@@ -40,7 +40,7 @@ import org.apache.maven.shared.utils.StringUtils;
  * Most of the code was copied from maven-embedder's <a href=
  * "https://github.com/apache/maven/blob/9ae008a67db18693d7debf99bf3742ab180cc016/maven-embedder/src/main/java/org/apache/maven/cli/CLIReportingUtils.java#L84-L131">CLIReportingUtils.java</a>
  * </p>
- * 
+ *
  * @since 1.15
  */
 public class MavenProperties {
@@ -124,7 +124,7 @@ public class MavenProperties {
 
   /**
    * Add the "maven.version" and "maven.build.version" properties to the given properties
-   * 
+   *
    * @param properties
    */
   public static void setProperties(Properties properties) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/ReadonlyMavenExecutionRequest.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/ReadonlyMavenExecutionRequest.java
@@ -38,7 +38,7 @@ import org.apache.maven.toolchain.model.ToolchainModel;
 
 /**
  * Read-only MavenExecutionRequest that throws IllegalStateException from all modifiers.
- * 
+ *
  * @since 1.4
  */
 class ReadonlyMavenExecutionRequest implements MavenExecutionRequest {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/equinox/DevClassPathHelper.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/equinox/DevClassPathHelper.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.core.internal.equinox;
 
 /**
  * Facade that provides Equinox development classpath information.
- * 
+ *
  * @since 1.5
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/equinox/EquinoxLocker.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/equinox/EquinoxLocker.java
@@ -21,7 +21,7 @@ import org.eclipse.osgi.internal.location.Locker;
 
 /**
  * Adaptor for Equinox internal file Locker implementation
- * 
+ *
  * @since 1.5
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IIndex.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IIndex.java
@@ -27,7 +27,7 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
  */
 public interface IIndex {
 
-  // search keys 
+  // search keys
 
   public static final String SEARCH_GROUP = "groupId"; //$NON-NLS-1$
 
@@ -61,7 +61,7 @@ public interface IIndex {
 //  public Set<SearchClassifiers> ALL_CLASSIFIERS = new HashSet<IIndex.SearchClassifiers>(Arrays.asList(SearchClassifiers
 //      .values()));
 
-  // 
+  //
 
   public static final int SEARCH_JARS = 1 << 0;
 
@@ -89,7 +89,7 @@ public interface IIndex {
 
   /**
    * Performs a search for artifacts with given parameters.
-   * 
+   *
    * @param groupId
    * @param artifactId
    * @param version
@@ -104,7 +104,7 @@ public interface IIndex {
    * Performs a search for artifacts with given parameters. Similar to
    * {@link IIndex#find(SearchExpression, SearchExpression, SearchExpression, SearchExpression)}, but here you are able
    * to pass in multiple values for all searches. All elements of collections will form an "OR" of one query.
-   * 
+   *
    * @param groupId
    * @param artifactId
    * @param version
@@ -125,7 +125,7 @@ public interface IIndex {
   /**
    * Convenience method to search in all indexes enabled for repositories defined in settings.xml. This method always
    * performs "scored" search.
-   * 
+   *
    * @param term - search term
    * @param searchType - query type. Should be one of the SEARCH_* values.
    * @param classifier - the type of classifiers to search for, SEARCH_ALL, SEARCH_JAVADOCS, SEARCH_SOURCES,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IndexListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IndexListener.java
@@ -18,7 +18,7 @@ import org.eclipse.m2e.core.repository.IRepository;
 
 /**
  * IndexListener
- * 
+ *
  * @author Eugene Kuleshov
  */
 public interface IndexListener {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IndexManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IndexManager.java
@@ -25,7 +25,7 @@ public interface IndexManager {
 
   String WORKSPACE_INDEX = "workspace"; //$NON-NLS-1$
 
-  // 
+  //
 
   IMutableIndex getWorkspaceIndex();
 
@@ -41,7 +41,7 @@ public interface IndexManager {
 
   /**
    * Returns index aggregating all indexes enabled for repositories defined in settings.xml
-   * 
+   *
    * @return
    * @throws CoreException
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/MatchTyped.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/MatchTyped.java
@@ -12,7 +12,7 @@ package org.eclipse.m2e.core.internal.index;
 
 /**
  * MatchTyped is a interface that describes the wanted match type to be used.
- * 
+ *
  * @author cstamas
  */
 public interface MatchTyped {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/MatchTypedStringSearchExpression.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/MatchTypedStringSearchExpression.java
@@ -12,7 +12,7 @@ package org.eclipse.m2e.core.internal.index;
 
 /**
  * MatchTypedStringSearchExpression
- * 
+ *
  * @author cstamas
  */
 public class MatchTypedStringSearchExpression extends StringSearchExpression implements MatchTyped {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/SearchExpression.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/SearchExpression.java
@@ -12,14 +12,14 @@ package org.eclipse.m2e.core.internal.index;
 
 /**
  * SearchExpression is a wrapper interface for expressions representable as plain strings to be used within searches.
- * 
+ *
  * @author cstamas
  */
 public interface SearchExpression {
 
   /**
    * Returns the expression value as plain java String.
-   * 
+   *
    * @return
    */
   String getStringValue();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/SourcedSearchExpression.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/SourcedSearchExpression.java
@@ -14,7 +14,7 @@ package org.eclipse.m2e.core.internal.index;
  * SourcedSearchExpression is a search expression usually "sourced" from some programmatic source, and we already know
  * it is complete, exact value that we want to search for. Indexer will try to match exactly the provided string value,
  * no more no less.
- * 
+ *
  * @author cstamas
  */
 public class SourcedSearchExpression extends MatchTypedStringSearchExpression {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/StringSearchExpression.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/StringSearchExpression.java
@@ -12,7 +12,7 @@ package org.eclipse.m2e.core.internal.index;
 
 /**
  * StringSearchExpression is a SearchExpression that has String value.
- * 
+ *
  * @author cstamas
  */
 public class StringSearchExpression implements SearchExpression {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/UserInputSearchExpression.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/UserInputSearchExpression.java
@@ -14,7 +14,7 @@ package org.eclipse.m2e.core.internal.index;
  * UserInputSearchExpression is a search expression usually coming from user input (like some UI dialogue, element or
  * CLI). It will be normalized and tokenized and then a search will happen against it. Search expressions of this type
  * will always provide "broader" results, since it defaults to prefix searches.
- * 
+ *
  * @author cstamas
  */
 public class UserInputSearchExpression extends MatchTypedStringSearchExpression {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/filter/ArtifactFilterManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/filter/ArtifactFilterManager.java
@@ -35,7 +35,7 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
 
 /**
  * ArtifactFilterManager
- * 
+ *
  * @author igor
  */
 public class ArtifactFilterManager {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/filter/FilteredIndex.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/filter/FilteredIndex.java
@@ -32,7 +32,7 @@ import org.eclipse.m2e.core.internal.index.SearchExpression;
 
 /**
  * FilteredIndex
- * 
+ *
  * @author igor
  */
 public class FilteredIndex implements IIndex {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/AetherClientResourceFetcher.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/AetherClientResourceFetcher.java
@@ -158,7 +158,7 @@ public class AetherClientResourceFetcher implements ResourceFetcher {
       if(proxyInfo == null) {
         return null;
       }
-      //Bug 512006 don't return the proxy for nonProxyHosts 
+      //Bug 512006 don't return the proxy for nonProxyHosts
       try {
         if(ProxyUtils.validateNonProxyHosts(proxyInfo, new URL(baseUrl).getHost())) {
           return null;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/CompositeIndex.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/CompositeIndex.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.internal.index.SearchExpression;
 
 /**
  * CompositeIndex
- * 
+ *
  * @author igor
  */
 public class CompositeIndex implements IIndex {

--- a/org.eclipse.m2e.importer.tests/pom.xml
+++ b/org.eclipse.m2e.importer.tests/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.importer.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
+  <version>1.16.0-SNAPSHOT</version>
 
   <name>Tests for Maven Integration for Eclipse Importer framework</name>
 


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@mickaelistria Do you this cleanup type as PRs?