### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines - 1

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
@@ -41,7 +41,7 @@ import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 /**
  * A default {@link IndexerEngine} implementation.
- * 
+ *
  * @author Tamas Cservenak
  */
 @Singleton

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/src/main/java/org/apache/maven/index/NexusArchetypeDataSource.java
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/src/main/java/org/apache/maven/index/NexusArchetypeDataSource.java
@@ -23,7 +23,7 @@ import org.apache.maven.index.context.IndexingContext;
 
 /**
  * Trivial implementation of a Nexus indexer-based data source for archetypes.
- * 
+ *
  * The maven-indexer used to ship such a class, but it is now an abstract helper
  * class that consumers have to extend themselves in order to implement
  * maven-archetype's {@link ArchetypeDataSource} interface. This allows

--- a/org.eclipse.m2e.binaryproject.ui/src/org/eclipse/m2e/binaryproject/ui/internal/BinaryprojectUIActivator.java
+++ b/org.eclipse.m2e.binaryproject.ui/src/org/eclipse/m2e/binaryproject/ui/internal/BinaryprojectUIActivator.java
@@ -33,7 +33,7 @@ public class BinaryprojectUIActivator extends AbstractUIPlugin {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
    */
   public void start(BundleContext context) throws Exception {
@@ -43,7 +43,7 @@ public class BinaryprojectUIActivator extends AbstractUIPlugin {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
    */
   public void stop(BundleContext context) throws Exception {
@@ -53,7 +53,7 @@ public class BinaryprojectUIActivator extends AbstractUIPlugin {
 
   /**
    * Returns the shared instance
-   * 
+   *
    * @return the shared instance
    */
   public static BinaryprojectUIActivator getDefault() {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/MavenImages.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/MavenImages.java
@@ -65,7 +65,7 @@ public class MavenImages {
   // object images
   public static final String PATH_JAR = "jar_obj.png"; //$NON-NLS-1$
 
-  public static final String PATH_PROJECT = "project_obj.png"; //$NON-NLS-1$ 
+  public static final String PATH_PROJECT = "project_obj.png"; //$NON-NLS-1$
 
   public static final String PATH_LOCK = "lock_ovr.png"; //$NON-NLS-1$
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/Messages.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/Messages.java
@@ -19,7 +19,7 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * Messages
- * 
+ *
  * @author mkleint
  */
 public class Messages extends NLS {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/WorkingSets.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/WorkingSets.java
@@ -31,14 +31,14 @@ import org.eclipse.ui.PlatformUI;
 
 /**
  * Helpers to query and manipulate workbench working sets.
- * 
+ *
  * @since 1.5
  */
 public class WorkingSets {
 
   /**
    * Returns all visible workbench working sets.
-   * 
+   *
    * @since 1.5
    */
   public static String[] getWorkingSets() {
@@ -54,7 +54,7 @@ public class WorkingSets {
 
   /**
    * Returns existing or creates new workbench working set with the given name
-   * 
+   *
    * @since 1.5
    */
   public static IWorkingSet getOrCreateWorkingSet(String workingSetName) {
@@ -72,7 +72,7 @@ public class WorkingSets {
   /**
    * Adds given projects to workbench working set with the given name. Creates new working set if workbench working set
    * with given name does not already exist.
-   * 
+   *
    * @since 1.5
    */
   public static void addToWorkingSet(IProject[] projects, String workingSetName) {
@@ -85,7 +85,7 @@ public class WorkingSets {
 
   /**
    * Adds given projects to given workbench working sets.
-   * 
+   *
    * @since 1.5
    */
   public static void addToWorkingSets(IProject[] projects, List<IWorkingSet> workingSets) {
@@ -107,7 +107,7 @@ public class WorkingSets {
 
   /**
    * Adds given projects to given workbench working sets.
-   * 
+   *
    * @since 1.5
    */
   public static void addToWorkingSets(Collection<IProject> projects, List<IWorkingSet> workingSets) {
@@ -116,7 +116,7 @@ public class WorkingSets {
 
   /**
    * Returns all projects that belong to workbench working sets.
-   * 
+   *
    * @since 1.5
    */
   public static Set<IProject> getProjects() {
@@ -140,7 +140,7 @@ public class WorkingSets {
   /**
    * Returns one of the working sets the element directly belongs to. Returns {@code null} if the element does not
    * belong to any working set.
-   * 
+   *
    * @since 1.5
    */
   public static IWorkingSet getAssignedWorkingSet(IResource element) {
@@ -158,7 +158,7 @@ public class WorkingSets {
   /**
    * Returns all working sets the element directly belongs to. Returns empty collection if the element does not belong
    * to any working set. The order of returned working sets is not specified.
-   * 
+   *
    * @since 1.5
    */
   public static List<IWorkingSet> getAssignedWorkingSets(IResource element) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/DisableNatureAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/DisableNatureAction.java
@@ -72,7 +72,7 @@ public class DisableNatureAction implements IObjectActionDelegate {
   }
 
   /*
-   * (non-Javadoc) 
+   * (non-Javadoc)
    * @see org.eclipse.ui.IObjectActionDelegate#setActivePart(org.eclipse.jface.action.IAction,
    *      org.eclipse.ui.IWorkbenchPart)
    */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenActionSupport.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenActionSupport.java
@@ -39,7 +39,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 /**
  * MavenActionSupport
- * 
+ *
  * @author Jason van Zyl
  */
 public abstract class MavenActionSupport implements IObjectActionDelegate {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.project.ResolverConfiguration;
 /**
  * Helper IPropertyTester implementation to check if receiver can be launched with Maven. E.g. it is pom.xml file of
  * folder or project that has pom.xml.
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenPropertyTester extends PropertyTester {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenMavenConsoleAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenMavenConsoleAction.java
@@ -20,7 +20,7 @@ import org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator;
 
 /**
  * Open Maven Console Action
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class OpenMavenConsoleAction extends Action {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenPomAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenPomAction.java
@@ -80,7 +80,7 @@ import org.eclipse.m2e.core.ui.internal.dialogs.MavenRepositorySearchDialog;
 
 /**
  * Open POM Action
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowActionDelegate, IObjectActionDelegate {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
@@ -233,7 +233,7 @@ public class SelectionUtil {
 //      String groupId = dependency.getGroupId();
 //      String artifactId = dependency.getArtifactId();
 //      String version = dependency.getVersion();
-//      
+//
 //      if(version == null) {
 //        //mkleint: this looks scary
 //        IEditorPart editor = getActiveEditor();
@@ -332,7 +332,7 @@ public class SelectionUtil {
 
   /**
    * Finds the pom.xml from the given selection or the current active pom editor.
-   * 
+   *
    * @param selection
    * @return the first pom.xml from the given selection or the current active pom editor. returns
    *         <code>null</null> if no pom was found.
@@ -383,7 +383,7 @@ public class SelectionUtil {
   /**
    * Returns all the Maven projects found in the given selection. If no projects are found in the selection and
    * <code>includeAll</code> is true, all workspace projects are returned.
-   * 
+   *
    * @param selection
    * @param includeAll flag to return all workspace projects if selection doesn't contain any Maven projects.
    * @return an array of {@link IProject} containing all the Maven projects found in the given selection, or all the

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectAction.java
@@ -18,7 +18,7 @@ import org.eclipse.jface.action.IAction;
 
 /**
  * UpdateMavenProjectAction
- * 
+ *
  * @deprecated this action is deprecated in favor of {@link UpdateMavenProjectCommandHandler}
  */
 @Deprecated

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectCommandHandler.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectCommandHandler.java
@@ -38,7 +38,7 @@ import org.eclipse.m2e.core.ui.internal.dialogs.UpdateMavenProjectsDialog;
 /**
  * Handler for the Update Project command. This can then be bound to whatever key binding the user prefers (defaults to
  * Alt+F5).
- * 
+ *
  * @author Fred Bricon
  * @since 1.4.0
  */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/TextComboBoxCellEditor.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/TextComboBoxCellEditor.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.Control;
 /**
  * A TextComboBoxCellEditor to overcome the limitation of the standard ComboBoxCellEditor, which does not allow to edit
  * plain text values.
- * 
+ *
  * @author Dmitry Platonoff
  */
 public class TextComboBoxCellEditor extends CellEditor {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
@@ -52,7 +52,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Working set group
- * 
+ *
  * @author Eugene Kuleshov
  */
 // TODO reconcile with WorkingSets

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/IMavenConsoleListener.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/IMavenConsoleListener.java
@@ -18,7 +18,7 @@ import java.util.EventListener;
 
 /**
  * A console listener is notified of output to the Maven console.
- * 
+ *
  * @author Benjamin Bentmann
  */
 public interface IMavenConsoleListener extends EventListener {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsole.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsole.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.core.ui.internal.console;
 
 /**
  * Maven Console
- * 
+ *
  * @author Eugene Kuleshov
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleFactory.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleFactory.java
@@ -20,7 +20,7 @@ import org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator;
 
 /**
  * Maven Console factory is used to show the console from the "Open Console" drop-down action in Console view.
- * 
+ *
  * @see org.eclipse.ui.console.consoleFactory extension point.
  * @author Eugene Kuleshov
  */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenShowConsoleAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenShowConsoleAction.java
@@ -24,7 +24,7 @@ import org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator;
 
 /**
  * MavenShowConsoleAction
- * 
+ *
  * @author dyocum
  */
 public abstract class MavenShowConsoleAction extends Action implements IPropertyChangeListener {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenMessageDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenMessageDialog.java
@@ -29,7 +29,7 @@ import org.eclipse.swt.widgets.Shell;
 
 /**
  * MavenMessageDialog
- * 
+ *
  * @author dyocum
  */
 public class MavenMessageDialog extends MessageDialog {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenPropertyDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenPropertyDialog.java
@@ -101,7 +101,7 @@ public class MavenPropertyDialog extends Dialog {
 //      gd.widthHint = Math.max(widthHint, variablesButton.computeSize(SWT.DEFAULT, SWT.DEFAULT, true).x);
 //      variablesButton.setLayoutData(gd);
 //      variablesButton.setFont(comp.getFont());
-//  
+//
 //      variablesButton.addSelectionListener(new SelectionAdapter() {
 //        public void widgetSelected(SelectionEvent se) {
 //          StringVariableSelectionDialog variablesDialog = new StringVariableSelectionDialog(getShell());
@@ -175,7 +175,7 @@ public class MavenPropertyDialog extends Dialog {
 
   /**
    * Enable the buttons on creation.
-   * 
+   *
    * @see org.eclipse.jface.window.Window#create()
    */
   public void create() {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
@@ -53,7 +53,7 @@ import org.eclipse.m2e.core.ui.internal.wizards.MavenPomSelectionComponent;
 
 /**
  * Maven POM Search dialog
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenRepositorySearchDialog extends AbstractMavenDialog {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/UpdateMavenProjectsDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/UpdateMavenProjectsDialog.java
@@ -83,7 +83,7 @@ public class UpdateMavenProjectsDialog extends TitleAreaDialog {
 
   /**
    * Create contents of the dialog.
-   * 
+   *
    * @param parent
    */
   @Override
@@ -140,7 +140,7 @@ public class UpdateMavenProjectsDialog extends TitleAreaDialog {
 
   /**
    * Create contents of the button bar.
-   * 
+   *
    * @param parent
    */
   @Override

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
@@ -37,7 +37,7 @@ import org.eclipse.text.edits.TextEditGroup;
 
 /**
  * This class creates an org.eclipse.ltk.core.refactoring.DocumentChange instance based on old and new text values
- * 
+ *
  * @author Anton Kraev
  */
 public class ChangeCreator {
@@ -97,7 +97,7 @@ public class ChangeCreator {
 
     /**
      * Create a line comparator for the given document.
-     * 
+     *
      * @param document
      */
     public LineComparator(IDocument document) {
@@ -150,7 +150,7 @@ public class ChangeCreator {
 
     /**
      * Compute a hash using the DJB hash algorithm
-     * 
+     *
      * @param string the string for which to compute a hash
      * @return the DJB hash value of the string
      */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/LifecycleMappingOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/LifecycleMappingOperation.java
@@ -96,7 +96,7 @@ public class LifecycleMappingOperation implements Operation {
 
   public void process(Document document) {
     Element root = document.getDocumentElement();
-    Element pluginExecutions; // add the new plugins here 
+    Element pluginExecutions; // add the new plugins here
 
     //now find the lifecycle stuff if it's there.
     if(createAtTopLevel) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
@@ -42,7 +42,7 @@ import org.eclipse.wst.xml.core.internal.provisional.format.FormatProcessorXML;
 
 /**
  * this class contains tools for editing the pom files using dom tree operations.
- * 
+ *
  * @author mkleint
  */
 @SuppressWarnings("restriction")
@@ -86,7 +86,7 @@ public class PomEdits {
 
   public static final String PARENT = "parent";//$NON-NLS-1$
 
-  public static final String RELATIVE_PATH = "relativePath";//$NON-NLS-1$ 
+  public static final String RELATIVE_PATH = "relativePath";//$NON-NLS-1$
 
   public static final String TYPE = "type";//$NON-NLS-1$
 
@@ -142,7 +142,7 @@ public class PomEdits {
 
   public static final String EXECUTIONS = "executions"; //$NON-NLS-1$
 
-  public static final String EXECUTION = "execution";//$NON-NLS-1$ 
+  public static final String EXECUTION = "execution";//$NON-NLS-1$
 
   public static final String GOAL = "goal";//$NON-NLS-1$
 
@@ -191,7 +191,7 @@ public class PomEdits {
       Node child = list.item(i);
       if(child instanceof Text) {
         Text text = (Text) child;
-        buff.append(text.getData().trim()); //352416 the value is trimmed because of the multiline values 
+        buff.append(text.getData().trim()); //352416 the value is trimmed because of the multiline values
         //that get trimmed by maven itself as well, any comparison to resolved model needs to do the trimming
         // or risks false negative results.
       }
@@ -202,7 +202,7 @@ public class PomEdits {
   /**
    * finds exactly one (first) occurence of child element with the given name (eg. dependency) that fulfills conditions
    * expressed by the Matchers (eg. groupId/artifactId match)
-   * 
+   *
    * @param parent
    * @param name
    * @param matchers
@@ -223,7 +223,7 @@ public class PomEdits {
   /**
    * helper method, creates a subelement with text embedded. does not format the result. primarily to be used in cases
    * like <code>&lt;goals&gt;&lt;goal&gt;xxx&lt;/goal&gt;&lt;/goals&gt;</code>
-   * 
+   *
    * @param parent
    * @param name
    * @param value
@@ -239,7 +239,7 @@ public class PomEdits {
 
   /**
    * helper method, creates a subelement, does not format result.
-   * 
+   *
    * @param parent the parent element
    * @param name the name of the new element
    * @return the created element
@@ -253,7 +253,7 @@ public class PomEdits {
 
   /**
    * sets text value to the given element. any existing text children are removed and replaced by this new one.
-   * 
+   *
    * @param element
    * @param value
    */
@@ -276,7 +276,7 @@ public class PomEdits {
   /**
    * unlike the findChild() equivalent, this one creates the element if not present and returns it. Therefore it shall
    * only be invoked within the PomEdits.Operation
-   * 
+   *
    * @param parent
    * @param names chain of element names to find/create
    * @return
@@ -343,7 +343,7 @@ public class PomEdits {
   /**
    * remove the current element if it doesn't contain any sublements, useful for lists etc, works recursively removing
    * all parents up that don't have any children elements.
-   * 
+   *
    * @param el
    */
   public static void removeIfNoChildElement(Element el) {
@@ -399,7 +399,7 @@ public class PomEdits {
 
   /**
    * finds the element at offset, if other type of node at offset, will return it's parent element (if any)
-   * 
+   *
    * @param doc
    * @param offset
    * @return
@@ -426,7 +426,7 @@ public class PomEdits {
 
   /**
    * formats the node (and content). please make sure to only format the node you have created..
-   * 
+   *
    * @param newNode
    */
   public static void format(Node newNode) {
@@ -449,7 +449,7 @@ public class PomEdits {
 
   /**
    * performs an modifying operation on top the
-   * 
+   *
    * @param file
    * @param operation
    * @throws IOException
@@ -554,7 +554,7 @@ public class PomEdits {
 
     /**
      * operation on top of IFile is always saved
-     * 
+     *
      * @param file
      * @param operation
      */
@@ -570,7 +570,7 @@ public class PomEdits {
 
     /**
      * operation on top of IDocument is only saved when noone else is editing the document.
-     * 
+     *
      * @param document
      * @param operation
      */
@@ -580,7 +580,7 @@ public class PomEdits {
 
     /**
      * operation on top of IDocument is only saved when noone else is editing the document.
-     * 
+     *
      * @param document
      * @param operation
      * @param readonly operation that doesn't modify the content. Will only get the read, not edit model, up to the user
@@ -597,7 +597,7 @@ public class PomEdits {
 
     /**
      * only use for unmanaged models
-     * 
+     *
      * @param model
      * @param operation
      */
@@ -647,7 +647,7 @@ public class PomEdits {
 
   /**
    * operation to perform on top of the DOM document. see performOnDOMDocument()
-   * 
+   *
    * @author mkleint
    */
   public static interface Operation {
@@ -656,7 +656,7 @@ public class PomEdits {
 
   /**
    * an Operation instance that aggregates multiple operations and performs then in given order.
-   * 
+   *
    * @author mkleint
    */
   public static final class CompoundOperation implements Operation {
@@ -676,13 +676,13 @@ public class PomEdits {
 
   /**
    * an interface for identifying child elements that fulfill conditions expressed by the matcher.
-   * 
+   *
    * @author mkleint
    */
   public static interface Matcher {
     /**
      * returns true if the given element matches the condition.
-     * 
+     *
      * @param child
      * @return
      */
@@ -717,7 +717,7 @@ public class PomEdits {
   /**
    * keeps internal state, needs to be recreated for each query, when used in conjunction with out matchers shall
    * probably be placed last.
-   * 
+   *
    * @param elementName
    * @param index
    * @return

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomHelper.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomHelper.java
@@ -140,7 +140,7 @@ public final class PomHelper {
 
   /**
    * by default will create a change that won't save files with opened documents
-   * 
+   *
    * @param file
    * @param operation
    * @param label
@@ -153,7 +153,7 @@ public final class PomHelper {
 
   /**
    * creates and adds new plugin to the parent. Formats the result.
-   * 
+   *
    * @param parentList
    * @param groupId null or value
    * @param artifactId never null
@@ -178,7 +178,7 @@ public final class PomHelper {
 
   /**
    * creates and adds new dependency to the parent. formats the result.
-   * 
+   *
    * @param parentList
    * @param groupId null or value
    * @param artifactId never null
@@ -201,7 +201,7 @@ public final class PomHelper {
 
   /**
    * node is expected to be the node containing <dependencies> node, so <project>, <dependencyManagement> etc..
-   * 
+   *
    * @param node
    * @return
    */
@@ -211,7 +211,7 @@ public final class PomHelper {
 
   /**
    * null in any value parameter mean remove the element.
-   * 
+   *
    * @param depsEl
    * @param groupId
    * @param artifactId

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/AggregateMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/AggregateMappingLabelProvider.java
@@ -6,7 +6,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation
  *******************************************************************************/
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 
 /**
  * AggregateMappingLabelProvider
- * 
+ *
  * @author mkleint
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/ILifecycleMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/ILifecycleMappingLabelProvider.java
@@ -6,7 +6,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation
  *******************************************************************************/
@@ -23,7 +23,7 @@ import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.LifecycleMapping
 
 /**
  * ILifecycleMappingLabelProvider
- * 
+ *
  * @author igor
  */
 public interface ILifecycleMappingLabelProvider {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/MojoExecutionMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/MojoExecutionMappingLabelProvider.java
@@ -6,7 +6,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation
  *******************************************************************************/
@@ -30,7 +30,7 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 
 /**
  * MojoExecutionMappingLabelProvider
- * 
+ *
  * @author igor
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/PackagingTypeMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/PackagingTypeMappingLabelProvider.java
@@ -6,7 +6,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation
  *******************************************************************************/
@@ -26,7 +26,7 @@ import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.ProjectLifecycle
 
 /**
  * PackagingTypeMappingLabelProvider
- * 
+ *
  * @author igor
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -74,7 +74,7 @@ import org.eclipse.m2e.model.edit.pom.util.NodeOperation;
 
 /**
  * a service impl used by the core module to improve marker locations and addition of our own markers
- * 
+ *
  * @author mkleint
  * @since 1.16
  */
@@ -255,7 +255,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
   /**
    * The xsi:schema info is not part of the model, it is stored in the xml only. Need to open the DOM and look for the
    * project node to see if it has this schema defined
-   * 
+   *
    * @param mavenMarkerManager
    * @param pomFile
    */
@@ -360,14 +360,14 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
         for(Dependency dep : deps) {
           if(dep.getVersion() != null) { //#335366
             //355882 use dep.getManagementKey() to prevent false positives
-            //when type or classifier doesn't match 
+            //when type or classifier doesn't match
             managed.put(dep.getManagementKey(), dep);
           }
         }
       }
     }
 
-    //now we have all the candidates, match them against the effective managed set 
+    //now we have all the candidates, match them against the effective managed set
     for(Element dep : candidates) {
       Element version = findChild(dep, PomEdits.VERSION);
       String grpString = getTextValue(findChild(dep, PomEdits.GROUP_ID));
@@ -504,7 +504,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
       }
     }
 
-    //now we have all the candidates, match them against the effective managed set 
+    //now we have all the candidates, match them against the effective managed set
     for(Element dep : candidates) {
       String grpString = getTextValue(findChild(dep, PomEdits.GROUP_ID)); //$NON-NLS-1$
       if(grpString == null) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MavenProblemResolution.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MavenProblemResolution.java
@@ -45,7 +45,7 @@ import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 /**
  * A single superclass for marker resolutions that can also act as completion proposals in text editor (e.g. shown when
  * called on ctrl+1)
- * 
+ *
  * @author atanasenko
  */
 public abstract class MavenProblemResolution extends WorkbenchMarkerResolution

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LocalArchetypeCatalogDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LocalArchetypeCatalogDialog.java
@@ -50,7 +50,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Local Archetype catalog dialog
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class LocalArchetypeCatalogDialog extends TitleAreaDialog {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenArchetypesPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenArchetypesPreferencePage.java
@@ -65,7 +65,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Maven Archetype catalogs preference page
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenArchetypesPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenPreferencePage.java
@@ -66,7 +66,7 @@ public class MavenPreferencePage extends FieldEditorPreferencePage implements IW
     addField(new BooleanFieldEditor(MavenPreferenceConstants.P_DEBUG_OUTPUT, //
         Messages.preferencesDebugOutput, getFieldEditorParent()));
 
-    // addField( new BooleanFieldEditor( MavenPreferenceConstants.P_UPDATE_SNAPSHOTS, 
+    // addField( new BooleanFieldEditor( MavenPreferenceConstants.P_UPDATE_SNAPSHOTS,
     //     Messages.getString( "preferences.updateSnapshots" ), //$NON-NLS-1$
     //     getFieldEditorParent() ) );
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenProjectPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenProjectPreferencePage.java
@@ -43,7 +43,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Maven project preference page
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenProjectPreferencePage extends PropertyPage {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenSettingsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenSettingsPreferencePage.java
@@ -74,7 +74,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Maven installations preference page
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenSettingsPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/RemoteArchetypeCatalogDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/RemoteArchetypeCatalogDialog.java
@@ -52,13 +52,13 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Remote Archetype catalog dialog
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class RemoteArchetypeCatalogDialog extends TitleAreaDialog {
 
   /**
-   * 
+   *
    */
   private static final int VERIFY_ID = IDialogConstants.CLIENT_ID + 1;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/WarningsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/WarningsPreferencePage.java
@@ -9,7 +9,7 @@
  *
  * Contributors:
  *      Rob Newton - initial warnings preference page
- *      Fred Bricon (Red Hat, Inc.) - use combos for problem severity 
+ *      Fred Bricon (Red Hat, Inc.) - use combos for problem severity
  *******************************************************************************/
 
 package org.eclipse.m2e.core.ui.internal.preferences;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/launch/MavenInstallationsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/launch/MavenInstallationsPreferencePage.java
@@ -56,7 +56,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 /**
  * Maven installations preference page
- * 
+ *
  * @author Eugene Kuleshov
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/ArtifactInfo.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/ArtifactInfo.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.core.ui.internal.search.util;
 
 /**
  * Information about the artifact.
- * 
+ *
  * @author Lukas Krecan
  */
 public class ArtifactInfo {
@@ -59,7 +59,7 @@ public class ArtifactInfo {
 
   /**
    * Constructs a <code>String</code> with all attributes in name = value format.
-   * 
+   *
    * @return a <code>String</code> representation of this object.
    */
   public String toString() {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/CComboContentAdapter.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/CComboContentAdapter.java
@@ -68,7 +68,7 @@ public class CComboContentAdapter implements IControlContentAdapter /*, IControl
   }
 
   public Rectangle getInsertionBounds(Control control) {
-    // This doesn't take horizontal scrolling into affect. 
+    // This doesn't take horizontal scrolling into affect.
     // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=204599
     CCombo combo = (CCombo) control;
     int position = combo.getSelection().y;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/ControlDecoration.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/ControlDecoration.java
@@ -59,7 +59,7 @@ import org.eclipse.swt.widgets.Widget;
  * altering the layout data margins, although this is not assumed or required by the ControlDecoration implementation.
  * <p>
  * This class is intended to be instantiated and used by clients. It is not intended to be subclassed by clients.
- * 
+ *
  * @since 3.3
  * @see FieldDecoration
  * @see FieldDecorationRegistry
@@ -376,7 +376,7 @@ public class ControlDecoration {
    * top, is specified as SWT.LEFT | SWT.TOP. If no position style bits are specified, the control decoration will be
    * positioned to the left and center of the control (<code>SWT.LEFT | SWT.CENTER</code>).
    * </p>
-   * 
+   *
    * @param control the control to be decorated
    * @param position bit-wise or of position constants (<code>SWT.TOP</code>, <code>SWT.BOTTOM</code>,
    *          <code>SWT.LEFT</code>, <code>SWT.RIGHT</code>, and <code>SWT.CENTER</code>).
@@ -400,7 +400,7 @@ public class ControlDecoration {
    * top, is specified as SWT.LEFT | SWT.TOP. If no position style bits are specified, the control decoration will be
    * positioned to the left and center of the control (<code>SWT.LEFT | SWT.CENTER</code>).
    * </p>
-   * 
+   *
    * @param control the control to be decorated
    * @param position bit-wise or of position constants (<code>SWT.TOP</code>, <code>SWT.BOTTOM</code>,
    *          <code>SWT.LEFT</code>, <code>SWT.RIGHT</code>, and <code>SWT.CENTER</code>).
@@ -427,7 +427,7 @@ public class ControlDecoration {
    * that received the click. The <code>x</code> and <code>y</code> fields will be in coordinates relative to the
    * display. The <code>data</code> field will contain the decoration that received the event.
    * </p>
-   * 
+   *
    * @param listener the listener which should be notified
    * @see org.eclipse.swt.events.MenuDetectListener
    * @see org.eclipse.swt.events.MenuDetectEvent
@@ -440,7 +440,7 @@ public class ControlDecoration {
   /**
    * Removes the listener from the collection of listeners who will be notified when the platform-specific context menu
    * trigger has occurred.
-   * 
+   *
    * @param listener the listener which should no longer be notified. This message has no effect if the listener was not
    *          previously added to the receiver.
    * @see org.eclipse.swt.events.MenuDetectListener
@@ -462,7 +462,7 @@ public class ControlDecoration {
    * that received the click. The <code>x</code> and <code>y</code> fields will be in coordinates relative to that
    * widget. The <code>data</code> field will contain the decoration that received the event.
    * </p>
-   * 
+   *
    * @param listener the listener which should be notified
    * @see org.eclipse.swt.events.SelectionListener
    * @see org.eclipse.swt.events.SelectionEvent
@@ -474,7 +474,7 @@ public class ControlDecoration {
 
   /**
    * Removes the listener from the collection of listeners who will be notified when the decoration is selected.
-   * 
+   *
    * @param listener the listener which should no longer be notified. This message has no effect if the listener was not
    *          previously added to the receiver.
    * @see org.eclipse.swt.events.SelectionListener
@@ -502,7 +502,7 @@ public class ControlDecoration {
 
   /**
    * Get the control that is decorated by the receiver.
-   * 
+   *
    * @return the Control decorated by the receiver. May be <code>null</code> if the control has been uninstalled.
    */
   public Control getControl() {
@@ -731,7 +731,7 @@ public class ControlDecoration {
    * an info hover over the field's control whenever the mouse hovers over the decoration. This method can be used to
    * show a decoration's description text at other times (such as when the control receives focus), or to show other
    * text associated with the field. The hover will not be shown if the decoration is hidden.
-   * 
+   *
    * @param text the text to be shown in the info hover, or <code>null</code> if no text should be shown.
    */
   public void showHoverText(String text) {
@@ -782,7 +782,7 @@ public class ControlDecoration {
 
   /**
    * Get the description text that may be shown in a hover for this decoration.
-   * 
+   *
    * @return the text to be shown as a description for the decoration, or <code>null</code> if none has been set.
    */
   public String getDescriptionText() {
@@ -791,7 +791,7 @@ public class ControlDecoration {
 
   /**
    * Set the image shown in this control decoration. Update the rendered decoration.
-   * 
+   *
    * @param text the text to be shown as a description for the decoration, or <code>null</code> if none has been set.
    */
   public void setDescriptionText(String text) {
@@ -801,7 +801,7 @@ public class ControlDecoration {
 
   /**
    * Get the image shown in this control decoration.
-   * 
+   *
    * @return the image to be shown adjacent to the control, or <code>null</code> if one has not been set.
    */
   public Image getImage() {
@@ -810,7 +810,7 @@ public class ControlDecoration {
 
   /**
    * Set the image shown in this control decoration. Update the rendered decoration.
-   * 
+   *
    * @param image the image to be shown adjacent to the control. Should never be <code>null</code>.
    */
   public void setImage(Image image) {
@@ -821,7 +821,7 @@ public class ControlDecoration {
   /**
    * Get the boolean that controls whether the decoration is shown only when the control has focus. The default value of
    * this setting is <code>false</code>.
-   * 
+   *
    * @return <code>true</code> if the decoration should only be shown when the control has focus, and <code>false</code>
    *         if it should always be shown. Note that if the control is not capable of receiving focus (
    *         <code>SWT.NO_FOCUS</code>), then the decoration will never show when this value is <code>true</code>.
@@ -833,7 +833,7 @@ public class ControlDecoration {
   /**
    * Set the boolean that controls whether the decoration is shown only when the control has focus. The default value of
    * this setting is <code>false</code>.
-   * 
+   *
    * @param showOnlyOnFocus <code>true</code> if the decoration should only be shown when the control has focus, and
    *          <code>false</code> if it should always be shown. Note that if the control is not capable of receiving
    *          focus (<code>SWT.NO_FOCUS</code>), then the decoration will never show when this value is
@@ -847,7 +847,7 @@ public class ControlDecoration {
   /**
    * Get the boolean that controls whether the decoration's description text should be shown in a hover when the user
    * hovers over the decoration. The default value of this setting is <code>true</code>.
-   * 
+   *
    * @return <code>true</code> if a hover popup containing the decoration's description text should be shown when the
    *         user hovers over the decoration, and <code>false</code> if a hover should not be shown.
    */
@@ -858,7 +858,7 @@ public class ControlDecoration {
   /**
    * Set the boolean that controls whether the decoration's description text should be shown in a hover when the user
    * hovers over the decoration. The default value of this setting is <code>true</code>.
-   * 
+   *
    * @param showHover <code>true</code> if a hover popup containing the decoration's description text should be shown
    *          when the user hovers over the decoration, and <code>false</code> if a hover should not be shown.
    */
@@ -870,7 +870,7 @@ public class ControlDecoration {
   /**
    * Get the margin width in pixels that should be used between the decorator and the horizontal edge of the control.
    * The default value of this setting is <code>0</code>.
-   * 
+   *
    * @return the number of pixels that should be reserved between the horizontal edge of the control and the adjacent
    *         edge of the decoration.
    */
@@ -881,7 +881,7 @@ public class ControlDecoration {
   /**
    * Set the margin width in pixels that should be used between the decorator and the horizontal edge of the control.
    * The default value of this setting is <code>0</code>.
-   * 
+   *
    * @param marginWidth the number of pixels that should be reserved between the horizontal edge of the control and the
    *          adjacent edge of the decoration.
    */
@@ -993,7 +993,7 @@ public class ControlDecoration {
   /**
    * Return the rectangle in which the decoration should be rendered, in coordinates relative to the specified control.
    * If the specified control is null, return the rectangle in display coordinates.
-   * 
+   *
    * @param targetControl the control whose coordinates should be used
    * @return the rectangle in which the decoration should be rendered
    */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/IndexSearchEngine.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/IndexSearchEngine.java
@@ -36,7 +36,7 @@ import org.eclipse.m2e.core.internal.index.SearchExpression;
 
 /**
  * Search engine integrating {@link IndexManager} with POM XML editor.
- * 
+ *
  * @author Lukas Krecan
  * @author Eugene Kuleshov
  */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/MenuDetectEvent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/MenuDetectEvent.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.widgets.Event;
 
 /**
  * Instances of this class are sent whenever the platform- specific trigger for showing a context menu is detected.
- * 
+ *
  * @see MenuDetectListener
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @since 3.3
@@ -47,7 +47,7 @@ public final class MenuDetectEvent extends TypedEvent {
 
   /**
    * Constructs a new instance of this class based on the information in the given untyped event.
-   * 
+   *
    * @param e the untyped event containing the information
    */
   public MenuDetectEvent(Event e) {
@@ -59,7 +59,7 @@ public final class MenuDetectEvent extends TypedEvent {
 
   /**
    * Returns a string containing a concise, human-readable description of the receiver.
-   * 
+   *
    * @return a string representation of the event
    */
   public String toString() {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/MenuDetectListener.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/MenuDetectListener.java
@@ -24,7 +24,7 @@ import java.util.EventListener;
  * the <code>addMenuDetectListener</code> method and removed using the <code>removeMenuDetectListener</code> method.
  * When the context menu trigger occurs, the <code>menuDetected</code> method will be invoked.
  * </p>
- * 
+ *
  * @see MenuDetectEvent
  * @since 3.3
  */
@@ -32,7 +32,7 @@ public interface MenuDetectListener extends EventListener {
 
   /**
    * Sent when the platform-dependent trigger for showing a menu item is detected.
-   * 
+   *
    * @param e an event containing information about the menu detect
    */
   public void menuDetected(MenuDetectEvent e);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/Packaging.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/Packaging.java
@@ -19,7 +19,7 @@ import org.eclipse.m2e.core.internal.index.SourcedSearchExpression;
 
 /**
  * Packaging representation.
- * 
+ *
  * @author Lukas Krecan
  */
 public enum Packaging {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/SearchEngine.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/SearchEngine.java
@@ -18,14 +18,14 @@ import java.util.Collection;
 
 /**
  * Interface to be implemented by a SearchEngine.
- * 
+ *
  * @author Lukas Krecan
  */
 public interface SearchEngine {
 
   /**
    * Finds groupIds for given expression.
-   * 
+   *
    * @param searchExpression
    * @param packaging
    * @param containingArtifact When looking for exclusion, contains information about artifact we are excluding from.
@@ -35,7 +35,7 @@ public interface SearchEngine {
 
   /**
    * Finds artifactIds for given expression
-   * 
+   *
    * @param groupId
    * @param searchExpression
    * @param packaging


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>