### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines - 5

### DIFF
--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/StringLabelProvider.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/StringLabelProvider.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.graphics.Image;
 
 /**
  * Label provider for <code>String</code> entries
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class StringLabelProvider extends LabelProvider {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/dialogs/ManageDependenciesDialog.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/dialogs/ManageDependenciesDialog.java
@@ -85,7 +85,7 @@ import org.eclipse.m2e.editor.pom.ValueProvider;
 /**
  * This dialog is used to present the user with a list of dialogs that they can move to being managed under
  * "dependencyManagement". It allows them to pick the destination POM where the dependencies will be managed.
- * 
+ *
  * @author rgould
  */
 public class ManageDependenciesDialog extends AbstractMavenDialog {
@@ -356,7 +356,7 @@ public class ManageDependenciesDialog extends AbstractMavenDialog {
    * Compare the list of selected dependencies against the selected targetPOM. If one of the dependencies is already
    * under dependencyManagement, but has a different version than the selected dependency, warn the user about this.
    * returns true if the user has been warned (but this method updates the status itself)
-   * 
+   *
    * @param model
    * @param dependencies
    */

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/MarkerHoverControl.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/MarkerHoverControl.java
@@ -273,7 +273,7 @@ public class MarkerHoverControl extends AbstractInformationControl
       Point constraints = getSizeConstraints();
       Point contentSize = composite.computeSize(constraints != null ? constraints.x : SWT.DEFAULT, SWT.DEFAULT);
 
-      composite.setSize(new Point(contentSize.x, contentSize.y)); //12 is the magic number for height of status line 
+      composite.setSize(new Point(contentSize.x, contentSize.y)); //12 is the magic number for height of status line
 
     }
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/LifecycleMappingDialog.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/LifecycleMappingDialog.java
@@ -131,7 +131,7 @@ public class LifecycleMappingDialog extends Dialog implements ISelectionChangedL
   }
 
   /*
-   * Should only be called after dialog has closed with OK return code 
+   * Should only be called after dialog has closed with OK return code
    */
   public IFile getPomFile() {
     return pomFile;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MarkerResolutionWrapper.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MarkerResolutionWrapper.java
@@ -26,7 +26,7 @@ import org.eclipse.ui.IMarkerResolution2;
 
 /**
  * Wrapper for marker resolutions that can be used as a completion proposal
- * 
+ *
  * @author mkleint
  */
 public class MarkerResolutionWrapper implements ICompletionProposal {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MavenMarkerResolutionGenerator.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MavenMarkerResolutionGenerator.java
@@ -27,7 +27,7 @@ import org.eclipse.m2e.editor.internal.lifecycle.WorkspaceLifecycleMappingResolu
 
 /**
  * MavenMarkerResolutionGenerator
- * 
+ *
  * @author dyocum
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
@@ -49,7 +49,7 @@ import org.codehaus.plexus.classworlds.realm.ClassRealm;
 /**
  * Mirrors logic implemented in default maven mojo configurator with regards to discovering how a PlexusConfiguration
  * can be applied to an arbitrary object tree.
- * 
+ *
  * @see org.codehaus.plexus.component.configurator.BasicComponentConfigurator
  * @see org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup
  * @see org.codehaus.plexus.component.configurator.converters.composite.ObjectWithFieldsConverter
@@ -442,16 +442,16 @@ public class PlexusConfigHelper {
       Boolean.class.getName(),
       char.class.getName(),
       Character.class.getName(),
-  
+
       String.class.getName(),
       StringBuilder.class.getName(),
       StringBuffer.class.getName(),
-  
+
       File.class.getName(),
       URI.class.getName(),
       URL.class.getName(),
       Date.class.getName(),
-  
+
       "org.codehaus.plexus.configuration.PlexusConfiguration"
     );
     // @formatter:on

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/DependencyTreePage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/DependencyTreePage.java
@@ -1099,7 +1099,7 @@ public class DependencyTreePage extends FormPage implements IMavenProjectChanged
 
     for(MavenProjectChangedEvent event : events) {
       if(event.getSource().equals(((MavenPomEditor) getEditor()).getPomFile())) {
-        // file has been changed. need to update graph  
+        // file has been changed. need to update graph
         new UIJob(Messages.DependencyTreePage_job_reloading) {
           public IStatus runInUIThread(IProgressMonitor monitor) {
             loadData();

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/FormUtils.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/FormUtils.java
@@ -206,7 +206,7 @@ public abstract class FormUtils {
    * be very careful when using this method, see MNGECLIPSE-2674 ideally this would be replaced by a distributed system
    * where each component reacts to the readonly or not-readonly event and with the knowledge of the inner state decides
    * what gets enabled/disabled
-   * 
+   *
    * @param composite
    * @param readonly
    * @deprecated so that you think hard before using it. Using it for disabling all controls is probably fine. Enabling
@@ -263,7 +263,7 @@ public abstract class FormUtils {
       Control[] kids = head.getChildren();
       for(final Control kid : kids) {
         //want to get the title region only
-        //Note: doing this instead of adding a head 'client' control because that gets put 
+        //Note: doing this instead of adding a head 'client' control because that gets put
         //on the second line of the title, and looks broken. instead, converting the title
         //into a url
         if(kid != form && kid instanceof Canvas) {
@@ -292,7 +292,7 @@ public abstract class FormUtils {
       Control[] kids = head.getChildren();
       for(Control kid : kids) {
         //want to get the title region only
-        //Note: doing this instead of adding a head 'client' control because that gets put 
+        //Note: doing this instead of adding a head 'client' control because that gets put
         //on the second line of the title, and looks broken. instead, converting the title
         //into a url
         if(kid != form && kid instanceof Canvas) {
@@ -306,7 +306,7 @@ public abstract class FormUtils {
 
   /**
    * copy pas
-   * 
+   *
    * @param project
    * @param text
    * @return

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
@@ -102,7 +102,7 @@ import org.eclipse.m2e.editor.internal.Messages;
 
 /**
  * Maven POM editor
- * 
+ *
  * @author Eugene Kuleshov
  * @author Anton Kraev
  * @param <page>
@@ -166,7 +166,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
 
   /**
    * the pom document being edited..
-   * 
+   *
    * @return
    */
   public IDocument getDocument() {
@@ -379,7 +379,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
     if(EFFECTIVE_POM.equals(name)) {
       loadEffectivePOM();
     }
-    //The editor occassionally doesn't get 
+    //The editor occassionally doesn't get
     //closed if the project gets deleted. In this case, the editor
     //stays open and very bad things happen if you select it
     try {
@@ -388,7 +388,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
       MavenEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, MavenEditorPlugin.PLUGIN_ID, "", e)); //$NON-NLS-1$
       this.close(false);
     }
-    // a workaround for editor pages not returned 
+    // a workaround for editor pages not returned
     IEditorActionBarContributor contributor = getEditorSite().getActionBarContributor();
     if(contributor instanceof MultiPageEditorActionBarContributor) {
       IEditorPart activeEditor = getActivePageInstance();
@@ -474,7 +474,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
 
   /**
    * Load the effective POM in a job and then update the effective pom page when its done
-   * 
+   *
    * @author dyocum
    */
   class LoadEffectivePomJob extends Job {
@@ -599,7 +599,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
   /**
    * this method is safer than readMavenProject for instances that shall return fast and don't mind not having the
    * MavenProject instance around.
-   * 
+   *
    * @return the cached MavenProject instance or null if not loaded.
    */
   public MavenProject getMavenProject() {
@@ -611,7 +611,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
    * return fast getMavenProject() is preferable please see <code>mavenProjectChanged()</code> for explanation why even
    * force==true might not give you the latest uptodate MavenProject instance matching the current saved file in some
    * circumstances.
-   * 
+   *
    * @param force
    * @param monitor
    * @return
@@ -758,7 +758,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
   /**
    * returns only the pages that implement MavenPomEditorPage will not return the effective pom and xml editor page for
    * example..
-   * 
+   *
    * @return
    */
   public List<MavenPomEditorPage> getMavenPomEditorPages() {
@@ -767,7 +767,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
 
   /**
    * use the <code>getMavenPomEditorPages()</code> method instead
-   * 
+   *
    * @return
    */
   @Deprecated
@@ -985,7 +985,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
     }
   }
 
-  /* 
+  /*
    * @see org.eclipse.ui.part.MultiPageEditorPart#setPageText(int, java.lang.String)
    */
   public void setPageText(int pageIndex, String text) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorContributor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorContributor.java
@@ -101,7 +101,7 @@ public class MavenPomEditorContributor extends MultiPageEditorActionBarContribut
 
   /**
    * Returns the action registered with the given text editor.
-   * 
+   *
    * @return IAction or null if editor is null.
    */
   protected IAction getAction(String actionId) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
@@ -94,7 +94,7 @@ import org.eclipse.m2e.editor.internal.Messages;
 
 /**
  * This class provides basic page editor functionality (event listeners, readonly, etc)
- * 
+ *
  * @author Anton Kraev
  * @author Eugene Kuleshov
  */
@@ -159,7 +159,7 @@ public abstract class MavenPomEditorPage extends FormPage {
 
   /**
    * all edits in the editor to be channeled through this method..
-   * 
+   *
    * @param operation
    * @param logger
    * @param logMessage
@@ -421,7 +421,7 @@ public abstract class MavenPomEditorPage extends FormPage {
 
   /**
    * creates a text field/Ccombo decoration that shows the evaluated value
-   * 
+   *
    * @param control
    */
   public final void createEvaluatorInfo(final Control control) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPageFactory.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPageFactory.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.editor.pom;
 
 /**
  * A factory for creating POMeditor pages
- * 
+ *
  * @author Eugene Kuleshov
  */
 public abstract class MavenPomEditorPageFactory {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/OverviewPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/OverviewPage.java
@@ -349,7 +349,7 @@ public class OverviewPage extends MavenPomEditorPage {
     artifactPackagingCombo.add("ear"); //$NON-NLS-1$
     artifactPackagingCombo.add("pom"); //$NON-NLS-1$
     artifactPackagingCombo.add("maven-plugin"); //$NON-NLS-1$
-// uncomment this only if you are able to not to break the project    
+// uncomment this only if you are able to not to break the project
 //    artifactPackagingCombo.add("osgi-bundle");
 //    artifactPackagingCombo.add("eclipse-feature");
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
@@ -203,7 +203,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
         String artifactId = XmlUtils.getTextValue(artNode);
         final MavenProject prj = XmlUtils.extractMavenProject(textViewer);
         if(prj != null) {
-          //now we can create the region I guess, 
+          //now we can create the region I guess,
           return new ManagedArtifactRegion(startOffset, length, groupId, artifactId, isDependency, isPlugin, prj);
         }
       }
@@ -325,7 +325,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
           final String expr = before.substring(start) + after.substring(0, end + 1);
           final int length = expr.length();
           final String prop = before.substring(start + 2) + after.substring(0, end);
-// there are often properties that start with project. eg. project.build.sourceEncoding          
+// there are often properties that start with project. eg. project.build.sourceEncoding
 //          if (prop.startsWith("project.") || prop.startsWith("pom.")) { //$NON-NLS-1$ //$NON-NLS-2$
 //            return null; //ignore these, not in properties section.
 //          }
@@ -572,7 +572,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
           new Job(org.eclipse.m2e.editor.internal.Messages.PomHyperlinkDetector_job_name) {
             protected IStatus run(IProgressMonitor monitor) {
               // TODO resolve groupId if groupId==null
-              String gridString = groupId == null ? "org.apache.maven.plugins" : XmlUtils.getTextValue(groupId); //$NON-NLS-1$      
+              String gridString = groupId == null ? "org.apache.maven.plugins" : XmlUtils.getTextValue(groupId); //$NON-NLS-1$
               String artidString = artifactId == null ? null : XmlUtils.getTextValue(artifactId);
               String versionString = version == null ? null : XmlUtils.getTextValue(version);
               if(prj != null && gridString != null && artidString != null
@@ -591,7 +591,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
                 return Status.OK_STATUS;
               }
               OpenPomAction.openEditor(gridString, artidString, versionString, prj, monitor);
-// TODO: it's preferable to open the xml page, but this code will blink and open overview first and later switch. looks bad            
+// TODO: it's preferable to open the xml page, but this code will blink and open overview first and later switch. looks bad
 //            Display.getDefault().syncExec(new Runnable() {
 //              public void run() {
 //                selectEditorPage(page);

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
@@ -83,7 +83,7 @@ import org.eclipse.m2e.editor.mojo.MojoParameterMetadataProvider;
 
 /**
  * Context types.
- * 
+ *
  * @author Lukas Krecan
  * @author Eugene Kuleshov
  */
@@ -825,7 +825,7 @@ public enum PomTemplateContext {
 
           //TODO polyglot?
           if(Arrays.asList("src", "target", "bin").contains(name) && dir.resolve("../pom.xml").toFile().exists()) {
-            // skip recursing into certain the project dirs 
+            // skip recursing into certain the project dirs
             return FileVisitResult.SKIP_SUBTREE;
           }
 
@@ -1097,7 +1097,7 @@ public enum PomTemplateContext {
   }
 
   // TODO copy of this resides in FormUtils
-  // TODO: This was previously just "static" not public static 
+  // TODO: This was previously just "static" not public static
   public static String simpleInterpolate(MavenProject project, String text) {
     if(text != null && text.contains("${")) { //$NON-NLS-1$
       //when expression is in the version but no project instance around

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PropertiesSection.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PropertiesSection.java
@@ -58,7 +58,7 @@ import org.eclipse.m2e.editor.internal.Messages;
 
 /**
  * This is properties editor (double click edits the property)
- * 
+ *
  * @author Anton Kraev, Milos Kleint
  */
 public class PropertiesSection {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/ScopeArtifactFilter.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/ScopeArtifactFilter.java
@@ -19,7 +19,7 @@ import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 
 /**
  * An artifact filter supporting all dependency scopes
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class ScopeArtifactFilter implements ArtifactFilter {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/SearchControl.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/SearchControl.java
@@ -64,7 +64,7 @@ public class SearchControl extends ControlContribution {
 
     GridLayout layout = new GridLayout(3, false);
     layout.marginWidth = 0;
-    //gross, but on the Mac the search controls are cut off on the bottom, 
+    //gross, but on the Mac the search controls are cut off on the bottom,
     //so they need to be bumped up  a little. other OSs are fine.
     if(isMac()) {
       layout.marginHeight = -1;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/ValueProvider.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/ValueProvider.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.editor.pom;
 
 /**
  * Value provider for retrieving and creating holder element values
- * 
+ *
  * @author Eugene Kuleshov
  */
 public abstract class ValueProvider<T> {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/XMLEditorUtility.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/XMLEditorUtility.java
@@ -9,7 +9,7 @@
  *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation (code moved here from PomHyperlinkDetector).
- * 
+ *
  *******************************************************************************/
 
 package org.eclipse.m2e.editor.pom;
@@ -116,7 +116,7 @@ public class XMLEditorUtility {
 
   /**
    * duplicate of OpenPomAction method
-   * 
+   *
    * @param is
    * @return
    * @throws IOException

--- a/org.eclipse.m2e.importer/src/org/eclipse/m2e/importer/internal/Activator.java
+++ b/org.eclipse.m2e.importer/src/org/eclipse/m2e/importer/internal/Activator.java
@@ -31,7 +31,7 @@ public class Activator extends AbstractUIPlugin {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
      * BundleContext)
      */
@@ -42,7 +42,7 @@ public class Activator extends AbstractUIPlugin {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.
      * BundleContext)
      */

--- a/org.eclipse.m2e.importer/src/org/eclipse/m2e/importer/internal/MavenProjectConfigurator.java
+++ b/org.eclipse.m2e.importer/src/org/eclipse/m2e/importer/internal/MavenProjectConfigurator.java
@@ -68,7 +68,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
             super(Collections.<IProject>emptyList());
             this.toProcess = Collections.synchronizedSet(new HashSet<IProject>());
         }
-        
+
         public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
             try {
                 // This makes job execution wait until the main Import job is completed
@@ -114,7 +114,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
     /**
      * This singleton job will loop running on the background to update
      * configuration of Maven projects as they're imported.
-     * 
+     *
      * @author mistria
      *
      */
@@ -140,7 +140,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
          * Rather than scheduling this job another time, requestors simply add
          * to ask for being processed here. The job lifecycle will take care of
          * processing it as best.
-         * 
+         *
          * @param project
          */
         public void addProjectToProcess(IProject project) {
@@ -204,7 +204,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
         }
         return res;
     }
-    
+
     // TODO Uncomment @Override when this method API is exposed in ProjectConfigurator
     // @Override
     public void removeDirtyDirectories(Map<File, List<ProjectConfigurator>> proposals) {

--- a/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/DownloadSourcesActionDelegate.java
+++ b/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/DownloadSourcesActionDelegate.java
@@ -30,7 +30,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
 
 /**
  * DownloadSourcesActionDelegate
- * 
+ *
  * @author Anton Kraev
  */
 

--- a/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/JavaUiElementsAdapterFactory.java
+++ b/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/JavaUiElementsAdapterFactory.java
@@ -27,7 +27,7 @@ import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
 /**
  * Adapter factory for Java elements
- * 
+ *
  * @author Igor Fedorenko
  * @author Eugene Kuleshov
  * @author Miles Parker

--- a/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/MavenClasspathContainerPage.java
+++ b/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/MavenClasspathContainerPage.java
@@ -31,7 +31,7 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
 
 /**
  * MavenClasspathContainerPage
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenClasspathContainerPage extends WizardPage

--- a/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/Messages.java
+++ b/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/Messages.java
@@ -18,7 +18,7 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * Messages
- * 
+ *
  * @author mkleint
  */
 public class Messages extends NLS {

--- a/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/actions/OpenJavaDocAction.java
+++ b/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/actions/OpenJavaDocAction.java
@@ -49,7 +49,7 @@ import org.eclipse.m2e.jdt.internal.Messages;
 
 /**
  * Open JavaDoc action
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class OpenJavaDocAction extends ActionDelegate {

--- a/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/filter/MavenModuleFilter.java
+++ b/org.eclipse.m2e.jdt.ui/src/org/eclipse/m2e/jdt/ui/internal/filter/MavenModuleFilter.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
 /**
  * MavenModuleFilter
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenModuleFilter extends ViewerFilter {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractClassifierClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractClassifierClasspathProvider.java
@@ -34,7 +34,7 @@ import org.eclipse.m2e.jdt.internal.ModuleSupport;
 
 /**
  * Base class for {@link IClassifierClasspathProvider} implementations.
- * 
+ *
  * @author Fred Bricon
  * @since 1.3
  */
@@ -90,7 +90,7 @@ public abstract class AbstractClassifierClasspathProvider
 
   /**
    * Adds test classes folder to the runtime classpath.
-   * 
+   *
    * @param requiredModules
    */
   protected void addTestFolder(Set<IRuntimeClasspathEntry> runtimeClasspath, IMavenProjectFacade mavenProjectFacade,
@@ -103,7 +103,7 @@ public abstract class AbstractClassifierClasspathProvider
 
   /**
    * Adds main classes folder to the runtime classpath.
-   * 
+   *
    * @param classpathProperty
    */
   protected void addMainFolder(Set<IRuntimeClasspathEntry> runtimeClasspath, IMavenProjectFacade mavenProjectFacade,

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractSourcesGenerationProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractSourcesGenerationProjectConfigurator.java
@@ -36,7 +36,7 @@ import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
  * before executing the mojo and <strong>MUST</strong> refresh output folders from local filesystem after executing the
  * mojo. BuildContext API is the recommending way to implement both check for model changes and refresh output folders
  * from local filesystem.
- * 
+ *
  * @see {@link AbstractBuildParticipant#getBuildContext()}
  * @since 1.4
  */

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClassifierClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClassifierClasspathProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 /**
  * Configures Runtime Classpath for Launch configuration of a given workspace project, depending on its classifier.
- * 
+ *
  * @author Fred Bricon
  * @since 1.3
  */
@@ -42,7 +42,7 @@ public interface IClassifierClasspathProvider {
 
   /**
    * Configures the test classpath of the given project
-   * 
+   *
    * @deprecated replaced by {@link #setTestClasspath(Set, IMavenProjectFacade, IProgressMonitor, int)}
    */
   @Deprecated
@@ -59,7 +59,7 @@ public interface IClassifierClasspathProvider {
 
   /**
    * Configures the runtime classpath of the given project.
-   * 
+   *
    * @deprecated replaced by {@link #setRuntimeClasspath(Set, IMavenProjectFacade, IProgressMonitor, int)}.
    */
   @Deprecated

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathDescriptor.java
@@ -26,7 +26,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 /**
  * Instances of this class can be used to incrementally define IClasspathEntry[] arrays used by JDT to describe Java
  * Project classpath and contents of Java classpath containers.
- * 
+ *
  * @author igor
  * @noimplement This interface is not intended to be implemented by clients.
  */
@@ -61,14 +61,14 @@ public interface IClasspathDescriptor {
 
   /**
    * Removes entry from stale entries list.
-   * 
+   *
    * @since 1.7
    */
   public void touchEntry(IPath entryPath);
 
   /**
    * Replaces a single ClasspathEntry instance matched by filter. Returns null if none were replaced.
-   * 
+   *
    * @since 1.6
    */
   public IClasspathEntryDescriptor replaceEntry(EntryFilter filter, IClasspathEntry entry);
@@ -86,21 +86,21 @@ public interface IClasspathDescriptor {
   /**
    * Removes entry with specified path from the classpath. That this can remove multiple entries because classpath does
    * not enforce uniqueness of entry paths
-   * 
+   *
    * @TODO should really be removeEntries (i.e. plural)
    */
   public List<IClasspathEntryDescriptor> removeEntry(IPath path);
 
   /**
    * Removes entries that match EntryFilter (i.e. EntryFilter#accept(entry) returns true) from the classpath
-   * 
+   *
    * @TODO should really be removeEntries (i.e. plural)
    */
   public List<IClasspathEntryDescriptor> removeEntry(EntryFilter filter);
 
   /**
    * Renders classpath as IClasspathEntry[] array
-   * 
+   *
    * @TODO should really be toEntriesArray
    */
   public IClasspathEntry[] getEntries();
@@ -115,7 +115,7 @@ public interface IClasspathDescriptor {
 
   /**
    * Adds Maven artifact with corresponding sources and javadoc paths to the classpath.
-   * 
+   *
    * @deprecated this method exposes Maven core classes, which are not part of m2eclipse-jdt API
    */
   @Deprecated
@@ -123,7 +123,7 @@ public interface IClasspathDescriptor {
 
   /**
    * Adds worksapce Maven project dependency to the classpath
-   * 
+   *
    * @deprecated this method exposes Maven core classes, which are not part of m2eclipse-jdt API
    */
   @Deprecated

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathEntryDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathEntryDescriptor.java
@@ -25,7 +25,7 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
 
 /**
  * Mutable version of IClasspathEntry with additional Maven specific attributes.
- * 
+ *
  * @author igor
  * @noimplement This interface is not intended to be implemented by clients.
  */
@@ -124,7 +124,7 @@ public interface IClasspathEntryDescriptor {
   /**
    * Returns <code>true</code> if this classpath entry was derived from pom.xml and <code>false</code> otherwise. <br/>
    * Stale derived entries are automatically removed when workspace project configuration is synchronized with pom.xml.
-   * 
+   *
    * @see #setPomDerived(boolean)
    * @since 1.1
    */
@@ -143,7 +143,7 @@ public interface IClasspathEntryDescriptor {
    * <p>
    * Although not enforced, derived flag only applies to project 'raw' classpath entries. The flag is silently ignored
    * for classpath container entries.
-   * 
+   *
    * @since 1.1
    */
   public void setPomDerived(boolean derived);

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathManager.java
@@ -65,7 +65,7 @@ public interface IClasspathManager {
   /**
    * Name of IClasspathEntry attribute that is set to {@code true} for entries that correspond to optional Maven
    * dependency.
-   * 
+   *
    * @since 1.5
    */
   public static final String OPTIONALDEPENDENCY_ATTRIBUTE = "maven.optionaldependency"; //$NON-NLS-1$
@@ -73,7 +73,7 @@ public interface IClasspathManager {
   /**
    * Name of IClasspathEntry attribute that is used to mark test sources and dependencies by jdt.core. Same as
    * org.eclipse.jdt.core.IClasspathAttribute.TEST, copied here to allow running with older jdt.core version.
-   * 
+   *
    * @since 1.9
    */
   public static final String TEST_ATTRIBUTE = "test";
@@ -82,7 +82,7 @@ public interface IClasspathManager {
    * Name of IClasspathEntry attribute that is to limit the imported code of project by jdt.core. Same as
    * org.eclipse.jdt.core.IClasspathAttribute.WITHOUT_TEST_CODE, copied here to allow running with older jdt.core
    * version.
-   * 
+   *
    * @since 1.9
    */
   public static final String WITHOUT_TEST_CODE = "without_test_code";
@@ -119,7 +119,7 @@ public interface IClasspathManager {
 
   /**
    * Calculates and returns Maven classpath of the project.
-   * 
+   *
    * @param project the project to calculate classpath for
    * @param scope one of CLASPATH_* constants, that specifies Maven dependency resolution scope for the classpath
    * @param uniquePaths enforce (true) or not to enforce (false) uniqueness of classpath entries paths.

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IJavaProjectConfigurator.java
@@ -22,7 +22,7 @@ import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
 
 /**
  * IJavaProjectConfigurator
- * 
+ *
  * @author igor
  */
 public interface IJavaProjectConfigurator {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IMavenClassifierManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IMavenClassifierManager.java
@@ -18,7 +18,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 /**
  * IMavenClassifierManager
- * 
+ *
  * @author Fred Bricon
  * @since 1.3
  * @noimplement This interface is not intended to be implemented by clients.

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -63,7 +63,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
 
 /**
  * AbstractJavaProjectConfigurator
- * 
+ *
  * @author igor
  */
 public abstract class AbstractJavaProjectConfigurator extends AbstractProjectConfigurator
@@ -168,7 +168,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     // now apply new configuration
 
     // A single setOptions call erases everything else from an existing settings file.
-    // Must invoke setOption individually to preserve previous options. 
+    // Must invoke setOption individually to preserve previous options.
     for(Map.Entry<String, String> option : options.entrySet()) {
       javaProject.setOption(option.getKey(), option.getValue());
     }
@@ -386,8 +386,8 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
         continue;
       }
 
-      // be extra nice to less perfectly written maven plugins, which contribute compile source root to the model 
-      // but do not use BuildContext to tell as about the actual resources 
+      // be extra nice to less perfectly written maven plugins, which contribute compile source root to the model
+      // but do not use BuildContext to tell as about the actual resources
       sourceFolder.refreshLocal(IResource.DEPTH_ZERO, monitor);
 
       if(sourceFolder.exists() && !sourceFolder.getProject().equals(project)) {
@@ -405,7 +405,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
         log.info("Adding source folder " + sourceFolder.getFullPath());
 
         // source folder entries are created even when corresponding resources do not actually exist in workspace
-        // to keep JDT from complaining too loudly about non-existing folders, 
+        // to keep JDT from complaining too loudly about non-existing folders,
         // all source entries are marked as generated (a.k.a. optional)
         IClasspathEntryDescriptor descriptor = classpath.addSourceEntry(sourceFolder.getFullPath(), outputPath,
             inclusion, exclusion, true /*generated*/);
@@ -450,11 +450,11 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
         IPath relativePath = getProjectRelativePath(project, directory);
         IResource r = project.findMember(relativePath);
         if(r == project) {
-          /* 
-           * Workaround for the Java Model Exception: 
+          /*
+           * Workaround for the Java Model Exception:
            *   Cannot nest output folder 'xxx/src/main/resources' inside output folder 'xxx'
            * when pom.xml have something like this:
-           * 
+           *
            * <build>
            *   <resources>
            *     <resource>

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
@@ -102,7 +102,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
 public class BuildPathManager implements IMavenProjectChangedListener, IResourceChangeListener, IClasspathManager {
   private static final Logger log = LoggerFactory.getLogger(BuildPathManager.class);
 
-  public static final int SOURCE_DOWNLOAD_PRIORITY = Job.DECORATE;//Low priority 
+  public static final int SOURCE_DOWNLOAD_PRIORITY = Job.DECORATE;//Low priority
 
   // local repository variable
   public static final String M2_REPO = "M2_REPO"; //$NON-NLS-1$
@@ -662,8 +662,8 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
             if(monitor.isCanceled()) {
               return false;
             }
-            // Probably not the best way to detect if module path has changed, like, on the very 1st time a 
-            // module-info.java is modified, there will be no previous state to compare to, but should work 
+            // Probably not the best way to detect if module path has changed, like, on the very 1st time a
+            // module-info.java is modified, there will be no previous state to compare to, but should work
             // well enough the rest of the time, for cases that don't involve obscure module path configs
             InternalModuleInfo oldModuleInfo = moduleInfosMap.get(location);
             if(Objects.equals(newModuleInfo, oldModuleInfo)) {
@@ -739,7 +739,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
    * Resolves artifact from local repository. Returns null if the artifact is not available locally
    */
   private File getAttachedArtifactFile(ArtifactKey a, String classifier) {
-    // can't use Maven resolve methods since they mark artifacts as not-found even if they could be resolved remotely  
+    // can't use Maven resolve methods since they mark artifacts as not-found even if they could be resolved remotely
     try {
       ArtifactRepository localRepository = maven.getLocalRepository();
       String relPath = maven.getArtifactPath(localRepository, a.getGroupId(), a.getArtifactId(), a.getVersion(), "jar", //$NON-NLS-1$
@@ -824,7 +824,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
    * Download sources for an {@link IPackageFragmentRoot} that has already been identified as the given
    * <code>artifact</code>. <br/>
    * TODO promote to API in {@link IClasspathManager} once this as been battle-tested.
-   * 
+   *
    * @since 1.16.0
    */
   public void scheduleDownload(IPackageFragmentRoot fragment, ArtifactKey artifact, boolean downloadSources,
@@ -905,7 +905,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
           CLASSIFIER_JAVADOC);
       if(downloadSources) {
         if(isUnavailable(sourcesArtifact, repositories)) {
-          // 501553: fall back to requesting JavaDoc, if requested sources are missing, 
+          // 501553: fall back to requesting JavaDoc, if requested sources are missing,
           // but only if it doesn't exist locally
           if(getAttachedArtifactFile(a, CLASSIFIER_JAVADOC) == null) {
             downloadJavaDoc = true;
@@ -944,7 +944,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
           }
 
           cp[i] = JavaCore.newLibraryEntry(entry.getPath(), srcPath, null, entry.getAccessRules(), //
-              attributes.toArray(new IClasspathAttribute[attributes.size()]), // 
+              attributes.toArray(new IClasspathAttribute[attributes.size()]), //
               entry.isExported());
 
           break;

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ClasspathDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ClasspathDescriptor.java
@@ -40,7 +40,7 @@ import org.eclipse.m2e.jdt.IClasspathEntryDescriptor;
  * This class is an attempt to encapsulate list of IClasspathEntry's and operations on the list such as "removeEntry",
  * "addSourceEntry" and "addEntryAttribute". The idea is to provide JavaProjectConfigurator's classpath whiteboard they
  * can use to incrementally define classpath in a consistent manner.
- * 
+ *
  * @author igor
  */
 public class ClasspathDescriptor implements IClasspathDescriptor {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ClasspathEntryDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ClasspathEntryDescriptor.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.jdt.IClasspathManager;
 
 /**
  * ClasspathEntryDescriptor
- * 
+ *
  * @author igor
  */
 public class ClasspathEntryDescriptor implements IClasspathEntryDescriptor {
@@ -60,7 +60,7 @@ public class ClasspathEntryDescriptor implements IClasspathEntryDescriptor {
 
   private boolean combineAccessRules;
 
-  // maven specific attributes below 
+  // maven specific attributes below
 
   private ArtifactKey artifactKey;
 

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DefaultClasspathManagerDelegate.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DefaultClasspathManagerDelegate.java
@@ -45,7 +45,7 @@ import org.eclipse.m2e.jdt.IJavaProjectConfigurator;
 
 /**
  * DefaultClasspathManagerDelegate
- * 
+ *
  * @author igor
  */
 public class DefaultClasspathManagerDelegate implements IClasspathManagerDelegate {
@@ -102,8 +102,8 @@ public class DefaultClasspathManagerDelegate implements IClasspathManagerDelegat
     MavenProject mavenProject = facade.getMavenProject(monitor);
     Set<Artifact> artifacts = mavenProject.getArtifacts();
 
-    //if the project is used as a test-jar by another one, the test flag must be disabled on 
-    //its test sources to make them visible by other main code, AND test dependencies. 
+    //if the project is used as a test-jar by another one, the test flag must be disabled on
+    //its test sources to make them visible by other main code, AND test dependencies.
     // so that its test sources can compile
     boolean isTestFlagDisabled = MavenClasspathHelpers.hasTestFlagDisabled(mavenProject);
     Map<IPath, ProjectTestAttributes> projectTestAttributes = new HashMap<>(artifacts.size());

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
@@ -55,7 +55,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
 
 /**
  * DownloadSourcesJob
- * 
+ *
  * @author igor
  */
 class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
@@ -331,7 +331,7 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
         artifact.getArtifactId(), //
         artifact.getVersion(), //
         "jar" /*type*/, // //$NON-NLS-1$
-        artifact.getClassifier(), // 
+        artifact.getClassifier(), //
         repositories, //
         monitor);
     return resolved.getFile();

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaElementsAdapterFactory.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaElementsAdapterFactory.java
@@ -35,7 +35,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
 
 /**
  * Adapter factory for Java elements
- * 
+ *
  * @author Igor Fedorenko
  * @author Eugene Kuleshov
  * @author Miles Parker (Split out into JavaUiElementsAdapterFactory)

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaProjectConfigurator.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.jdt.internal;
 
 /**
  * DefaultJavaConfigurator
- * 
+ *
  * @author igor
  */
 public class JavaProjectConfigurator extends AbstractJavaProjectConfigurator {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaProjectConversionParticipant.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaProjectConversionParticipant.java
@@ -63,7 +63,7 @@ import org.eclipse.m2e.core.project.conversion.AbstractProjectConversionParticip
  * Converts existing Eclipse Java projects by setting the maven compiler source and target values. It also tries to best
  * match existing Java source directories with the corresponding source, test source, resource and test resource
  * directories of the Maven model.
- * 
+ *
  * @author Fred Bricon
  */
 public class JavaProjectConversionParticipant extends AbstractProjectConversionParticipant {
@@ -233,7 +233,7 @@ public class JavaProjectConversionParticipant extends AbstractProjectConversionP
 
   private Plugin getOrCreateCompilerPlugin(Build build) {
     build.flushPluginMap();//We need to force the re-generation of the plugin map as it may be stale
-    Plugin compiler = build.getPluginsAsMap().get(COMPILER_GROUP_ID + ":" + COMPILER_ARTIFACT_ID); //$NON-NLS-1$  
+    Plugin compiler = build.getPluginsAsMap().get(COMPILER_GROUP_ID + ":" + COMPILER_ARTIFACT_ID); //$NON-NLS-1$
     if(compiler == null) {
       compiler = build.getPluginsAsMap().get(COMPILER_ARTIFACT_ID);
     }
@@ -281,7 +281,7 @@ public class JavaProjectConversionParticipant extends AbstractProjectConversionP
         }
 
         if(!isResource) {
-          //For source folders not already flagged as resource folder, check if 
+          //For source folders not already flagged as resource folder, check if
           // they contain non-java sources, so we can add them as resources too
           boolean hasNonJavaResources = false;
           IFolder folder = javaProject.getProject().getFolder(path);
@@ -373,7 +373,7 @@ public class JavaProjectConversionParticipant extends AbstractProjectConversionP
       }
     }
     return false;
-    //TODO Maybe check if the folder has java files with a Test or TestSuite suffix? 
+    //TODO Maybe check if the folder has java files with a Test or TestSuite suffix?
   }
 
   private Build getOrCreateBuild(Model model) {
@@ -461,7 +461,7 @@ public class JavaProjectConversionParticipant extends AbstractProjectConversionP
       IIndex index = MavenPlugin.getIndexManager().getAllIndexes();
       SearchExpression a = new SourcedSearchExpression(artifactId);
 
-      //For some reason, an exact search using : 
+      //For some reason, an exact search using :
       //ISearchEngine searchEngine  = M2EUIPluginActivator.getDefault().getSearchEngine(null)
       //searchEngine.findVersions(groupId, artifactId, searchExpression, packaging)
       //

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaSettingsUtils.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/JavaSettingsUtils.java
@@ -34,7 +34,7 @@ public class JavaSettingsUtils {
 
   /**
    * Checks if the given {@link IJavaProject} has preview features enabled.
-   * 
+   *
    * @param project the {@link IJavaProject}
    * @return <code>true</code> if the project preferences have JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES=enabled,
    *         <code>false</code> otherwise.

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClassifierManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClassifierManager.java
@@ -46,7 +46,7 @@ import org.eclipse.m2e.jdt.IMavenClassifierManager;
 
 /**
  * MavenClassifierManager
- * 
+ *
  * @author Fred Bricon
  */
 public class MavenClassifierManager implements IMavenClassifierManager {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClasspathContainerInitializer.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClasspathContainerInitializer.java
@@ -36,7 +36,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
 
 /**
  * MavenClasspathContainerInitializer
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenClasspathContainerInitializer extends ClasspathContainerInitializer {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClasspathContainerSaveHelper.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClasspathContainerSaveHelper.java
@@ -33,7 +33,7 @@ import org.eclipse.jdt.core.JavaCore;
 
 /**
  * BuildPath save helper
- * 
+ *
  * @author Eugene Kuleshov
  */
 public class MavenClasspathContainerSaveHelper {


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>