### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines - 3

### DIFF
--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationPropertyItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationPropertyItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.ActivationProperty} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ActivationPropertyItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationPropertyItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -69,7 +69,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -84,7 +84,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
 
   /**
    * This adds a property descriptor for the Value feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addValuePropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
 
   /**
    * This returns ActivationProperty.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -109,7 +109,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -122,7 +122,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -141,7 +141,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -151,7 +151,7 @@ public class ActivationPropertyItemProvider extends ItemProviderAdapter implemen
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/BuildBaseItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/BuildBaseItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.BuildBase} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public BuildBaseItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -72,7 +72,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Default Goal feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDefaultGoalPropertyDescriptor(Object object) {
@@ -86,7 +86,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Directory feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDirectoryPropertyDescriptor(Object object) {
@@ -100,7 +100,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Final Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addFinalNamePropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -135,7 +135,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -149,7 +149,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns BuildBase.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -159,7 +159,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -172,7 +172,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -199,7 +199,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -224,7 +224,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -244,7 +244,7 @@ public class BuildBaseItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/BuildItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/BuildItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Build} object. <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class BuildItemProvider extends BuildBaseItemProvider implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public BuildItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -72,7 +72,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
 
   /**
    * This adds a property descriptor for the Source Directory feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSourceDirectoryPropertyDescriptor(Object object) {
@@ -87,7 +87,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
   /**
    * This adds a property descriptor for the Script Source Directory feature. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @generated
    */
   protected void addScriptSourceDirectoryPropertyDescriptor(Object object) {
@@ -102,7 +102,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
   /**
    * This adds a property descriptor for the Test Source Directory feature. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @generated
    */
   protected void addTestSourceDirectoryPropertyDescriptor(Object object) {
@@ -116,7 +116,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
 
   /**
    * This adds a property descriptor for the Output Directory feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOutputDirectoryPropertyDescriptor(Object object) {
@@ -131,7 +131,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
   /**
    * This adds a property descriptor for the Test Output Directory feature. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @generated
    */
   protected void addTestOutputDirectoryPropertyDescriptor(Object object) {
@@ -148,7 +148,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -162,7 +162,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -176,7 +176,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
 
   /**
    * This returns Build.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -186,7 +186,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -199,7 +199,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -224,7 +224,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -238,7 +238,7 @@ public class BuildItemProvider extends BuildBaseItemProvider implements IEditing
   /**
    * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/CiManagementItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/CiManagementItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.CiManagement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class CiManagementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public CiManagementItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the System feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSystemPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -102,7 +102,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -116,7 +116,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -130,7 +130,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns CiManagement.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -140,7 +140,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -175,7 +175,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -188,7 +188,7 @@ public class CiManagementItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ConfigurationItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ConfigurationItemProvider.java
@@ -31,14 +31,14 @@ import org.eclipse.emf.edit.provider.ItemProviderAdapter;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Configuration} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ConfigurationItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ConfigurationItemProvider(AdapterFactory adapterFactory) {
@@ -47,7 +47,7 @@ public class ConfigurationItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -61,7 +61,7 @@ public class ConfigurationItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This returns Configuration.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ConfigurationItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -82,7 +82,7 @@ public class ConfigurationItemProvider extends ItemProviderAdapter implements IE
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -94,7 +94,7 @@ public class ConfigurationItemProvider extends ItemProviderAdapter implements IE
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -104,7 +104,7 @@ public class ConfigurationItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ContributorItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ContributorItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Contributor} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ContributorItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ContributorItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -75,7 +75,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -89,7 +89,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Email feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addEmailPropertyDescriptor(Object object) {
@@ -103,7 +103,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Organization feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOrganizationPropertyDescriptor(Object object) {
@@ -133,7 +133,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Organization Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOrganizationUrlPropertyDescriptor(Object object) {
@@ -148,7 +148,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Timezone feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addTimezonePropertyDescriptor(Object object) {
@@ -165,7 +165,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -180,7 +180,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -194,7 +194,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This returns Contributor.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -204,7 +204,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -217,7 +217,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -244,7 +244,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -259,7 +259,7 @@ public class ContributorItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DependencyItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DependencyItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Dependency} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class DependencyItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DependencyItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -77,7 +77,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -91,7 +91,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -105,7 +105,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -119,7 +119,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Type feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addTypePropertyDescriptor(Object object) {
@@ -133,7 +133,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Classifier feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addClassifierPropertyDescriptor(Object object) {
@@ -147,7 +147,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Scope feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addScopePropertyDescriptor(Object object) {
@@ -161,7 +161,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the System Path feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSystemPathPropertyDescriptor(Object object) {
@@ -175,7 +175,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Optional feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOptionalPropertyDescriptor(Object object) {
@@ -192,7 +192,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -206,7 +206,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -220,7 +220,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns Dependency.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -230,7 +230,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -243,7 +243,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -271,7 +271,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -284,7 +284,7 @@ public class DependencyItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DependencyManagementItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DependencyManagementItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.DependencyManagement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class DependencyManagementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DependencyManagementItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -70,7 +70,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -84,7 +84,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -98,7 +98,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
 
   /**
    * This returns DependencyManagement.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -108,7 +108,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -119,7 +119,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class DependencyManagementItemProvider extends ItemProviderAdapter implem
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DeploymentRepositoryItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DeploymentRepositoryItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.DeploymentRepository} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DeploymentRepositoryItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -72,7 +72,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This adds a property descriptor for the Unique Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUniqueVersionPropertyDescriptor(Object object) {
@@ -87,7 +87,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -102,7 +102,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -132,7 +132,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This adds a property descriptor for the Layout feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addLayoutPropertyDescriptor(Object object) {
@@ -147,7 +147,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This returns DeploymentRepository.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -157,7 +157,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -170,7 +170,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -192,7 +192,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -202,7 +202,7 @@ public class DeploymentRepositoryItemProvider extends ItemProviderAdapter implem
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DeveloperItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DeveloperItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Developer} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class DeveloperItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DeveloperItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -76,7 +76,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -89,7 +89,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -103,7 +103,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Email feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addEmailPropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -131,7 +131,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Organization feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOrganizationPropertyDescriptor(Object object) {
@@ -145,7 +145,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Organization Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOrganizationUrlPropertyDescriptor(Object object) {
@@ -159,7 +159,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Timezone feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addTimezonePropertyDescriptor(Object object) {
@@ -176,7 +176,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -191,7 +191,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -205,7 +205,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns Developer.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -215,7 +215,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -228,7 +228,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -256,7 +256,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -271,7 +271,7 @@ public class DeveloperItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DistributionManagementItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DistributionManagementItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.DistributionManagement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class DistributionManagementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DistributionManagementItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * This adds a property descriptor for the Download Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDownloadUrlPropertyDescriptor(Object object) {
@@ -86,7 +86,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * This adds a property descriptor for the Status feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addStatusPropertyDescriptor(Object object) {
@@ -104,7 +104,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -121,7 +121,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -135,7 +135,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * This returns DistributionManagement.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -145,7 +145,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -158,7 +158,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -183,7 +183,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -206,7 +206,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
   /**
    * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -226,7 +226,7 @@ public class DistributionManagementItemProvider extends ItemProviderAdapter impl
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DocumentRootItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/DocumentRootItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.DocumentRoot} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class DocumentRootItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DocumentRootItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -70,7 +70,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -84,7 +84,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -98,7 +98,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns DocumentRoot.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -108,7 +108,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -119,7 +119,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class DocumentRootItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ExclusionItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ExclusionItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Exclusion} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ExclusionItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ExclusionItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -69,7 +69,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -83,7 +83,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -97,7 +97,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns Exclusion.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -107,7 +107,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -120,7 +120,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -139,7 +139,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -149,7 +149,7 @@ public class ExclusionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ExtensionItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ExtensionItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Extension} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ExtensionItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ExtensionItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -70,7 +70,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -84,7 +84,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -98,7 +98,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -112,7 +112,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns Extension.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -122,7 +122,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -135,7 +135,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -155,7 +155,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -165,7 +165,7 @@ public class ExtensionItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/IssueManagementItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/IssueManagementItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.IssueManagement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class IssueManagementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public IssueManagementItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -69,7 +69,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the System feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSystemPropertyDescriptor(Object object) {
@@ -84,7 +84,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -98,7 +98,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns IssueManagement.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -108,7 +108,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -121,7 +121,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -140,7 +140,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class IssueManagementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/LicenseItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/LicenseItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.License} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class LicenseItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public LicenseItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -84,7 +84,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -97,7 +97,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This adds a property descriptor for the Distribution feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDistributionPropertyDescriptor(Object object) {
@@ -111,7 +111,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This adds a property descriptor for the Comments feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addCommentsPropertyDescriptor(Object object) {
@@ -125,7 +125,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This returns License.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -135,7 +135,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -148,7 +148,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -169,7 +169,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -179,7 +179,7 @@ public class LicenseItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/MailingListItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/MailingListItemProvider.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.MailingList} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class MailingListItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public MailingListItemProvider(AdapterFactory adapterFactory) {
@@ -54,7 +54,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -73,7 +73,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -87,7 +87,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Subscribe feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSubscribePropertyDescriptor(Object object) {
@@ -101,7 +101,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Unsubscribe feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUnsubscribePropertyDescriptor(Object object) {
@@ -115,7 +115,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Post feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addPostPropertyDescriptor(Object object) {
@@ -129,7 +129,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This adds a property descriptor for the Archive feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArchivePropertyDescriptor(Object object) {
@@ -146,7 +146,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -160,7 +160,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -174,7 +174,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This returns MailingList.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -184,7 +184,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -197,7 +197,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -222,7 +222,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -234,7 +234,7 @@ public class MailingListItemProvider extends ItemProviderAdapter implements IEdi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ModelItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ModelItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Model} object. <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ModelItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ModelItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -78,7 +78,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Model Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addModelVersionPropertyDescriptor(Object object) {
@@ -92,7 +92,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -106,7 +106,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -120,7 +120,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Packaging feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addPackagingPropertyDescriptor(Object object) {
@@ -134,7 +134,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -147,7 +147,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -161,7 +161,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Description feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDescriptionPropertyDescriptor(Object object) {
@@ -175,7 +175,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -188,7 +188,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This adds a property descriptor for the Inception Year feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addInceptionYearPropertyDescriptor(Object object) {
@@ -205,7 +205,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -238,7 +238,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -252,7 +252,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This returns Model.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -262,7 +262,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -275,7 +275,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -323,7 +323,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -391,7 +391,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
   /**
    * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -411,7 +411,7 @@ public class ModelItemProvider extends ItemProviderAdapter implements IEditingDo
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/NotifierItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/NotifierItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Notifier} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class NotifierItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotifierItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -75,7 +75,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Type feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addTypePropertyDescriptor(Object object) {
@@ -89,7 +89,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Send On Error feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSendOnErrorPropertyDescriptor(Object object) {
@@ -103,7 +103,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Send On Failure feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSendOnFailurePropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Send On Success feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSendOnSuccessPropertyDescriptor(Object object) {
@@ -131,7 +131,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Send On Warning feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addSendOnWarningPropertyDescriptor(Object object) {
@@ -145,7 +145,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Address feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addAddressPropertyDescriptor(Object object) {
@@ -162,7 +162,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -176,7 +176,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -190,7 +190,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This returns Notifier.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -200,7 +200,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -213,7 +213,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -239,7 +239,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -252,7 +252,7 @@ public class NotifierItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/OrganizationItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/OrganizationItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Organization} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class OrganizationItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public OrganizationItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -69,7 +69,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -83,7 +83,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -97,7 +97,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns Organization.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -107,7 +107,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -120,7 +120,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -139,7 +139,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -149,7 +149,7 @@ public class OrganizationItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ParentItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ParentItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Parent} object. <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ParentItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ParentItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -113,7 +113,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Relative Path feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addRelativePathPropertyDescriptor(Object object) {
@@ -127,7 +127,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This returns Parent.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -171,7 +171,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -181,7 +181,7 @@ public class ParentItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PluginExecutionItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PluginExecutionItemProvider.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.PluginExecution} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PluginExecutionItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PluginExecutionItemProvider(AdapterFactory adapterFactory) {
@@ -54,7 +54,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -72,7 +72,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -86,7 +86,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Phase feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addPhasePropertyDescriptor(Object object) {
@@ -102,7 +102,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Inherited feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addInheritedPropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Configuration feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addConfigurationPropertyDescriptor(Object object) {
@@ -135,7 +135,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -149,7 +149,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -163,7 +163,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns PluginExecution.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -173,7 +173,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -186,7 +186,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -209,7 +209,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -221,7 +221,7 @@ public class PluginExecutionItemProvider extends ItemProviderAdapter implements 
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PluginItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PluginItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Plugin} object. <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PluginItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PluginItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -75,7 +75,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -89,7 +89,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -103,7 +103,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -117,7 +117,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Extensions feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addExtensionsPropertyDescriptor(Object object) {
@@ -131,7 +131,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Inherited feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addInheritedPropertyDescriptor(Object object) {
@@ -145,7 +145,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This adds a property descriptor for the Configuration feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addConfigurationPropertyDescriptor(Object object) {
@@ -161,7 +161,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -176,7 +176,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -190,7 +190,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This returns Plugin.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -200,7 +200,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -213,7 +213,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -239,7 +239,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -255,7 +255,7 @@ public class PluginItemProvider extends ItemProviderAdapter implements IEditingD
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PluginManagementItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PluginManagementItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.PluginManagement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PluginManagementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PluginManagementItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -70,7 +70,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -84,7 +84,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -98,7 +98,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
 
   /**
    * This returns PluginManagement.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -108,7 +108,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -119,7 +119,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class PluginManagementItemProvider extends ItemProviderAdapter implements
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PomEditPlugin.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PomEditPlugin.java
@@ -19,27 +19,27 @@ import org.eclipse.emf.common.util.ResourceLocator;
 
 /**
  * This is the central singleton for the Pom edit plugin. <!-- begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public final class PomEditPlugin extends EMFPlugin {
   /**
    * Keep track of the singleton. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public static final PomEditPlugin INSTANCE = new PomEditPlugin();
 
   /**
    * Keep track of the singleton. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private static Implementation plugin;
 
   /**
    * Create the instance. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomEditPlugin() {
@@ -48,7 +48,7 @@ public final class PomEditPlugin extends EMFPlugin {
 
   /**
    * Returns the singleton instance of the Eclipse plugin. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return the singleton instance.
    * @generated
    */
@@ -59,7 +59,7 @@ public final class PomEditPlugin extends EMFPlugin {
 
   /**
    * Returns the singleton instance of the Eclipse plugin. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return the singleton instance.
    * @generated
    */
@@ -69,13 +69,13 @@ public final class PomEditPlugin extends EMFPlugin {
 
   /**
    * The actual implementation of the Eclipse <b>Plugin</b>. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public static class Implementation extends EclipsePlugin {
     /**
      * Creates an instance. <!-- begin-user-doc --> <!-- end-user-doc -->
-     * 
+     *
      * @generated
      */
     public Implementation() {

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PomItemProviderAdapterFactory.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PomItemProviderAdapterFactory.java
@@ -39,7 +39,7 @@ import org.eclipse.m2e.model.edit.pom.util.PomAdapterFactory;
  * factory convert EMF adapter notifications into calls to {@link #fireNotifyChanged fireNotifyChanged}. The adapters
  * also support Eclipse property sheets. Note that most of the adapters are shared among multiple instances. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PomItemProviderAdapterFactory extends PomAdapterFactory implements ComposeableAdapterFactory,
@@ -47,7 +47,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the root adapter factory that delegates to this adapter factory. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ComposedAdapterFactory parentAdapterFactory;
@@ -55,7 +55,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This is used to implement {@link org.eclipse.emf.edit.provider.IChangeNotifier}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected IChangeNotifier changeNotifier = new ChangeNotifier();
@@ -63,14 +63,14 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of all the supported types checked by {@link #isFactoryForType isFactoryForType}. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected Collection<Object> supportedTypes = new ArrayList<>();
 
   /**
    * This constructs an instance. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomItemProviderAdapterFactory() {
@@ -84,7 +84,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Activation} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationItemProvider activationItemProvider;
@@ -92,7 +92,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Activation}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -107,7 +107,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.ActivationFile} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationFileItemProvider activationFileItemProvider;
@@ -115,7 +115,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.ActivationFile}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -130,7 +130,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.ActivationOS} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationOSItemProvider activationOSItemProvider;
@@ -138,7 +138,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.ActivationOS}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.ActivationProperty}
    * instances. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationPropertyItemProvider activationPropertyItemProvider;
@@ -161,7 +161,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.ActivationProperty}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -176,7 +176,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Build} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected BuildItemProvider buildItemProvider;
@@ -184,7 +184,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Build}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -199,7 +199,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.BuildBase} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected BuildBaseItemProvider buildBaseItemProvider;
@@ -207,7 +207,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.BuildBase}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -222,7 +222,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.CiManagement} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected CiManagementItemProvider ciManagementItemProvider;
@@ -230,7 +230,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.CiManagement}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -245,7 +245,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Contributor} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ContributorItemProvider contributorItemProvider;
@@ -253,7 +253,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Contributor}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -268,7 +268,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Dependency} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DependencyItemProvider dependencyItemProvider;
@@ -276,7 +276,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Dependency}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -291,7 +291,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.DependencyManagement}
    * instances. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DependencyManagementItemProvider dependencyManagementItemProvider;
@@ -299,7 +299,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.DependencyManagement}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -314,7 +314,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.DeploymentRepository}
    * instances. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DeploymentRepositoryItemProvider deploymentRepositoryItemProvider;
@@ -322,7 +322,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.DeploymentRepository}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -337,7 +337,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Developer} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DeveloperItemProvider developerItemProvider;
@@ -345,7 +345,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Developer}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -360,7 +360,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.DistributionManagement}
    * instances. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DistributionManagementItemProvider distributionManagementItemProvider;
@@ -368,7 +368,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.DistributionManagement}. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -383,7 +383,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.DocumentRoot} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DocumentRootItemProvider documentRootItemProvider;
@@ -391,7 +391,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.DocumentRoot}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -406,7 +406,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Exclusion} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ExclusionItemProvider exclusionItemProvider;
@@ -414,7 +414,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Exclusion}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -429,7 +429,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Extension} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ExtensionItemProvider extensionItemProvider;
@@ -437,7 +437,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Extension}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -452,7 +452,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.IssueManagement} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected IssueManagementItemProvider issueManagementItemProvider;
@@ -460,7 +460,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.IssueManagement}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -475,7 +475,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.License} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected LicenseItemProvider licenseItemProvider;
@@ -483,7 +483,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.License}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -498,7 +498,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.MailingList} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected MailingListItemProvider mailingListItemProvider;
@@ -506,7 +506,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.MailingList}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -521,7 +521,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Model} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ModelItemProvider modelItemProvider;
@@ -529,7 +529,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Model}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -544,7 +544,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Notifier} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected NotifierItemProvider notifierItemProvider;
@@ -552,7 +552,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Notifier}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -567,7 +567,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Organization} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected OrganizationItemProvider organizationItemProvider;
@@ -575,7 +575,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Organization}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -590,7 +590,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Parent} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ParentItemProvider parentItemProvider;
@@ -598,7 +598,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Parent} . <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -613,7 +613,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Plugin} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PluginItemProvider pluginItemProvider;
@@ -621,7 +621,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Plugin} . <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -636,7 +636,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.PluginExecution} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PluginExecutionItemProvider pluginExecutionItemProvider;
@@ -644,7 +644,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.PluginExecution}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -659,7 +659,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.PluginManagement} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PluginManagementItemProvider pluginManagementItemProvider;
@@ -667,7 +667,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.PluginManagement}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -682,7 +682,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Prerequisites} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PrerequisitesItemProvider prerequisitesItemProvider;
@@ -690,7 +690,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Prerequisites}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -705,7 +705,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Profile} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ProfileItemProvider profileItemProvider;
@@ -713,7 +713,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Profile}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -728,7 +728,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Relocation} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected RelocationItemProvider relocationItemProvider;
@@ -736,7 +736,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Relocation}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -751,7 +751,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Reporting} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ReportingItemProvider reportingItemProvider;
@@ -759,7 +759,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Reporting}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -774,7 +774,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.ReportPlugin} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ReportPluginItemProvider reportPluginItemProvider;
@@ -782,7 +782,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.ReportPlugin}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -797,7 +797,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.ReportSet} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ReportSetItemProvider reportSetItemProvider;
@@ -805,7 +805,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.ReportSet}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -820,7 +820,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Repository} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected RepositoryItemProvider repositoryItemProvider;
@@ -828,7 +828,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Repository}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -843,7 +843,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected RepositoryPolicyItemProvider repositoryPolicyItemProvider;
@@ -851,7 +851,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -866,7 +866,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Resource} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ResourceItemProvider resourceItemProvider;
@@ -874,7 +874,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Resource}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -889,7 +889,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Scm} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ScmItemProvider scmItemProvider;
@@ -897,7 +897,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Scm}. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -912,7 +912,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Site} instances. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected SiteItemProvider siteItemProvider;
@@ -920,7 +920,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Site}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -935,7 +935,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.PropertyElement} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PropertyElementItemProvider propertyElementItemProvider;
@@ -943,7 +943,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.PropertyElement}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -958,7 +958,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This keeps track of the one adapter used for all {@link org.eclipse.m2e.model.edit.pom.Configuration} instances.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ConfigurationItemProvider configurationItemProvider;
@@ -966,7 +966,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This creates an adapter for a {@link org.eclipse.m2e.model.edit.pom.Configuration}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -980,7 +980,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * This returns the root adapter factory that contains this factory. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ComposeableAdapterFactory getRootAdapterFactory() {
@@ -989,7 +989,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * This sets the composed adapter factory that contains this factory. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setParentAdapterFactory(ComposedAdapterFactory parentAdapterFactory) {
@@ -998,7 +998,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -1009,7 +1009,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This implementation substitutes the factory itself as the key for the adapter. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -1019,7 +1019,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -1036,7 +1036,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * This adds a listener. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void addListener(INotifyChangedListener notifyChangedListener) {
@@ -1045,7 +1045,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * This removes a listener. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void removeListener(INotifyChangedListener notifyChangedListener) {
@@ -1055,7 +1055,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
   /**
    * This delegates to {@link #changeNotifier} and to {@link #parentAdapterFactory}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void fireNotifyChanged(Notification notification) {
@@ -1068,7 +1068,7 @@ public class PomItemProviderAdapterFactory extends PomAdapterFactory implements 
 
   /**
    * This disposes all of the item providers created by this factory. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void dispose() {

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PrerequisitesItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PrerequisitesItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.Prerequisites;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Prerequisites} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PrerequisitesItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PrerequisitesItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -68,7 +68,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This adds a property descriptor for the Maven feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addMavenPropertyDescriptor(Object object) {
@@ -82,7 +82,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This returns Prerequisites.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -92,7 +92,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -105,7 +105,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -123,7 +123,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -133,7 +133,7 @@ public class PrerequisitesItemProvider extends ItemProviderAdapter implements IE
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ProfileItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ProfileItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.Profile;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Profile} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ProfileItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ProfileItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -84,7 +84,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This adds a property descriptor for the Reporting feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addReportingPropertyDescriptor(Object object) {
@@ -100,7 +100,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -123,7 +123,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This returns Profile.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -147,7 +147,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -160,7 +160,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -190,7 +190,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -233,7 +233,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
   /**
    * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -253,7 +253,7 @@ public class ProfileItemProvider extends ItemProviderAdapter implements IEditing
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PropertyElementItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/PropertyElementItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.PropertyElement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PropertyElementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PropertyElementItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -69,7 +69,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This adds a property descriptor for the Value feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addValuePropertyDescriptor(Object object) {
@@ -101,7 +101,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns PropertyElement.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -111,7 +111,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -124,7 +124,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -143,7 +143,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class PropertyElementItemProvider extends ItemProviderAdapter implements 
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/RelocationItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/RelocationItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.Relocation;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Relocation} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class RelocationItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public RelocationItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -113,7 +113,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Message feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addMessagePropertyDescriptor(Object object) {
@@ -127,7 +127,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns Relocation.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -171,7 +171,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -181,7 +181,7 @@ public class RelocationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ReportPluginItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ReportPluginItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.ReportPlugin;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.ReportPlugin} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ReportPluginItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ReportPluginItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -74,7 +74,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Group Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addGroupIdPropertyDescriptor(Object object) {
@@ -88,7 +88,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Artifact Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArtifactIdPropertyDescriptor(Object object) {
@@ -104,7 +104,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -118,7 +118,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Inherited feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addInheritedPropertyDescriptor(Object object) {
@@ -132,7 +132,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Configuration feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addConfigurationPropertyDescriptor(Object object) {
@@ -150,7 +150,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -164,7 +164,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -178,7 +178,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns ReportPlugin.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -188,7 +188,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -201,7 +201,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -225,7 +225,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -238,7 +238,7 @@ public class ReportPluginItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ReportSetItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ReportSetItemProvider.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.ReportSet;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.ReportSet} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ReportSetItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ReportSetItemProvider(AdapterFactory adapterFactory) {
@@ -54,7 +54,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Inherited feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addInheritedPropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Configuration feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addConfigurationPropertyDescriptor(Object object) {
@@ -115,7 +115,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -129,7 +129,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -143,7 +143,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns ReportSet.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -166,7 +166,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -188,7 +188,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -200,7 +200,7 @@ public class ReportSetItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ReportingItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ReportingItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.Reporting;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Reporting} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ReportingItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ReportingItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Exclude Defaults feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addExcludeDefaultsPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This adds a property descriptor for the Output Directory feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addOutputDirectoryPropertyDescriptor(Object object) {
@@ -102,7 +102,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -116,7 +116,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -130,7 +130,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns Reporting.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -140,7 +140,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -175,7 +175,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -188,7 +188,7 @@ public class ReportingItemProvider extends ItemProviderAdapter implements IEditi
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/RepositoryItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/RepositoryItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.Repository;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Repository} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class RepositoryItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public RepositoryItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -73,7 +73,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -87,7 +87,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -101,7 +101,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -115,7 +115,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Layout feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addLayoutPropertyDescriptor(Object object) {
@@ -132,7 +132,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -147,7 +147,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -161,7 +161,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns Repository.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -171,7 +171,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -184,7 +184,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -209,7 +209,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -226,7 +226,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -246,7 +246,7 @@ public class RepositoryItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/RepositoryPolicyItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/RepositoryPolicyItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.RepositoryPolicy;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public RepositoryPolicyItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -70,7 +70,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * This adds a property descriptor for the Enabled feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addEnabledPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * This adds a property descriptor for the Update Policy feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUpdatePolicyPropertyDescriptor(Object object) {
@@ -100,7 +100,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * This adds a property descriptor for the Checksum Policy feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addChecksumPolicyPropertyDescriptor(Object object) {
@@ -115,7 +115,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * This returns RepositoryPolicy.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -125,7 +125,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -138,7 +138,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -158,7 +158,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -168,7 +168,7 @@ public class RepositoryPolicyItemProvider extends ItemProviderAdapter implements
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ResourceItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ResourceItemProvider.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.Resource;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Resource} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ResourceItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ResourceItemProvider(AdapterFactory adapterFactory) {
@@ -54,7 +54,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Target Path feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addTargetPathPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Filtering feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addFilteringPropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This adds a property descriptor for the Directory feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDirectoryPropertyDescriptor(Object object) {
@@ -116,7 +116,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -131,7 +131,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -145,7 +145,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This returns Resource.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -155,7 +155,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -168,7 +168,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -192,7 +192,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -206,7 +206,7 @@ public class ResourceItemProvider extends ItemProviderAdapter implements IEditin
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ScmItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ScmItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.Scm;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Scm} object. <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ScmItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ScmItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This adds a property descriptor for the Connection feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addConnectionPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This adds a property descriptor for the Developer Connection feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addDeveloperConnectionPropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This adds a property descriptor for the Tag feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addTagPropertyDescriptor(Object object) {
@@ -112,7 +112,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -125,7 +125,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This returns Scm.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -135,7 +135,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -147,7 +147,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -168,7 +168,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -178,7 +178,7 @@ public class ScmItemProvider extends ItemProviderAdapter implements IEditingDoma
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/SiteItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/SiteItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.Site;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Site} object. <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class SiteItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public SiteItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -70,7 +70,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * This adds a property descriptor for the Id feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addIdPropertyDescriptor(Object object) {
@@ -83,7 +83,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -96,7 +96,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * This adds a property descriptor for the Url feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addUrlPropertyDescriptor(Object object) {
@@ -109,7 +109,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * This returns Site.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -119,7 +119,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -131,7 +131,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -151,7 +151,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -161,7 +161,7 @@ public class SiteItemProvider extends ItemProviderAdapter implements IEditingDom
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ConfigurationAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ConfigurationAdapter.java
@@ -24,7 +24,7 @@ import org.eclipse.m2e.model.edit.pom.impl.ConfigurationImpl;
 
 /**
  * Synchronizes configuration elements between XML and model
- * 
+ *
  * @author Mike Poindexter
  */
 class ConfigurationAdapter extends TranslatorAdapter implements INodeAdapter {
@@ -44,7 +44,7 @@ class ConfigurationAdapter extends TranslatorAdapter implements INodeAdapter {
 
   public void notifyChanged(INodeNotifier notifier, int eventType, Object changedFeature, Object oldValue,
       Object newValue, int pos) {
-    // A catch-all notificator. 
+    // A catch-all notificator.
     // The configuration section can differ with every plugin, so we cannot really have a
     // static EMF model. So we'll just notify the subscribers and let them act accordingly.
     ((ConfigurationImpl) modelObject).doNotify(eventType, changedFeature, oldValue, newValue);

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ListAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ListAdapter.java
@@ -32,7 +32,7 @@ import org.eclipse.m2e.model.edit.pom.PomFactory;
 
 /**
  * Translates a multi valued feature into a <foos> <foo>bar</foo> </foos> structure.
- * 
+ *
  * @author Mike Poindexter
  */
 @SuppressWarnings("restriction")
@@ -198,7 +198,7 @@ public class ListAdapter extends TranslatorAdapter {
 
   @Override
   public void load() {
-    //MNGECLIPSE-2345, MNGECLIPSE-2694 when load is called on a list adapter already containing items, 
+    //MNGECLIPSE-2345, MNGECLIPSE-2694 when load is called on a list adapter already containing items,
     // the old items shall be discarded to avoid duplicates.
     list.clear();
     NodeList children = node.getChildNodes();

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ModelObjectAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ModelObjectAdapter.java
@@ -41,7 +41,7 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
 
 /**
  * Listens for notifications from the dom model and the E model, and syncs the models.
- * 
+ *
  * @author Mike Poindexter
  */
 public class ModelObjectAdapter extends TranslatorAdapter implements Adapter, INodeAdapter {
@@ -212,7 +212,7 @@ public class ModelObjectAdapter extends TranslatorAdapter implements Adapter, IN
 
   /**
    * Removes the dom child matching the feature.
-   * 
+   *
    * @param feature
    */
   private void removeDomChild(EStructuralFeature feature) {
@@ -225,7 +225,7 @@ public class ModelObjectAdapter extends TranslatorAdapter implements Adapter, IN
 
   /**
    * Inserts an element under the current node, attempting to preserve proper node ordering.
-   * 
+   *
    * @param element
    * @param position
    */

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/PropertiesAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/PropertiesAdapter.java
@@ -34,7 +34,7 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
 
 /**
  * Translates a property list using the name and value instead of reflection.
- * 
+ *
  * @author Mike Poindexter
  */
 public class PropertiesAdapter extends ListAdapter {
@@ -138,7 +138,7 @@ public class PropertiesAdapter extends ListAdapter {
 
   @Override
   public void load() {
-    //MNGECLIPSE-2345, MNGECLIPSE-2694 when load is called on a list adapter already containing items, 
+    //MNGECLIPSE-2345, MNGECLIPSE-2694 when load is called on a list adapter already containing items,
     // the old items shall be discarded to avoid duplicates.
     properties.clear();
     NodeList children = node.getChildNodes();

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/TranslatorAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/TranslatorAdapter.java
@@ -28,7 +28,7 @@ import org.eclipse.wst.xml.core.internal.provisional.document.IDOMNode;
  * A base class for all adapters that can translate a EMF to DOM and vice-versa. Each translator adaptor is expected to
  * have a single root element that controls its existence. It is responsible for the subtree of that node by updating it
  * directly or delegating to child adapters to do the work.
- * 
+ *
  * @author Mike Poindexter
  */
 public abstract class TranslatorAdapter implements INodeAdapter {
@@ -42,7 +42,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Returns the textual value of an element.
-   * 
+   *
    * @param e
    * @return
    */
@@ -76,7 +76,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Returns the index of the given element in the list of elements of the same name.
-   * 
+   *
    * @param e
    * @return
    */
@@ -101,7 +101,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Returns the index of the given element in the list of child elements.
-   * 
+   *
    * @param e
    * @return
    */
@@ -126,7 +126,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Returns the first child with the given name, or null if none exists.
-   * 
+   *
    * @param name
    * @return
    */
@@ -136,7 +136,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Returns the nth child element with a given name, or null if no such element exists.
-   * 
+   *
    * @param name
    * @param n
    * @return
@@ -175,7 +175,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Ensure at least one NL between this node and the previous, and proper start tag indentation.
-   * 
+   *
    * @param element
    * @return
    */
@@ -220,7 +220,7 @@ public abstract class TranslatorAdapter implements INodeAdapter {
 
   /**
    * Ensure at least one NL between this node and the next, and proper indent to the next tag tag indentation.
-   * 
+   *
    * @param element
    * @return
    */

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ValueUpdateAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ValueUpdateAdapter.java
@@ -32,12 +32,12 @@ import org.eclipse.wst.sse.core.internal.provisional.INodeNotifier;
 
 /**
  * Handles notifications from the DOM that a simple text value has changed.
- * 
+ *
  * @author Mike Poindexter
  */
 class ValueUpdateAdapter extends TranslatorAdapter implements INodeAdapter {
   /**
-     * 
+     *
      */
   private EObject modelObject;
 
@@ -103,7 +103,7 @@ class ValueUpdateAdapter extends TranslatorAdapter implements INodeAdapter {
 
   /**
    * Sets the text value of an existing node, attempting to preserve whitespace
-   * 
+   *
    * @param element
    * @param oldValue
    * @param newValue

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/NodeOperation.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/NodeOperation.java
@@ -21,7 +21,7 @@ import org.eclipse.wst.sse.core.internal.provisional.text.IStructuredDocument;
 /**
  * A non-editing operation on top of the DOM document, to be used with XmlUtils.performOnRootElement and
  * XmlUtils.performOnCurrentElement
- * 
+ *
  * @author mkleint
  * @param <T>
  */

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomAdapterFactory.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomAdapterFactory.java
@@ -69,21 +69,21 @@ import org.eclipse.m2e.model.edit.pom.Site;
 /**
  * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides an adapter <code>createXXX</code>
  * method for each class of the model. <!-- end-user-doc -->
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage
  * @generated
  */
 public class PomAdapterFactory extends AdapterFactoryImpl {
   /**
    * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected static PomPackage modelPackage;
 
   /**
    * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomAdapterFactory() {
@@ -96,7 +96,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Returns whether this factory is applicable for the type of the object. <!-- begin-user-doc --> This implementation
    * returns <code>true</code> if the object is either the model's package or is an instance object of the model. <!--
    * end-user-doc -->
-   * 
+   *
    * @return whether this factory is applicable for the type of the object.
    * @generated
    */
@@ -113,7 +113,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
 
   /**
    * The switch that delegates to the <code>createXXX</code> methods. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PomSwitch<Adapter> modelSwitch = new PomSwitch<Adapter>() {
@@ -320,7 +320,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
 
   /**
    * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param target the object to adapt.
    * @return the adapter for the <code>target</code>.
    * @generated
@@ -334,7 +334,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Activation
    * <em>Activation</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Activation
    * @generated
@@ -347,7 +347,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.ActivationFile
    * <em>Activation File</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.ActivationFile
    * @generated
@@ -360,7 +360,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.ActivationOS
    * <em>Activation OS</em>} '. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.ActivationOS
    * @generated
@@ -374,7 +374,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * <em>Activation Property</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can
    * easily ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.ActivationProperty
    * @generated
@@ -387,7 +387,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Build <em>Build</em>}'. <!--
    * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Build
    * @generated
@@ -400,7 +400,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.BuildBase <em>Build Base</em>}
    * '. <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful
    * to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.BuildBase
    * @generated
@@ -413,7 +413,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.CiManagement
    * <em>Ci Management</em>} '. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.CiManagement
    * @generated
@@ -426,7 +426,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Contributor
    * <em>Contributor</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Contributor
    * @generated
@@ -439,7 +439,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Dependency
    * <em>Dependency</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Dependency
    * @generated
@@ -453,7 +453,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * <em>Dependency Management</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can
    * easily ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.DependencyManagement
    * @generated
@@ -467,7 +467,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * <em>Deployment Repository</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can
    * easily ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.DeploymentRepository
    * @generated
@@ -480,7 +480,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Developer <em>Developer</em>}
    * '. <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful
    * to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Developer
    * @generated
@@ -494,7 +494,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * <em>Distribution Management</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can
    * easily ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.DistributionManagement
    * @generated
@@ -507,7 +507,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.DocumentRoot
    * <em>Document Root</em>} '. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.DocumentRoot
    * @generated
@@ -520,7 +520,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Exclusion <em>Exclusion</em>}
    * '. <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful
    * to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Exclusion
    * @generated
@@ -533,7 +533,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Extension <em>Extension</em>}
    * '. <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful
    * to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Extension
    * @generated
@@ -546,7 +546,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.IssueManagement
    * <em>Issue Management</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.IssueManagement
    * @generated
@@ -559,7 +559,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.License <em>License</em>}'.
    * <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.License
    * @generated
@@ -572,7 +572,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.MailingList
    * <em>Mailing List</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.MailingList
    * @generated
@@ -585,7 +585,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Model <em>Model</em>}'. <!--
    * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Model
    * @generated
@@ -598,7 +598,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Notifier <em>Notifier</em>}'.
    * <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Notifier
    * @generated
@@ -611,7 +611,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Organization
    * <em>Organization</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Organization
    * @generated
@@ -624,7 +624,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Parent <em>Parent</em>}'. <!--
    * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Parent
    * @generated
@@ -637,7 +637,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Plugin <em>Plugin</em>}'. <!--
    * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Plugin
    * @generated
@@ -650,7 +650,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.PluginExecution
    * <em>Plugin Execution</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.PluginExecution
    * @generated
@@ -664,7 +664,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * <em>Plugin Management</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can
    * easily ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.PluginManagement
    * @generated
@@ -677,7 +677,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Prerequisites
    * <em>Prerequisites</em>} '. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Prerequisites
    * @generated
@@ -690,7 +690,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Profile <em>Profile</em>}'.
    * <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Profile
    * @generated
@@ -703,7 +703,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Relocation
    * <em>Relocation</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Relocation
    * @generated
@@ -716,7 +716,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Reporting <em>Reporting</em>}
    * '. <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful
    * to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Reporting
    * @generated
@@ -729,7 +729,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.ReportPlugin
    * <em>Report Plugin</em>} '. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.ReportPlugin
    * @generated
@@ -742,7 +742,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.ReportSet <em>Report Set</em>}
    * '. <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful
    * to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.ReportSet
    * @generated
@@ -755,7 +755,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Repository
    * <em>Repository</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Repository
    * @generated
@@ -769,7 +769,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * <em>Repository Policy</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can
    * easily ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.RepositoryPolicy
    * @generated
@@ -782,7 +782,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Resource <em>Resource</em>}'.
    * <!-- begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Resource
    * @generated
@@ -795,7 +795,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Scm <em>Scm</em>}'. <!--
    * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Scm
    * @generated
@@ -808,7 +808,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Site <em>Site</em>}'. <!--
    * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
    * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Site
    * @generated
@@ -821,7 +821,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.PropertyElement
    * <em>Property Element</em>}'. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.PropertyElement
    * @generated
@@ -834,7 +834,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
    * Creates a new adapter for an object of class ' {@link org.eclipse.m2e.model.edit.pom.Configuration
    * <em>Configuration</em>} '. <!-- begin-user-doc --> This default implementation returns null so that we can easily
    * ignore cases; it's useful to ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @see org.eclipse.m2e.model.edit.pom.Configuration
    * @generated
@@ -846,7 +846,7 @@ public class PomAdapterFactory extends AdapterFactoryImpl {
   /**
    * Creates a new adapter for the default case. <!-- begin-user-doc --> This default implementation returns null. <!--
    * end-user-doc -->
-   * 
+   *
    * @return the new adapter.
    * @generated
    */

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomResourceFactoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomResourceFactoryImpl.java
@@ -27,7 +27,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 
 /**
  * <!-- begin-user-doc --> The <b>Resource Factory</b> associated with the package. <!-- end-user-doc -->
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.util.PomResourceImpl
  */
 public class PomResourceFactoryImpl extends ResourceFactoryImpl {

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomResourceImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomResourceImpl.java
@@ -24,14 +24,14 @@ import org.eclipse.m2e.model.edit.pom.translators.SSESyncResource;
 
 /**
  * <!-- begin-user-doc --> The <b>Resource </b> associated with the package. <!-- end-user-doc -->
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.util.PomResourceFactoryImpl
  * @generated NOT
  */
 public class PomResourceImpl extends SSESyncResource {
   /**
    * Creates an instance of the resource. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param uri the URI of the new resource.
    * @generated
    */

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomSwitch.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomSwitch.java
@@ -72,21 +72,21 @@ import org.eclipse.m2e.model.edit.pom.Site;
  * {@link #doSwitch(EObject) doSwitch(object)} to invoke the <code>caseXXX</code> method for each class of the model,
  * starting with the actual class of the object and proceeding up the inheritance hierarchy until a non-null result is
  * returned, which is the result of the switch. <!-- end-user-doc -->
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage
  * @generated
  */
 public class PomSwitch<T> {
   /**
    * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected static PomPackage modelPackage;
 
   /**
    * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomSwitch() {
@@ -98,7 +98,7 @@ public class PomSwitch<T> {
   /**
    * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return the first non-null result returned by a <code>caseXXX</code> call.
    * @generated
    */
@@ -109,7 +109,7 @@ public class PomSwitch<T> {
   /**
    * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return the first non-null result returned by a <code>caseXXX</code> call.
    * @generated
    */
@@ -124,7 +124,7 @@ public class PomSwitch<T> {
   /**
    * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return the first non-null result returned by a <code>caseXXX</code> call.
    * @generated
    */
@@ -413,7 +413,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Activation</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Activation</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -426,7 +426,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Activation File</em>'. <!-- begin-user-doc
    * --> This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Activation File</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -439,7 +439,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Activation OS</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Activation OS</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -453,7 +453,7 @@ public class PomSwitch<T> {
    * Returns the result of interpreting the object as an instance of ' <em>Activation Property</em>'. <!--
    * begin-user-doc --> This implementation returns null; returning a non-null result will terminate the switch. <!--
    * end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Activation Property</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -466,7 +466,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Build</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Build</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -479,7 +479,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Build Base</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Build Base</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -492,7 +492,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Ci Management</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Ci Management</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -505,7 +505,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Contributor</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Contributor</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -518,7 +518,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Dependency</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Dependency</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -532,7 +532,7 @@ public class PomSwitch<T> {
    * Returns the result of interpreting the object as an instance of ' <em>Dependency Management</em>'. <!--
    * begin-user-doc --> This implementation returns null; returning a non-null result will terminate the switch. <!--
    * end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Dependency Management</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -546,7 +546,7 @@ public class PomSwitch<T> {
    * Returns the result of interpreting the object as an instance of ' <em>Deployment Repository</em>'. <!--
    * begin-user-doc --> This implementation returns null; returning a non-null result will terminate the switch. <!--
    * end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Deployment Repository</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -559,7 +559,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Developer</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Developer</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -573,7 +573,7 @@ public class PomSwitch<T> {
    * Returns the result of interpreting the object as an instance of ' <em>Distribution Management</em>'. <!--
    * begin-user-doc --> This implementation returns null; returning a non-null result will terminate the switch. <!--
    * end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Distribution Management</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -586,7 +586,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Document Root</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Document Root</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -599,7 +599,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Exclusion</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Exclusion</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -612,7 +612,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Extension</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Extension</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -625,7 +625,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Issue Management</em>'. <!-- begin-user-doc
    * --> This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Issue Management</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -638,7 +638,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>License</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>License</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -651,7 +651,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Mailing List</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Mailing List</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -664,7 +664,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Model</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Model</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -677,7 +677,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Notifier</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Notifier</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -690,7 +690,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Organization</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Organization</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -703,7 +703,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Parent</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Parent</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -716,7 +716,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Plugin</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Plugin</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -729,7 +729,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Plugin Execution</em>'. <!-- begin-user-doc
    * --> This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Plugin Execution</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -742,7 +742,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Plugin Management</em>'. <!-- begin-user-doc
    * --> This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Plugin Management</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -755,7 +755,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Prerequisites</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Prerequisites</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -768,7 +768,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Profile</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Profile</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -781,7 +781,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Relocation</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Relocation</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -794,7 +794,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Reporting</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Reporting</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -807,7 +807,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Report Plugin</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Report Plugin</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -820,7 +820,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Report Set</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Report Set</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -833,7 +833,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Repository</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Repository</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -846,7 +846,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Repository Policy</em>'. <!-- begin-user-doc
    * --> This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Repository Policy</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -859,7 +859,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Resource</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Resource</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -872,7 +872,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Scm</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Scm</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -885,7 +885,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Site</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Site</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -898,7 +898,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Property Element</em>'. <!-- begin-user-doc
    * --> This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Property Element</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -911,7 +911,7 @@ public class PomSwitch<T> {
   /**
    * Returns the result of interpreting the object as an instance of ' <em>Configuration</em>'. <!-- begin-user-doc -->
    * This implementation returns null; returning a non-null result will terminate the switch. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>Configuration</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
@@ -925,7 +925,7 @@ public class PomSwitch<T> {
    * Returns the result of interpreting the object as an instance of ' <em>EObject</em>'. <!-- begin-user-doc --> This
    * implementation returns null; returning a non-null result will terminate the switch, but this is the last case
    * anyway. <!-- end-user-doc -->
-   * 
+   *
    * @param object the target of the switch.
    * @return the result of interpreting the object as an instance of ' <em>EObject</em>'.
    * @see #doSwitch(org.eclipse.emf.ecore.EObject)

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomXMLProcessor.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/util/PomXMLProcessor.java
@@ -32,14 +32,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This class contains helper methods to serialize and deserialize XML documents <!-- begin-user-doc --> <!--
  * end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PomXMLProcessor extends XMLProcessor {
 
   /**
    * Public constructor to instantiate the helper. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomXMLProcessor() {
@@ -50,7 +50,7 @@ public class PomXMLProcessor extends XMLProcessor {
   /**
    * Register for "*" and "xml" file extensions the PomResourceFactoryImpl factory. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
