### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines

### DIFF
--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Reporting.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Reporting.java
@@ -28,7 +28,7 @@ import org.eclipse.emf.ecore.EObject;
  * <li>{@link org.eclipse.m2e.model.edit.pom.Reporting#getPlugins <em>Plugins </em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage#getReporting()
  * @model extendedMetaData="name='Reporting' kind='elementOnly'"
  * @generated
@@ -38,7 +38,7 @@ public interface Reporting extends EObject {
    * Returns the value of the '<em><b>Exclude Defaults</b></em>' attribute. The default value is <code>"false"</code>.
    * <!-- begin-user-doc --> <!-- end-user-doc --> <!-- begin-model-doc --> 4.0.0 If true, then the default reports are
    * not included in the site generation. This includes the reports in the "Project Info" menu. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Exclude Defaults</em>' attribute.
    * @see #isSetExcludeDefaults()
    * @see #unsetExcludeDefaults()
@@ -53,7 +53,7 @@ public interface Reporting extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Reporting#getExcludeDefaults
    * <em>Exclude Defaults</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Exclude Defaults</em>' attribute.
    * @see #isSetExcludeDefaults()
    * @see #unsetExcludeDefaults()
@@ -65,7 +65,7 @@ public interface Reporting extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Reporting#getExcludeDefaults
    * <em>Exclude Defaults</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetExcludeDefaults()
    * @see #getExcludeDefaults()
    * @see #setExcludeDefaults(String)
@@ -76,7 +76,7 @@ public interface Reporting extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Reporting#getExcludeDefaults
    * <em>Exclude Defaults</em>}' attribute is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Exclude Defaults</em>' attribute is set.
    * @see #unsetExcludeDefaults()
    * @see #getExcludeDefaults()
@@ -89,7 +89,7 @@ public interface Reporting extends EObject {
    * Returns the value of the '<em><b>Output Directory</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * --> <!-- begin-model-doc --> 4.0.0 Where to store all of the generated reports. The default is
    * &lt;code&gt;${project.build.directory}/site&lt;/code&gt; . <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Output Directory</em>' attribute.
    * @see #setOutputDirectory(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getReporting_OutputDirectory()
@@ -102,7 +102,7 @@ public interface Reporting extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Reporting#getOutputDirectory
    * <em>Output Directory</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Output Directory</em>' attribute.
    * @see #getOutputDirectory()
    * @generated
@@ -113,7 +113,7 @@ public interface Reporting extends EObject {
    * Returns the value of the '<em><b>Plugins</b></em>' containment reference list. The list contents are of type
    * {@link org.eclipse.m2e.model.edit.pom.ReportPlugin}. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 The reporting plugins to use and their configuration. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Plugins</em>' containment reference list.
    * @see #isSetPlugins()
    * @see #unsetPlugins()
@@ -127,7 +127,7 @@ public interface Reporting extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Reporting#getPlugins <em>Plugins</em>}' containment
    * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetPlugins()
    * @see #getPlugins()
    * @generated
@@ -137,7 +137,7 @@ public interface Reporting extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Reporting#getPlugins <em>Plugins</em>}'
    * containment reference list is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Plugins</em>' containment reference list is set.
    * @see #unsetPlugins()
    * @see #getPlugins()

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Repository.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Repository.java
@@ -31,7 +31,7 @@ import org.eclipse.emf.ecore.EObject;
  * <li>{@link org.eclipse.m2e.model.edit.pom.Repository#getLayout <em>Layout</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepository()
  * @model extendedMetaData="name='Repository' kind='elementOnly'"
  * @generated
@@ -41,7 +41,7 @@ public interface Repository extends EObject {
    * Returns the value of the '<em><b>Releases</b></em>' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc --> <!-- begin-model-doc --> 4.0.0 How to handle downloading of releases from this repository. <!--
    * end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Releases</em>' containment reference.
    * @see #isSetReleases()
    * @see #unsetReleases()
@@ -56,7 +56,7 @@ public interface Repository extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getReleases <em>Releases</em>}'
    * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Releases</em>' containment reference.
    * @see #isSetReleases()
    * @see #unsetReleases()
@@ -68,7 +68,7 @@ public interface Repository extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getReleases <em>Releases</em>}'
    * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetReleases()
    * @see #getReleases()
    * @see #setReleases(RepositoryPolicy)
@@ -79,7 +79,7 @@ public interface Repository extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getReleases <em>Releases</em>}'
    * containment reference is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Releases</em>' containment reference is set.
    * @see #unsetReleases()
    * @see #getReleases()
@@ -92,7 +92,7 @@ public interface Repository extends EObject {
    * Returns the value of the '<em><b>Snapshots</b></em>' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc --> <!-- begin-model-doc --> 4.0.0 How to handle downloading of snapshots from this repository. <!--
    * end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Snapshots</em>' containment reference.
    * @see #isSetSnapshots()
    * @see #unsetSnapshots()
@@ -107,7 +107,7 @@ public interface Repository extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getSnapshots <em>Snapshots</em>}'
    * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Snapshots</em>' containment reference.
    * @see #isSetSnapshots()
    * @see #unsetSnapshots()
@@ -119,7 +119,7 @@ public interface Repository extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getSnapshots <em>Snapshots</em>}'
    * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetSnapshots()
    * @see #getSnapshots()
    * @see #setSnapshots(RepositoryPolicy)
@@ -130,7 +130,7 @@ public interface Repository extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getSnapshots
    * <em>Snapshots</em>}' containment reference is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Snapshots</em>' containment reference is set.
    * @see #unsetSnapshots()
    * @see #getSnapshots()
@@ -143,7 +143,7 @@ public interface Repository extends EObject {
    * Returns the value of the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 A unique identifier for a repository. This is used to match the repository to
    * configuration in the &lt;code&gt;settings.xml&lt;/code&gt; file, for example. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Id</em>' attribute.
    * @see #setId(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepository_Id()
@@ -156,7 +156,7 @@ public interface Repository extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getId <em>Id</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Id</em>' attribute.
    * @see #getId()
    * @generated
@@ -166,7 +166,7 @@ public interface Repository extends EObject {
   /**
    * Returns the value of the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 Human readable name of the repository. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Name</em>' attribute.
    * @see #setName(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepository_Name()
@@ -179,7 +179,7 @@ public interface Repository extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getName <em>Name</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Name</em>' attribute.
    * @see #getName()
    * @generated
@@ -190,7 +190,7 @@ public interface Repository extends EObject {
    * Returns the value of the '<em><b>Url</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 The url of the repository, in the form &lt;code&gt;protocol://hostname/path&lt;/code&gt;.
    * <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Url</em>' attribute.
    * @see #setUrl(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepository_Url()
@@ -203,7 +203,7 @@ public interface Repository extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getUrl <em>Url</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Url</em>' attribute.
    * @see #getUrl()
    * @generated
@@ -214,7 +214,7 @@ public interface Repository extends EObject {
    * Returns the value of the '<em><b>Layout</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 The type of layout this repository uses for locating and storing artifacts - can be
    * &lt;code&gt;legacy&lt;/code&gt; or &lt;code&gt;default&lt;/code&gt;. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Layout</em>' attribute.
    * @see #isSetLayout()
    * @see #unsetLayout()
@@ -229,7 +229,7 @@ public interface Repository extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getLayout <em>Layout</em>} ' attribute.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Layout</em>' attribute.
    * @see #isSetLayout()
    * @see #unsetLayout()
@@ -241,7 +241,7 @@ public interface Repository extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getLayout <em>Layout</em>} ' attribute.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetLayout()
    * @see #getLayout()
    * @see #setLayout(String)
@@ -252,7 +252,7 @@ public interface Repository extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Repository#getLayout <em>Layout</em>} '
    * attribute is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Layout</em>' attribute is set.
    * @see #unsetLayout()
    * @see #getLayout()

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/RepositoryPolicy.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/RepositoryPolicy.java
@@ -27,7 +27,7 @@ import org.eclipse.emf.ecore.EObject;
  * <li>{@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy#getChecksumPolicy <em>Checksum Policy</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepositoryPolicy()
  * @model extendedMetaData="name='RepositoryPolicy' kind='elementOnly'"
  * @generated
@@ -37,7 +37,7 @@ public interface RepositoryPolicy extends EObject {
    * Returns the value of the '<em><b>Enabled</b></em>' attribute. The default value is <code>"true"</code>. <!--
    * begin-user-doc --> <!-- end-user-doc --> <!-- begin-model-doc --> 4.0.0 Whether to use this repository for
    * downloading this type of artifact. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Enabled</em>' attribute.
    * @see #isSetEnabled()
    * @see #unsetEnabled()
@@ -52,7 +52,7 @@ public interface RepositoryPolicy extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy#getEnabled <em>Enabled</em>}'
    * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Enabled</em>' attribute.
    * @see #isSetEnabled()
    * @see #unsetEnabled()
@@ -64,7 +64,7 @@ public interface RepositoryPolicy extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy#getEnabled <em>Enabled</em>}'
    * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetEnabled()
    * @see #getEnabled()
    * @see #setEnabled(String)
@@ -75,7 +75,7 @@ public interface RepositoryPolicy extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy#getEnabled
    * <em>Enabled</em>}' attribute is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Enabled</em>' attribute is set.
    * @see #unsetEnabled()
    * @see #getEnabled()
@@ -89,7 +89,7 @@ public interface RepositoryPolicy extends EObject {
    * <!-- begin-model-doc --> 4.0.0 The frequency for downloading updates - can be &lt;code&gt;always,&lt;/code&gt;
    * &lt;code&gt;daily&lt;/code&gt; (default), &lt;code&gt;interval:XXX&lt;/code&gt; (in minutes) or
    * &lt;code&gt;never&lt;/code&gt; (only if it doesn't exist locally). <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Update Policy</em>' attribute.
    * @see #setUpdatePolicy(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepositoryPolicy_UpdatePolicy()
@@ -102,7 +102,7 @@ public interface RepositoryPolicy extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy#getUpdatePolicy
    * <em>Update Policy</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Update Policy</em>' attribute.
    * @see #getUpdatePolicy()
    * @generated
@@ -114,7 +114,7 @@ public interface RepositoryPolicy extends EObject {
    * <!-- begin-model-doc --> 4.0.0 What to do when verification of an artifact checksum fails. Valid values are
    * &lt;code&gt;ignore&lt;/code&gt; , &lt;code&gt;fail&lt;/code&gt; or &lt;code&gt;warn&lt;/code&gt; (the default).
    * <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Checksum Policy</em>' attribute.
    * @see #setChecksumPolicy(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getRepositoryPolicy_ChecksumPolicy()
@@ -127,7 +127,7 @@ public interface RepositoryPolicy extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.RepositoryPolicy#getChecksumPolicy
    * <em>Checksum Policy</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Checksum Policy</em>' attribute.
    * @see #getChecksumPolicy()
    * @generated

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Resource.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Resource.java
@@ -31,7 +31,7 @@ import org.eclipse.emf.ecore.EObject;
  * <li>{@link org.eclipse.m2e.model.edit.pom.Resource#getExcludes <em>Excludes </em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage#getResource()
  * @model extendedMetaData="name='Resource' kind='elementOnly'"
  * @generated
@@ -43,7 +43,7 @@ public interface Resource extends EObject {
    * in a specific package (&lt;code&gt;org.apache.maven.messages&lt;/code&gt;), you must specify this element with this
    * value: &lt;code&gt;org/apache/maven/messages&lt;/code&gt;. This is not required if you simply put the resources in
    * that directory structure at the source, however. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Target Path</em>' attribute.
    * @see #setTargetPath(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getResource_TargetPath()
@@ -56,7 +56,7 @@ public interface Resource extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Resource#getTargetPath <em>Target Path</em>}'
    * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Target Path</em>' attribute.
    * @see #getTargetPath()
    * @generated
@@ -68,7 +68,7 @@ public interface Resource extends EObject {
    * begin-user-doc --> <!-- end-user-doc --> <!-- begin-model-doc --> 3.0.0+ Whether resources are filtered to replace
    * tokens with parameterised values or not. The values are taken from the &lt;code&gt;properties&lt;/code&gt; element
    * and from the properties in the files listed in the &lt;code&gt;filters&lt;/code&gt; element. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Filtering</em>' attribute.
    * @see #isSetFiltering()
    * @see #unsetFiltering()
@@ -83,7 +83,7 @@ public interface Resource extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Resource#getFiltering <em>Filtering</em>}' attribute.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Filtering</em>' attribute.
    * @see #isSetFiltering()
    * @see #unsetFiltering()
@@ -95,7 +95,7 @@ public interface Resource extends EObject {
   /**
    * Unsets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Resource#getFiltering <em>Filtering</em>}'
    * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetFiltering()
    * @see #getFiltering()
    * @see #setFiltering(String)
@@ -106,7 +106,7 @@ public interface Resource extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Resource#getFiltering <em>Filtering</em>}'
    * attribute is set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Filtering</em>' attribute is set.
    * @see #unsetFiltering()
    * @see #getFiltering()
@@ -119,7 +119,7 @@ public interface Resource extends EObject {
    * Returns the value of the '<em><b>Directory</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 3.0.0+ Describe the directory where the resources are stored. The path is relative to the POM.
    * <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Directory</em>' attribute.
    * @see #setDirectory(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getResource_Directory()
@@ -132,7 +132,7 @@ public interface Resource extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Resource#getDirectory <em>Directory</em>}' attribute.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Directory</em>' attribute.
    * @see #getDirectory()
    * @generated
@@ -147,7 +147,7 @@ public interface Resource extends EObject {
    * here...
    * </p>
    * <!-- end-user-doc -->
-   * 
+   *
    * @return the value of the '<em>Includes</em>' attribute list.
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getResource_Includes()
    * @model unique="false" dataType="org.eclipse.emf.ecore.xml.type.String"
@@ -163,7 +163,7 @@ public interface Resource extends EObject {
    * here...
    * </p>
    * <!-- end-user-doc -->
-   * 
+   *
    * @return the value of the '<em>Excludes</em>' attribute list.
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getResource_Excludes()
    * @model unique="false" dataType="org.eclipse.emf.ecore.xml.type.String"

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Scm.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Scm.java
@@ -28,7 +28,7 @@ import org.eclipse.emf.ecore.EObject;
  * <li>{@link org.eclipse.m2e.model.edit.pom.Scm#getUrl <em>Url</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage#getScm()
  * @model extendedMetaData="name='Scm' kind='elementOnly'"
  * @generated
@@ -41,7 +41,7 @@ public interface Scm extends EObject {
    * href="http://maven.apache.org/scm/scm-url-format.html"&gt;URL format&lt;/a&gt; and &lt;a
    * href="http://maven.apache.org/scm/scms-overview.html"&gt;list of supported SCMs&lt;/a&gt;. This connection is
    * read-only. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Connection</em>' attribute.
    * @see #setConnection(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getScm_Connection()
@@ -54,7 +54,7 @@ public interface Scm extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Scm#getConnection <em>Connection</em>}' attribute.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Connection</em>' attribute.
    * @see #getConnection()
    * @generated
@@ -65,7 +65,7 @@ public interface Scm extends EObject {
    * Returns the value of the '<em><b>Developer Connection</b></em>' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc --> <!-- begin-model-doc --> 4.0.0 Just like &lt;code&gt;connection&lt;/code&gt;, but for developers,
    * i.e. this scm connection will not be read only. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Developer Connection</em>' attribute.
    * @see #setDeveloperConnection(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getScm_DeveloperConnection()
@@ -78,7 +78,7 @@ public interface Scm extends EObject {
   /**
    * Sets the value of the ' {@link org.eclipse.m2e.model.edit.pom.Scm#getDeveloperConnection
    * <em>Developer Connection</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Developer Connection</em>' attribute.
    * @see #getDeveloperConnection()
    * @generated
@@ -89,7 +89,7 @@ public interface Scm extends EObject {
    * Returns the value of the '<em><b>Tag</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 The tag of current code. By default, it's set to HEAD during development. <!--
    * end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Tag</em>' attribute.
    * @see #isSetTag()
    * @see #unsetTag()
@@ -104,7 +104,7 @@ public interface Scm extends EObject {
   /**
    * Sets the value of the '{@link org.eclipse.m2e.model.edit.pom.Scm#getTag <em>Tag</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Tag</em>' attribute.
    * @see #isSetTag()
    * @see #unsetTag()
@@ -116,7 +116,7 @@ public interface Scm extends EObject {
   /**
    * Unsets the value of the '{@link org.eclipse.m2e.model.edit.pom.Scm#getTag <em>Tag</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #isSetTag()
    * @see #getTag()
    * @see #setTag(String)
@@ -127,7 +127,7 @@ public interface Scm extends EObject {
   /**
    * Returns whether the value of the ' {@link org.eclipse.m2e.model.edit.pom.Scm#getTag <em>Tag</em>}' attribute is
    * set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @return whether the value of the '<em>Tag</em>' attribute is set.
    * @see #unsetTag()
    * @see #getTag()
@@ -140,7 +140,7 @@ public interface Scm extends EObject {
    * Returns the value of the '<em><b>Url</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 The URL to the project's browsable SCM repository, such as ViewVC or Fisheye. <!--
    * end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Url</em>' attribute.
    * @see #setUrl(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getScm_Url()
@@ -153,7 +153,7 @@ public interface Scm extends EObject {
   /**
    * Sets the value of the '{@link org.eclipse.m2e.model.edit.pom.Scm#getUrl <em>Url</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Url</em>' attribute.
    * @see #getUrl()
    * @generated

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Site.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Site.java
@@ -27,7 +27,7 @@ import org.eclipse.emf.ecore.EObject;
  * <li>{@link org.eclipse.m2e.model.edit.pom.Site#getUrl <em>Url</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.eclipse.m2e.model.edit.pom.PomPackage#getSite()
  * @model extendedMetaData="name='Site' kind='elementOnly'"
  * @generated
@@ -37,7 +37,7 @@ public interface Site extends EObject {
    * Returns the value of the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 A unique identifier for a deployment locataion. This is used to match the site to
    * configuration in the &lt;code&gt;settings.xml&lt;/code&gt; file, for example. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Id</em>' attribute.
    * @see #setId(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getSite_Id()
@@ -50,7 +50,7 @@ public interface Site extends EObject {
   /**
    * Sets the value of the '{@link org.eclipse.m2e.model.edit.pom.Site#getId <em>Id</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Id</em>' attribute.
    * @see #getId()
    * @generated
@@ -60,7 +60,7 @@ public interface Site extends EObject {
   /**
    * Returns the value of the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 Human readable name of the deployment location. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Name</em>' attribute.
    * @see #setName(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getSite_Name()
@@ -73,7 +73,7 @@ public interface Site extends EObject {
   /**
    * Sets the value of the '{@link org.eclipse.m2e.model.edit.pom.Site#getName <em>Name</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Name</em>' attribute.
    * @see #getName()
    * @generated
@@ -84,7 +84,7 @@ public interface Site extends EObject {
    * Returns the value of the '<em><b>Url</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
    * begin-model-doc --> 4.0.0 The url of the location where website is deployed, in the form
    * &lt;code&gt;protocol://hostname/path&lt;/code&gt;. <!-- end-model-doc -->
-   * 
+   *
    * @return the value of the '<em>Url</em>' attribute.
    * @see #setUrl(String)
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#getSite_Url()
@@ -97,7 +97,7 @@ public interface Site extends EObject {
   /**
    * Sets the value of the '{@link org.eclipse.m2e.model.edit.pom.Site#getUrl <em>Url</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @param value the new value of the '<em>Url</em>' attribute.
    * @see #getUrl()
    * @generated

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationFileImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationFileImpl.java
@@ -32,14 +32,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ActivationFileImpl#getExists <em>Exists</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
   /**
    * The default value of the '{@link #getMissing() <em>Missing</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getMissing()
    * @generated
    * @ordered
@@ -49,7 +49,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
   /**
    * The cached value of the '{@link #getMissing() <em>Missing</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getMissing()
    * @generated
    * @ordered
@@ -59,7 +59,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
   /**
    * The default value of the '{@link #getExists() <em>Exists</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getExists()
    * @generated
    * @ordered
@@ -69,7 +69,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
   /**
    * The cached value of the '{@link #getExists() <em>Exists</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getExists()
    * @generated
    * @ordered
@@ -78,7 +78,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationFileImpl() {
@@ -87,7 +87,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -97,7 +97,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getMissing() {
@@ -106,7 +106,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setMissing(String newMissing) {
@@ -118,7 +118,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getExists() {
@@ -127,7 +127,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setExists(String newExists) {
@@ -139,7 +139,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -155,7 +155,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -173,7 +173,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -191,7 +191,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -207,7 +207,7 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationImpl.java
@@ -40,14 +40,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ActivationImpl#getFile <em>File </em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ActivationImpl extends EObjectImpl implements Activation {
   /**
    * The default value of the '{@link #getActiveByDefault() <em>Active By Default</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getActiveByDefault()
    * @generated
    * @ordered
@@ -57,7 +57,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
   /**
    * The cached value of the '{@link #getActiveByDefault() <em>Active By Default</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getActiveByDefault()
    * @generated
    * @ordered
@@ -66,7 +66,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * This is true if the Active By Default attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -74,7 +74,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * The default value of the '{@link #getJdk() <em>Jdk</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getJdk()
    * @generated
    * @ordered
@@ -83,7 +83,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * The cached value of the '{@link #getJdk() <em>Jdk</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getJdk()
    * @generated
    * @ordered
@@ -93,7 +93,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
   /**
    * The cached value of the '{@link #getOs() <em>Os</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOs()
    * @generated
    * @ordered
@@ -102,7 +102,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * This is true if the Os containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -111,7 +111,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
   /**
    * The cached value of the '{@link #getProperty() <em>Property</em>}' containment reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getProperty()
    * @generated
    * @ordered
@@ -120,7 +120,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * This is true if the Property containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -129,7 +129,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
   /**
    * The cached value of the '{@link #getFile() <em>File</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFile()
    * @generated
    * @ordered
@@ -138,7 +138,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * This is true if the File containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -146,7 +146,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationImpl() {
@@ -155,7 +155,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -165,7 +165,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getActiveByDefault() {
@@ -174,7 +174,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setActiveByDefault(String newActiveByDefault) {
@@ -189,7 +189,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetActiveByDefault() {
@@ -204,7 +204,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetActiveByDefault() {
@@ -213,7 +213,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getJdk() {
@@ -222,7 +222,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setJdk(String newJdk) {
@@ -234,7 +234,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationOS getOs() {
@@ -243,7 +243,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetOs(ActivationOS newOs, NotificationChain msgs) {
@@ -264,7 +264,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOs(ActivationOS newOs) {
@@ -289,7 +289,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetOs(NotificationChain msgs) {
@@ -310,7 +310,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetOs() {
@@ -331,7 +331,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetOs() {
@@ -340,7 +340,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationProperty getProperty() {
@@ -349,7 +349,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetProperty(ActivationProperty newProperty, NotificationChain msgs) {
@@ -370,7 +370,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setProperty(ActivationProperty newProperty) {
@@ -396,7 +396,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetProperty(NotificationChain msgs) {
@@ -417,7 +417,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetProperty() {
@@ -439,7 +439,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetProperty() {
@@ -448,7 +448,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationFile getFile() {
@@ -457,7 +457,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetFile(ActivationFile newFile, NotificationChain msgs) {
@@ -478,7 +478,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setFile(ActivationFile newFile) {
@@ -504,7 +504,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetFile(NotificationChain msgs) {
@@ -525,7 +525,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetFile() {
@@ -546,7 +546,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetFile() {
@@ -555,7 +555,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -573,7 +573,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -595,7 +595,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -622,7 +622,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -649,7 +649,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -671,7 +671,7 @@ public class ActivationImpl extends EObjectImpl implements Activation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationOSImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationOSImpl.java
@@ -33,14 +33,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ActivationOSImpl#getVersion <em> Version</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -49,7 +49,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -59,7 +59,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
   /**
    * The default value of the '{@link #getFamily() <em>Family</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFamily()
    * @generated
    * @ordered
@@ -69,7 +69,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
   /**
    * The cached value of the '{@link #getFamily() <em>Family</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getFamily()
    * @generated
    * @ordered
@@ -79,7 +79,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
   /**
    * The default value of the '{@link #getArch() <em>Arch</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getArch()
    * @generated
    * @ordered
@@ -88,7 +88,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * The cached value of the '{@link #getArch() <em>Arch</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getArch()
    * @generated
    * @ordered
@@ -98,7 +98,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -108,7 +108,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -117,7 +117,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationOSImpl() {
@@ -126,7 +126,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -136,7 +136,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -145,7 +145,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -157,7 +157,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getFamily() {
@@ -166,7 +166,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setFamily(String newFamily) {
@@ -178,7 +178,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArch() {
@@ -187,7 +187,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArch(String newArch) {
@@ -199,7 +199,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -208,7 +208,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -220,7 +220,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -240,7 +240,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -264,7 +264,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -288,7 +288,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -308,7 +308,7 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationPropertyImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ActivationPropertyImpl.java
@@ -32,14 +32,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ActivationPropertyImpl#getValue <em>Value</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ActivationPropertyImpl extends EObjectImpl implements ActivationProperty {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -48,7 +48,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -58,7 +58,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
   /**
    * The default value of the '{@link #getValue() <em>Value</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getValue()
    * @generated
    * @ordered
@@ -68,7 +68,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
   /**
    * The cached value of the '{@link #getValue() <em>Value</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getValue()
    * @generated
    * @ordered
@@ -77,7 +77,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ActivationPropertyImpl() {
@@ -86,7 +86,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -96,7 +96,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -105,7 +105,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -117,7 +117,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getValue() {
@@ -126,7 +126,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setValue(String newValue) {
@@ -138,7 +138,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -154,7 +154,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -172,7 +172,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -190,7 +190,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -206,7 +206,7 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/BuildBaseImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/BuildBaseImpl.java
@@ -49,14 +49,14 @@ import org.eclipse.m2e.model.edit.pom.Resource;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.BuildBaseImpl#getFilters <em> Filters</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The default value of the '{@link #getDefaultGoal() <em>Default Goal</em>} ' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDefaultGoal()
    * @generated
    * @ordered
@@ -66,7 +66,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getDefaultGoal() <em>Default Goal</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDefaultGoal()
    * @generated
    * @ordered
@@ -76,7 +76,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getResources() <em>Resources</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getResources()
    * @generated
    * @ordered
@@ -86,7 +86,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getTestResources() <em>Test Resources</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTestResources()
    * @generated
    * @ordered
@@ -96,7 +96,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The default value of the '{@link #getDirectory() <em>Directory</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDirectory()
    * @generated
    * @ordered
@@ -106,7 +106,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getDirectory() <em>Directory</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDirectory()
    * @generated
    * @ordered
@@ -116,7 +116,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The default value of the '{@link #getFinalName() <em>Final Name</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFinalName()
    * @generated
    * @ordered
@@ -126,7 +126,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getFinalName() <em>Final Name</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFinalName()
    * @generated
    * @ordered
@@ -136,7 +136,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getPluginManagement() <em>Plugin Management</em>}' containment reference. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPluginManagement()
    * @generated
    * @ordered
@@ -146,7 +146,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * This is true if the Plugin Management containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -155,7 +155,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getPlugins() <em>Plugins</em>}' containment reference list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPlugins()
    * @generated
    * @ordered
@@ -165,7 +165,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
   /**
    * The cached value of the '{@link #getFilters() <em>Filters</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFilters()
    * @generated
    * @ordered
@@ -174,7 +174,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected BuildBaseImpl() {
@@ -183,7 +183,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -193,7 +193,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDefaultGoal() {
@@ -202,7 +202,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDefaultGoal(String newDefaultGoal) {
@@ -215,7 +215,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Resource> getResources() {
@@ -228,7 +228,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetResources() {
@@ -238,7 +238,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetResources() {
@@ -247,7 +247,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Resource> getTestResources() {
@@ -260,7 +260,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetTestResources() {
@@ -270,7 +270,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetTestResources() {
@@ -279,7 +279,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDirectory() {
@@ -288,7 +288,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDirectory(String newDirectory) {
@@ -300,7 +300,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getFinalName() {
@@ -309,7 +309,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setFinalName(String newFinalName) {
@@ -321,7 +321,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PluginManagement getPluginManagement() {
@@ -330,7 +330,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetPluginManagement(PluginManagement newPluginManagement, NotificationChain msgs) {
@@ -351,7 +351,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setPluginManagement(PluginManagement newPluginManagement) {
@@ -377,7 +377,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetPluginManagement(NotificationChain msgs) {
@@ -398,7 +398,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPluginManagement() {
@@ -420,7 +420,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPluginManagement() {
@@ -429,7 +429,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Plugin> getPlugins() {
@@ -441,7 +441,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPlugins() {
@@ -451,7 +451,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPlugins() {
@@ -460,7 +460,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getFilters() {
@@ -472,7 +472,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -492,7 +492,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -520,7 +520,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -561,7 +561,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -597,7 +597,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -625,7 +625,7 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/BuildImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/BuildImpl.java
@@ -45,14 +45,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.BuildImpl#getExtensions <em> Extensions</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The default value of the '{@link #getSourceDirectory() <em>Source Directory</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getSourceDirectory()
    * @generated
    * @ordered
@@ -62,7 +62,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The cached value of the '{@link #getSourceDirectory() <em>Source Directory</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getSourceDirectory()
    * @generated
    * @ordered
@@ -72,7 +72,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The default value of the '{@link #getScriptSourceDirectory() <em>Script Source Directory</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getScriptSourceDirectory()
    * @generated
    * @ordered
@@ -82,7 +82,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The cached value of the '{@link #getScriptSourceDirectory() <em>Script Source Directory</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getScriptSourceDirectory()
    * @generated
    * @ordered
@@ -92,7 +92,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The default value of the '{@link #getTestSourceDirectory() <em>Test Source Directory</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTestSourceDirectory()
    * @generated
    * @ordered
@@ -102,7 +102,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The cached value of the '{@link #getTestSourceDirectory() <em>Test Source Directory</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTestSourceDirectory()
    * @generated
    * @ordered
@@ -112,7 +112,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The default value of the '{@link #getOutputDirectory() <em>Output Directory</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOutputDirectory()
    * @generated
    * @ordered
@@ -122,7 +122,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The cached value of the '{@link #getOutputDirectory() <em>Output Directory</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOutputDirectory()
    * @generated
    * @ordered
@@ -132,7 +132,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The default value of the '{@link #getTestOutputDirectory() <em>Test Output Directory</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTestOutputDirectory()
    * @generated
    * @ordered
@@ -142,7 +142,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The cached value of the '{@link #getTestOutputDirectory() <em>Test Output Directory</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTestOutputDirectory()
    * @generated
    * @ordered
@@ -152,7 +152,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
   /**
    * The cached value of the '{@link #getExtensions() <em>Extensions</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getExtensions()
    * @generated
    * @ordered
@@ -161,7 +161,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected BuildImpl() {
@@ -170,7 +170,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -180,7 +180,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSourceDirectory() {
@@ -189,7 +189,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSourceDirectory(String newSourceDirectory) {
@@ -202,7 +202,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getScriptSourceDirectory() {
@@ -211,7 +211,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setScriptSourceDirectory(String newScriptSourceDirectory) {
@@ -224,7 +224,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getTestSourceDirectory() {
@@ -233,7 +233,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setTestSourceDirectory(String newTestSourceDirectory) {
@@ -246,7 +246,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOutputDirectory() {
@@ -255,7 +255,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOutputDirectory(String newOutputDirectory) {
@@ -268,7 +268,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getTestOutputDirectory() {
@@ -277,7 +277,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setTestOutputDirectory(String newTestOutputDirectory) {
@@ -290,7 +290,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Extension> getExtensions() {
@@ -303,7 +303,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetExtensions() {
@@ -313,7 +313,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetExtensions() {
@@ -322,7 +322,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -336,7 +336,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -360,7 +360,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -392,7 +392,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -422,7 +422,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -451,7 +451,7 @@ public class BuildImpl extends BuildBaseImpl implements Build {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/CiManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/CiManagementImpl.java
@@ -40,14 +40,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.CiManagementImpl#getNotifiers <em>Notifiers</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class CiManagementImpl extends EObjectImpl implements CiManagement {
   /**
    * The default value of the '{@link #getSystem() <em>System</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSystem()
    * @generated
    * @ordered
@@ -57,7 +57,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
   /**
    * The cached value of the '{@link #getSystem() <em>System</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getSystem()
    * @generated
    * @ordered
@@ -66,7 +66,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -75,7 +75,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -85,7 +85,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
   /**
    * The cached value of the '{@link #getNotifiers() <em>Notifiers</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getNotifiers()
    * @generated
    * @ordered
@@ -94,7 +94,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected CiManagementImpl() {
@@ -103,7 +103,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -113,7 +113,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSystem() {
@@ -122,7 +122,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSystem(String newSystem) {
@@ -134,7 +134,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -143,7 +143,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -155,7 +155,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Notifier> getNotifiers() {
@@ -168,7 +168,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetNotifiers() {
@@ -178,7 +178,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetNotifiers() {
@@ -187,7 +187,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -201,7 +201,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -219,7 +219,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -242,7 +242,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -263,7 +263,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -281,7 +281,7 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ConfigurationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ConfigurationImpl.java
@@ -38,7 +38,7 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ConfigurationImpl#getConfigurationNode <em>Configuration Node</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated NOT
  */
 public class ConfigurationImpl extends EObjectImpl implements Configuration {
@@ -46,7 +46,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ConfigurationImpl() {
@@ -55,7 +55,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -65,7 +65,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Node getConfigurationNode() {
@@ -74,7 +74,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setConfigurationNode(Node newConfigurationNode) {
@@ -83,7 +83,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -240,7 +240,7 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
   }
 
   public void doNotify(int eventType, Object changedFeature, Object oldValue, Object newValue) {
-    // A catch-all notificator. 
+    // A catch-all notificator.
     // The configuration section can differ with every plugin, so we cannot really have a
     // static EMF model. So we'll just notify the subscribers and let them act accordingly.
     if(eNotificationRequired())

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ContributorImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ContributorImpl.java
@@ -47,14 +47,14 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ContributorImpl#getRoles <em> Roles</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -63,7 +63,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -73,7 +73,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The default value of the '{@link #getEmail() <em>Email</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getEmail()
    * @generated
    * @ordered
@@ -83,7 +83,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The cached value of the '{@link #getEmail() <em>Email</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getEmail()
    * @generated
    * @ordered
@@ -92,7 +92,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -101,7 +101,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -111,7 +111,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The default value of the '{@link #getOrganization() <em>Organization</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOrganization()
    * @generated
    * @ordered
@@ -121,7 +121,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The cached value of the '{@link #getOrganization() <em>Organization</em>} ' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOrganization()
    * @generated
    * @ordered
@@ -131,7 +131,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The default value of the '{@link #getOrganizationUrl() <em>Organization Url</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOrganizationUrl()
    * @generated
    * @ordered
@@ -141,7 +141,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The cached value of the '{@link #getOrganizationUrl() <em>Organization Url</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOrganizationUrl()
    * @generated
    * @ordered
@@ -151,7 +151,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The default value of the '{@link #getTimezone() <em>Timezone</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getTimezone()
    * @generated
    * @ordered
@@ -161,7 +161,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The cached value of the '{@link #getTimezone() <em>Timezone</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getTimezone()
    * @generated
    * @ordered
@@ -171,7 +171,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The cached value of the '{@link #getProperties() <em>Properties</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getProperties()
    * @generated
    * @ordered
@@ -181,7 +181,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
   /**
    * The cached value of the '{@link #getRoles() <em>Roles</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getRoles()
    * @generated
    * @ordered
@@ -190,7 +190,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ContributorImpl() {
@@ -199,7 +199,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -209,7 +209,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -218,7 +218,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -230,7 +230,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getEmail() {
@@ -239,7 +239,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setEmail(String newEmail) {
@@ -251,7 +251,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -260,7 +260,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -272,7 +272,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOrganization() {
@@ -281,7 +281,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOrganization(String newOrganization) {
@@ -294,7 +294,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOrganizationUrl() {
@@ -303,7 +303,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOrganizationUrl(String newOrganizationUrl) {
@@ -316,7 +316,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getTimezone() {
@@ -325,7 +325,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setTimezone(String newTimezone) {
@@ -337,7 +337,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<PropertyElement> getProperties() {
@@ -350,7 +350,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetProperties() {
@@ -360,7 +360,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetProperties() {
@@ -369,7 +369,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getRoles() {
@@ -381,7 +381,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetRoles() {
@@ -391,7 +391,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetRoles() {
@@ -400,7 +400,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -414,7 +414,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -442,7 +442,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -481,7 +481,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -517,7 +517,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -546,7 +546,7 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DependencyImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DependencyImpl.java
@@ -46,14 +46,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.DependencyImpl#getOptional <em> Optional</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -63,7 +63,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -73,7 +73,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -83,7 +83,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -93,7 +93,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -103,7 +103,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -113,7 +113,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getType() <em>Type</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getType()
    * @generated
    * @ordered
@@ -122,7 +122,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * The cached value of the '{@link #getType() <em>Type</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getType()
    * @generated
    * @ordered
@@ -131,7 +131,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * This is true if the Type attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -140,7 +140,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getClassifier() <em>Classifier</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getClassifier()
    * @generated
    * @ordered
@@ -150,7 +150,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getClassifier() <em>Classifier</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getClassifier()
    * @generated
    * @ordered
@@ -160,7 +160,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getScope() <em>Scope</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getScope()
    * @generated
    * @ordered
@@ -170,7 +170,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getScope() <em>Scope</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getScope()
    * @generated
    * @ordered
@@ -180,7 +180,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getSystemPath() <em>System Path</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSystemPath()
    * @generated
    * @ordered
@@ -190,7 +190,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getSystemPath() <em>System Path</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSystemPath()
    * @generated
    * @ordered
@@ -200,7 +200,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getExclusions() <em>Exclusions</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getExclusions()
    * @generated
    * @ordered
@@ -210,7 +210,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The default value of the '{@link #getOptional() <em>Optional</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOptional()
    * @generated
    * @ordered
@@ -220,7 +220,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
   /**
    * The cached value of the '{@link #getOptional() <em>Optional</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOptional()
    * @generated
    * @ordered
@@ -229,7 +229,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * This is true if the Optional attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -237,7 +237,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DependencyImpl() {
@@ -246,7 +246,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -256,7 +256,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -265,7 +265,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -277,7 +277,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -286,7 +286,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -299,7 +299,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -308,7 +308,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -320,7 +320,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getType() {
@@ -329,7 +329,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setType(String newType) {
@@ -343,7 +343,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetType() {
@@ -358,7 +358,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetType() {
@@ -367,7 +367,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getClassifier() {
@@ -376,7 +376,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setClassifier(String newClassifier) {
@@ -389,7 +389,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getScope() {
@@ -398,7 +398,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setScope(String newScope) {
@@ -410,7 +410,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSystemPath() {
@@ -419,7 +419,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSystemPath(String newSystemPath) {
@@ -432,7 +432,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Exclusion> getExclusions() {
@@ -445,7 +445,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetExclusions() {
@@ -455,7 +455,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetExclusions() {
@@ -464,7 +464,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOptional() {
@@ -473,7 +473,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOptional(String newOptional) {
@@ -488,7 +488,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetOptional() {
@@ -503,7 +503,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetOptional() {
@@ -512,7 +512,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -526,7 +526,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -556,7 +556,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -597,7 +597,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -636,7 +636,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -666,7 +666,7 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DependencyManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DependencyManagementImpl.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * {@link org.eclipse.m2e.model.edit.pom.impl.DependencyManagementImpl#getDependencies <em>Dependencies</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class DependencyManagementImpl extends EObjectImpl implements DependencyManagement {
   /**
    * The cached value of the '{@link #getDependencies() <em>Dependencies</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDependencies()
    * @generated
    * @ordered
@@ -54,7 +54,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DependencyManagementImpl() {
@@ -63,7 +63,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -73,7 +73,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Dependency> getDependencies() {
@@ -86,7 +86,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDependencies() {
@@ -96,7 +96,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDependencies() {
@@ -105,7 +105,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -119,7 +119,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -133,7 +133,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -150,7 +150,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -165,7 +165,7 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DeploymentRepositoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DeploymentRepositoryImpl.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * {@link org.eclipse.m2e.model.edit.pom.impl.DeploymentRepositoryImpl#getLayout <em>Layout</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentRepository {
   /**
    * The default value of the '{@link #getUniqueVersion() <em>Unique Version</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getUniqueVersion()
    * @generated
    * @ordered
@@ -55,7 +55,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
   /**
    * The cached value of the '{@link #getUniqueVersion() <em>Unique Version</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getUniqueVersion()
    * @generated
    * @ordered
@@ -64,7 +64,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * This is true if the Unique Version attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -72,7 +72,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -81,7 +81,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -91,7 +91,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -100,7 +100,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -109,7 +109,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -118,7 +118,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -128,7 +128,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
   /**
    * The default value of the '{@link #getLayout() <em>Layout</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getLayout()
    * @generated
    * @ordered
@@ -138,7 +138,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
   /**
    * The cached value of the '{@link #getLayout() <em>Layout</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getLayout()
    * @generated
    * @ordered
@@ -147,7 +147,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * This is true if the Layout attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -155,7 +155,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DeploymentRepositoryImpl() {
@@ -164,7 +164,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -174,7 +174,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUniqueVersion() {
@@ -183,7 +183,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUniqueVersion(String newUniqueVersion) {
@@ -198,7 +198,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetUniqueVersion() {
@@ -213,7 +213,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetUniqueVersion() {
@@ -222,7 +222,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -231,7 +231,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -243,7 +243,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -252,7 +252,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -264,7 +264,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -273,7 +273,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -285,7 +285,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getLayout() {
@@ -294,7 +294,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setLayout(String newLayout) {
@@ -309,7 +309,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetLayout() {
@@ -324,7 +324,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetLayout() {
@@ -333,7 +333,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -355,7 +355,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -382,7 +382,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -409,7 +409,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -431,7 +431,7 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DeveloperImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DeveloperImpl.java
@@ -48,13 +48,13 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.DeveloperImpl#getRoles <em>Roles </em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -63,7 +63,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -73,7 +73,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -82,7 +82,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -92,7 +92,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The default value of the '{@link #getEmail() <em>Email</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getEmail()
    * @generated
    * @ordered
@@ -102,7 +102,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The cached value of the '{@link #getEmail() <em>Email</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getEmail()
    * @generated
    * @ordered
@@ -111,7 +111,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -120,7 +120,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -130,7 +130,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The default value of the '{@link #getOrganization() <em>Organization</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOrganization()
    * @generated
    * @ordered
@@ -140,7 +140,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The cached value of the '{@link #getOrganization() <em>Organization</em>} ' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getOrganization()
    * @generated
    * @ordered
@@ -150,7 +150,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The default value of the '{@link #getOrganizationUrl() <em>Organization Url</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOrganizationUrl()
    * @generated
    * @ordered
@@ -160,7 +160,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The cached value of the '{@link #getOrganizationUrl() <em>Organization Url</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOrganizationUrl()
    * @generated
    * @ordered
@@ -170,7 +170,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The default value of the '{@link #getTimezone() <em>Timezone</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getTimezone()
    * @generated
    * @ordered
@@ -180,7 +180,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The cached value of the '{@link #getTimezone() <em>Timezone</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getTimezone()
    * @generated
    * @ordered
@@ -190,7 +190,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The cached value of the '{@link #getProperties() <em>Properties</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getProperties()
    * @generated
    * @ordered
@@ -200,7 +200,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
   /**
    * The cached value of the '{@link #getRoles() <em>Roles</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getRoles()
    * @generated
    * @ordered
@@ -209,7 +209,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DeveloperImpl() {
@@ -218,7 +218,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -228,7 +228,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -237,7 +237,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -249,7 +249,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -258,7 +258,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -270,7 +270,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getEmail() {
@@ -279,7 +279,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setEmail(String newEmail) {
@@ -291,7 +291,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -300,7 +300,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -312,7 +312,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOrganization() {
@@ -321,7 +321,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOrganization(String newOrganization) {
@@ -334,7 +334,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOrganizationUrl() {
@@ -343,7 +343,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOrganizationUrl(String newOrganizationUrl) {
@@ -356,7 +356,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getTimezone() {
@@ -365,7 +365,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setTimezone(String newTimezone) {
@@ -377,7 +377,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<PropertyElement> getProperties() {
@@ -390,7 +390,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetProperties() {
@@ -400,7 +400,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetProperties() {
@@ -409,7 +409,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getRoles() {
@@ -421,7 +421,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetRoles() {
@@ -431,7 +431,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetRoles() {
@@ -440,7 +440,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -454,7 +454,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -484,7 +484,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -526,7 +526,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -565,7 +565,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -596,7 +596,7 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DistributionManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DistributionManagementImpl.java
@@ -48,14 +48,14 @@ import org.eclipse.m2e.model.edit.pom.Site;
  * {@link org.eclipse.m2e.model.edit.pom.impl.DistributionManagementImpl#getStatus <em>Status</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class DistributionManagementImpl extends EObjectImpl implements DistributionManagement {
   /**
    * The cached value of the '{@link #getRepository() <em>Repository</em>}' containment reference. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getRepository()
    * @generated
    * @ordered
@@ -64,7 +64,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * This is true if the Repository containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -73,7 +73,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The cached value of the '{@link #getSnapshotRepository() <em>Snapshot Repository</em>}' containment reference. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getSnapshotRepository()
    * @generated
    * @ordered
@@ -83,7 +83,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * This is true if the Snapshot Repository containment reference has been set. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -92,7 +92,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The cached value of the '{@link #getSite() <em>Site</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSite()
    * @generated
    * @ordered
@@ -101,7 +101,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * This is true if the Site containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -110,7 +110,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The default value of the '{@link #getDownloadUrl() <em>Download Url</em>} ' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDownloadUrl()
    * @generated
    * @ordered
@@ -120,7 +120,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The cached value of the '{@link #getDownloadUrl() <em>Download Url</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDownloadUrl()
    * @generated
    * @ordered
@@ -130,7 +130,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The cached value of the '{@link #getRelocation() <em>Relocation</em>}' containment reference. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getRelocation()
    * @generated
    * @ordered
@@ -139,7 +139,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * This is true if the Relocation containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -148,7 +148,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The default value of the '{@link #getStatus() <em>Status</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getStatus()
    * @generated
    * @ordered
@@ -158,7 +158,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
   /**
    * The cached value of the '{@link #getStatus() <em>Status</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getStatus()
    * @generated
    * @ordered
@@ -167,7 +167,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DistributionManagementImpl() {
@@ -176,7 +176,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -186,7 +186,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DeploymentRepository getRepository() {
@@ -195,7 +195,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetRepository(DeploymentRepository newRepository, NotificationChain msgs) {
@@ -216,7 +216,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setRepository(DeploymentRepository newRepository) {
@@ -242,7 +242,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetRepository(NotificationChain msgs) {
@@ -263,7 +263,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetRepository() {
@@ -285,7 +285,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetRepository() {
@@ -294,7 +294,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DeploymentRepository getSnapshotRepository() {
@@ -303,7 +303,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetSnapshotRepository(DeploymentRepository newSnapshotRepository, NotificationChain msgs) {
@@ -325,7 +325,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSnapshotRepository(DeploymentRepository newSnapshotRepository) {
@@ -351,7 +351,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetSnapshotRepository(NotificationChain msgs) {
@@ -373,7 +373,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSnapshotRepository() {
@@ -395,7 +395,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSnapshotRepository() {
@@ -404,7 +404,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Site getSite() {
@@ -413,7 +413,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetSite(Site newSite, NotificationChain msgs) {
@@ -434,7 +434,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSite(Site newSite) {
@@ -460,7 +460,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetSite(NotificationChain msgs) {
@@ -481,7 +481,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSite() {
@@ -503,7 +503,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSite() {
@@ -512,7 +512,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDownloadUrl() {
@@ -521,7 +521,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDownloadUrl(String newDownloadUrl) {
@@ -534,7 +534,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Relocation getRelocation() {
@@ -543,7 +543,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetRelocation(Relocation newRelocation, NotificationChain msgs) {
@@ -564,7 +564,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setRelocation(Relocation newRelocation) {
@@ -590,7 +590,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetRelocation(NotificationChain msgs) {
@@ -611,7 +611,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetRelocation() {
@@ -633,7 +633,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetRelocation() {
@@ -642,7 +642,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getStatus() {
@@ -651,7 +651,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setStatus(String newStatus) {
@@ -664,7 +664,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -684,7 +684,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -708,7 +708,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -738,7 +738,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -768,7 +768,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -792,7 +792,7 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DocumentRootImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/DocumentRootImpl.java
@@ -43,14 +43,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.DocumentRootImpl#getProject <em> Project</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
   /**
    * The cached value of the '{@link #getMixed() <em>Mixed</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getMixed()
    * @generated
    * @ordered
@@ -60,7 +60,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
   /**
    * The cached value of the '{@link #getXMLNSPrefixMap() <em>XMLNS Prefix Map</em>}' map. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getXMLNSPrefixMap()
    * @generated
    * @ordered
@@ -70,7 +70,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
   /**
    * The cached value of the '{@link #getXSISchemaLocation() <em>XSI Schema Location</em>}' map. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getXSISchemaLocation()
    * @generated
    * @ordered
@@ -79,7 +79,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected DocumentRootImpl() {
@@ -88,7 +88,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -98,7 +98,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public FeatureMap getMixed() {
@@ -110,7 +110,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EMap<String, String> getXMLNSPrefixMap() {
@@ -123,7 +123,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EMap<String, String> getXSISchemaLocation() {
@@ -136,7 +136,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Model getProject() {
@@ -145,7 +145,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetProject(Model newProject, NotificationChain msgs) {
@@ -154,7 +154,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setProject(Model newProject) {
@@ -163,7 +163,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -183,7 +183,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -212,7 +212,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -236,7 +236,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -260,7 +260,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -280,7 +280,7 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ExclusionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ExclusionImpl.java
@@ -31,14 +31,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ExclusionImpl#getGroupId <em> Group Id</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ExclusionImpl extends EObjectImpl implements Exclusion {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -48,7 +48,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -58,7 +58,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -68,7 +68,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -77,7 +77,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ExclusionImpl() {
@@ -86,7 +86,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -96,7 +96,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -105,7 +105,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -118,7 +118,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -127,7 +127,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -139,7 +139,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -155,7 +155,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -173,7 +173,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -191,7 +191,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -207,7 +207,7 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ExtensionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ExtensionImpl.java
@@ -32,14 +32,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ExtensionImpl#getVersion <em> Version</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ExtensionImpl extends EObjectImpl implements Extension {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -49,7 +49,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -59,7 +59,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -69,7 +69,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -79,7 +79,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -89,7 +89,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -98,7 +98,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ExtensionImpl() {
@@ -107,7 +107,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -117,7 +117,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -126,7 +126,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -138,7 +138,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -147,7 +147,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -160,7 +160,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -169,7 +169,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -181,7 +181,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -199,7 +199,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -220,7 +220,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -241,7 +241,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -259,7 +259,7 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/IssueManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/IssueManagementImpl.java
@@ -32,14 +32,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.IssueManagementImpl#getUrl <em> Url</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class IssueManagementImpl extends EObjectImpl implements IssueManagement {
   /**
    * The default value of the '{@link #getSystem() <em>System</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSystem()
    * @generated
    * @ordered
@@ -49,7 +49,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
   /**
    * The cached value of the '{@link #getSystem() <em>System</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getSystem()
    * @generated
    * @ordered
@@ -58,7 +58,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -67,7 +67,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -76,7 +76,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected IssueManagementImpl() {
@@ -85,7 +85,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -95,7 +95,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSystem() {
@@ -104,7 +104,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSystem(String newSystem) {
@@ -116,7 +116,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -125,7 +125,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -137,7 +137,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -171,7 +171,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -189,7 +189,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -205,7 +205,7 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/LicenseImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/LicenseImpl.java
@@ -33,14 +33,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.LicenseImpl#getComments <em> Comments</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class LicenseImpl extends EObjectImpl implements License {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -49,7 +49,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -58,7 +58,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -67,7 +67,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -77,7 +77,7 @@ public class LicenseImpl extends EObjectImpl implements License {
   /**
    * The default value of the '{@link #getDistribution() <em>Distribution</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDistribution()
    * @generated
    * @ordered
@@ -87,7 +87,7 @@ public class LicenseImpl extends EObjectImpl implements License {
   /**
    * The cached value of the '{@link #getDistribution() <em>Distribution</em>} ' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDistribution()
    * @generated
    * @ordered
@@ -97,7 +97,7 @@ public class LicenseImpl extends EObjectImpl implements License {
   /**
    * The default value of the '{@link #getComments() <em>Comments</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getComments()
    * @generated
    * @ordered
@@ -107,7 +107,7 @@ public class LicenseImpl extends EObjectImpl implements License {
   /**
    * The cached value of the '{@link #getComments() <em>Comments</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getComments()
    * @generated
    * @ordered
@@ -116,7 +116,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected LicenseImpl() {
@@ -125,7 +125,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -135,7 +135,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -144,7 +144,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -156,7 +156,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -165,7 +165,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -177,7 +177,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDistribution() {
@@ -186,7 +186,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDistribution(String newDistribution) {
@@ -199,7 +199,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getComments() {
@@ -208,7 +208,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setComments(String newComments) {
@@ -220,7 +220,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -240,7 +240,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -264,7 +264,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -288,7 +288,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -308,7 +308,7 @@ public class LicenseImpl extends EObjectImpl implements License {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/MailingListImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/MailingListImpl.java
@@ -41,14 +41,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * {@link org.eclipse.m2e.model.edit.pom.impl.MailingListImpl#getOtherArchives <em>Other Archives</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -57,7 +57,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -67,7 +67,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The default value of the '{@link #getSubscribe() <em>Subscribe</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSubscribe()
    * @generated
    * @ordered
@@ -77,7 +77,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The cached value of the '{@link #getSubscribe() <em>Subscribe</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSubscribe()
    * @generated
    * @ordered
@@ -87,7 +87,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The default value of the '{@link #getUnsubscribe() <em>Unsubscribe</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getUnsubscribe()
    * @generated
    * @ordered
@@ -97,7 +97,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The cached value of the '{@link #getUnsubscribe() <em>Unsubscribe</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getUnsubscribe()
    * @generated
    * @ordered
@@ -107,7 +107,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The default value of the '{@link #getPost() <em>Post</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getPost()
    * @generated
    * @ordered
@@ -116,7 +116,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * The cached value of the '{@link #getPost() <em>Post</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPost()
    * @generated
    * @ordered
@@ -126,7 +126,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The default value of the '{@link #getArchive() <em>Archive</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArchive()
    * @generated
    * @ordered
@@ -136,7 +136,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The cached value of the '{@link #getArchive() <em>Archive</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArchive()
    * @generated
    * @ordered
@@ -146,7 +146,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
   /**
    * The cached value of the '{@link #getOtherArchives() <em>Other Archives</em>}' attribute list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOtherArchives()
    * @generated
    * @ordered
@@ -155,7 +155,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected MailingListImpl() {
@@ -164,7 +164,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -174,7 +174,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -183,7 +183,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -195,7 +195,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSubscribe() {
@@ -204,7 +204,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSubscribe(String newSubscribe) {
@@ -216,7 +216,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUnsubscribe() {
@@ -225,7 +225,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUnsubscribe(String newUnsubscribe) {
@@ -238,7 +238,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getPost() {
@@ -247,7 +247,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setPost(String newPost) {
@@ -259,7 +259,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArchive() {
@@ -268,7 +268,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArchive(String newArchive) {
@@ -280,7 +280,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getOtherArchives() {
@@ -292,7 +292,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetOtherArchives() {
@@ -302,7 +302,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetOtherArchives() {
@@ -311,7 +311,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -335,7 +335,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -367,7 +367,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -397,7 +397,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -421,7 +421,7 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ModelImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ModelImpl.java
@@ -86,14 +86,14 @@ import org.eclipse.m2e.model.edit.pom.Scm;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ModelImpl#getModules <em>Modules </em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getParent() <em>Parent</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getParent()
    * @generated
    * @ordered
@@ -102,7 +102,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Parent containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -111,7 +111,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getModelVersion() <em>Model Version</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getModelVersion()
    * @generated
    * @ordered
@@ -121,7 +121,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getModelVersion() <em>Model Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getModelVersion()
    * @generated
    * @ordered
@@ -131,7 +131,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -141,7 +141,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -151,7 +151,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -161,7 +161,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -171,7 +171,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getPackaging() <em>Packaging</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getPackaging()
    * @generated
    * @ordered
@@ -181,7 +181,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getPackaging() <em>Packaging</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getPackaging()
    * @generated
    * @ordered
@@ -190,7 +190,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Packaging attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -199,7 +199,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -208,7 +208,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -218,7 +218,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -228,7 +228,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -238,7 +238,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getDescription() <em>Description</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDescription()
    * @generated
    * @ordered
@@ -248,7 +248,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDescription()
    * @generated
    * @ordered
@@ -257,7 +257,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -266,7 +266,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -276,7 +276,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getPrerequisites() <em>Prerequisites</em>}' containment reference. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPrerequisites()
    * @generated
    * @ordered
@@ -285,7 +285,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Prerequisites containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -294,7 +294,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getIssueManagement() <em>Issue Management</em>}' containment reference. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getIssueManagement()
    * @generated
    * @ordered
@@ -304,7 +304,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * This is true if the Issue Management containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -313,7 +313,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getCiManagement() <em>Ci Management</em>}' containment reference. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getCiManagement()
    * @generated
    * @ordered
@@ -322,7 +322,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Ci Management containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -331,7 +331,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The default value of the '{@link #getInceptionYear() <em>Inception Year</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getInceptionYear()
    * @generated
    * @ordered
@@ -341,7 +341,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getInceptionYear() <em>Inception Year</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getInceptionYear()
    * @generated
    * @ordered
@@ -351,7 +351,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getMailingLists() <em>Mailing Lists</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getMailingLists()
    * @generated
    * @ordered
@@ -361,7 +361,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getDevelopers() <em>Developers</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDevelopers()
    * @generated
    * @ordered
@@ -371,7 +371,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getContributors() <em>Contributors</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getContributors()
    * @generated
    * @ordered
@@ -381,7 +381,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getLicenses() <em>Licenses</em>}' containment reference list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getLicenses()
    * @generated
    * @ordered
@@ -391,7 +391,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getScm() <em>Scm</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getScm()
    * @generated
    * @ordered
@@ -400,7 +400,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Scm containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -409,7 +409,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getOrganization() <em>Organization</em>} ' containment reference. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOrganization()
    * @generated
    * @ordered
@@ -418,7 +418,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Organization containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -427,7 +427,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getBuild() <em>Build</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getBuild()
    * @generated
    * @ordered
@@ -436,7 +436,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Build containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -445,7 +445,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getProfiles() <em>Profiles</em>}' containment reference list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getProfiles()
    * @generated
    * @ordered
@@ -455,7 +455,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getRepositories() <em>Repositories</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getRepositories()
    * @generated
    * @ordered
@@ -465,7 +465,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getPluginRepositories() <em>Plugin Repositories</em>}' containment reference list.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPluginRepositories()
    * @generated
    * @ordered
@@ -475,7 +475,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getDependencies() <em>Dependencies</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDependencies()
    * @generated
    * @ordered
@@ -485,7 +485,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getReporting() <em>Reporting</em>}' containment reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getReporting()
    * @generated
    * @ordered
@@ -494,7 +494,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * This is true if the Reporting containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -503,7 +503,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getDependencyManagement() <em>Dependency Management</em>}' containment reference.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDependencyManagement()
    * @generated
    * @ordered
@@ -513,7 +513,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * This is true if the Dependency Management containment reference has been set. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -522,7 +522,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getDistributionManagement() <em>Distribution Management</em>}' containment
    * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDistributionManagement()
    * @generated
    * @ordered
@@ -532,7 +532,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * This is true if the Distribution Management containment reference has been set. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -541,7 +541,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getProperties() <em>Properties</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getProperties()
    * @generated
    * @ordered
@@ -551,7 +551,7 @@ public class ModelImpl extends EObjectImpl implements Model {
   /**
    * The cached value of the '{@link #getModules() <em>Modules</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getModules()
    * @generated
    * @ordered
@@ -560,7 +560,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ModelImpl() {
@@ -569,7 +569,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -579,7 +579,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Parent getParent() {
@@ -588,7 +588,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetParent(Parent newParent, NotificationChain msgs) {
@@ -609,7 +609,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setParent(Parent newParent) {
@@ -635,7 +635,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetParent(NotificationChain msgs) {
@@ -656,7 +656,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetParent() {
@@ -677,7 +677,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetParent() {
@@ -686,7 +686,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getModelVersion() {
@@ -695,7 +695,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setModelVersion(String newModelVersion) {
@@ -708,7 +708,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -717,7 +717,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -729,7 +729,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -738,7 +738,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -750,7 +750,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getPackaging() {
@@ -759,7 +759,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setPackaging(String newPackaging) {
@@ -774,7 +774,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPackaging() {
@@ -789,7 +789,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPackaging() {
@@ -798,7 +798,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -807,7 +807,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -819,7 +819,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -828,7 +828,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -840,7 +840,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDescription() {
@@ -849,7 +849,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDescription(String newDescription) {
@@ -861,7 +861,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -870,7 +870,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -882,7 +882,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Prerequisites getPrerequisites() {
@@ -891,7 +891,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetPrerequisites(Prerequisites newPrerequisites, NotificationChain msgs) {
@@ -912,7 +912,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setPrerequisites(Prerequisites newPrerequisites) {
@@ -938,7 +938,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetPrerequisites(NotificationChain msgs) {
@@ -959,7 +959,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPrerequisites() {
@@ -981,7 +981,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPrerequisites() {
@@ -990,7 +990,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public IssueManagement getIssueManagement() {
@@ -999,7 +999,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetIssueManagement(IssueManagement newIssueManagement, NotificationChain msgs) {
@@ -1020,7 +1020,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setIssueManagement(IssueManagement newIssueManagement) {
@@ -1046,7 +1046,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetIssueManagement(NotificationChain msgs) {
@@ -1067,7 +1067,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetIssueManagement() {
@@ -1089,7 +1089,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetIssueManagement() {
@@ -1098,7 +1098,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public CiManagement getCiManagement() {
@@ -1107,7 +1107,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetCiManagement(CiManagement newCiManagement, NotificationChain msgs) {
@@ -1128,7 +1128,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setCiManagement(CiManagement newCiManagement) {
@@ -1154,7 +1154,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetCiManagement(NotificationChain msgs) {
@@ -1175,7 +1175,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetCiManagement() {
@@ -1197,7 +1197,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetCiManagement() {
@@ -1206,7 +1206,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getInceptionYear() {
@@ -1215,7 +1215,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setInceptionYear(String newInceptionYear) {
@@ -1228,7 +1228,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<MailingList> getMailingLists() {
@@ -1241,7 +1241,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetMailingLists() {
@@ -1251,7 +1251,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetMailingLists() {
@@ -1260,7 +1260,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Developer> getDevelopers() {
@@ -1273,7 +1273,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDevelopers() {
@@ -1283,7 +1283,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDevelopers() {
@@ -1292,7 +1292,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Contributor> getContributors() {
@@ -1305,7 +1305,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetContributors() {
@@ -1315,7 +1315,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetContributors() {
@@ -1324,7 +1324,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<License> getLicenses() {
@@ -1336,7 +1336,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Scm getScm() {
@@ -1345,7 +1345,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetScm(Scm newScm, NotificationChain msgs) {
@@ -1366,7 +1366,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setScm(Scm newScm) {
@@ -1389,7 +1389,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetScm(NotificationChain msgs) {
@@ -1410,7 +1410,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetScm() {
@@ -1430,7 +1430,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetScm() {
@@ -1439,7 +1439,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Organization getOrganization() {
@@ -1448,7 +1448,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetOrganization(Organization newOrganization, NotificationChain msgs) {
@@ -1469,7 +1469,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOrganization(Organization newOrganization) {
@@ -1495,7 +1495,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetOrganization(NotificationChain msgs) {
@@ -1516,7 +1516,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetOrganization() {
@@ -1538,7 +1538,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetOrganization() {
@@ -1547,7 +1547,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Build getBuild() {
@@ -1556,7 +1556,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetBuild(Build newBuild, NotificationChain msgs) {
@@ -1577,7 +1577,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setBuild(Build newBuild) {
@@ -1603,7 +1603,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetBuild(NotificationChain msgs) {
@@ -1624,7 +1624,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetBuild() {
@@ -1645,7 +1645,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetBuild() {
@@ -1654,7 +1654,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Profile> getProfiles() {
@@ -1666,7 +1666,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetProfiles() {
@@ -1676,7 +1676,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetProfiles() {
@@ -1685,7 +1685,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Repository> getRepositories() {
@@ -1698,7 +1698,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetRepositories() {
@@ -1708,7 +1708,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetRepositories() {
@@ -1717,7 +1717,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Repository> getPluginRepositories() {
@@ -1730,7 +1730,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPluginRepositories() {
@@ -1740,7 +1740,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPluginRepositories() {
@@ -1749,7 +1749,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Dependency> getDependencies() {
@@ -1762,7 +1762,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDependencies() {
@@ -1772,7 +1772,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDependencies() {
@@ -1781,7 +1781,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Reporting getReporting() {
@@ -1790,7 +1790,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetReporting(Reporting newReporting, NotificationChain msgs) {
@@ -1811,7 +1811,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setReporting(Reporting newReporting) {
@@ -1837,7 +1837,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetReporting(NotificationChain msgs) {
@@ -1858,7 +1858,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetReporting() {
@@ -1880,7 +1880,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetReporting() {
@@ -1889,7 +1889,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DependencyManagement getDependencyManagement() {
@@ -1898,7 +1898,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetDependencyManagement(DependencyManagement newDependencyManagement,
@@ -1921,7 +1921,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDependencyManagement(DependencyManagement newDependencyManagement) {
@@ -1947,7 +1947,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetDependencyManagement(NotificationChain msgs) {
@@ -1968,7 +1968,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDependencyManagement() {
@@ -1990,7 +1990,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDependencyManagement() {
@@ -1999,7 +1999,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DistributionManagement getDistributionManagement() {
@@ -2008,7 +2008,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetDistributionManagement(DistributionManagement newDistributionManagement,
@@ -2031,7 +2031,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDistributionManagement(DistributionManagement newDistributionManagement) {
@@ -2057,7 +2057,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetDistributionManagement(NotificationChain msgs) {
@@ -2078,7 +2078,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDistributionManagement() {
@@ -2100,7 +2100,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDistributionManagement() {
@@ -2109,7 +2109,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<PropertyElement> getProperties() {
@@ -2122,7 +2122,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetProperties() {
@@ -2132,7 +2132,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetProperties() {
@@ -2141,7 +2141,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getModules() {
@@ -2153,7 +2153,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -2203,7 +2203,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -2273,7 +2273,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -2383,7 +2383,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -2482,7 +2482,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -2552,7 +2552,7 @@ public class ModelImpl extends EObjectImpl implements Model {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/NotifierImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/NotifierImpl.java
@@ -44,14 +44,14 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.NotifierImpl#getConfiguration <em>Configuration</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The default value of the '{@link #getType() <em>Type</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getType()
    * @generated
    * @ordered
@@ -60,7 +60,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * The cached value of the '{@link #getType() <em>Type</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getType()
    * @generated
    * @ordered
@@ -69,7 +69,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * This is true if the Type attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -78,7 +78,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The default value of the '{@link #getSendOnError() <em>Send On Error</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSendOnError()
    * @generated
    * @ordered
@@ -88,7 +88,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The cached value of the '{@link #getSendOnError() <em>Send On Error</em>} ' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getSendOnError()
    * @generated
    * @ordered
@@ -97,7 +97,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * This is true if the Send On Error attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -106,7 +106,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The default value of the '{@link #getSendOnFailure() <em>Send On Failure</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSendOnFailure()
    * @generated
    * @ordered
@@ -116,7 +116,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The cached value of the '{@link #getSendOnFailure() <em>Send On Failure</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSendOnFailure()
    * @generated
    * @ordered
@@ -125,7 +125,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * This is true if the Send On Failure attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -134,7 +134,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The default value of the '{@link #getSendOnSuccess() <em>Send On Success</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSendOnSuccess()
    * @generated
    * @ordered
@@ -144,7 +144,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The cached value of the '{@link #getSendOnSuccess() <em>Send On Success</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSendOnSuccess()
    * @generated
    * @ordered
@@ -153,7 +153,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * This is true if the Send On Success attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -162,7 +162,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The default value of the '{@link #getSendOnWarning() <em>Send On Warning</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSendOnWarning()
    * @generated
    * @ordered
@@ -172,7 +172,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The cached value of the '{@link #getSendOnWarning() <em>Send On Warning</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSendOnWarning()
    * @generated
    * @ordered
@@ -181,7 +181,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * This is true if the Send On Warning attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -190,7 +190,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The default value of the '{@link #getAddress() <em>Address</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getAddress()
    * @generated
    * @ordered
@@ -200,7 +200,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The cached value of the '{@link #getAddress() <em>Address</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getAddress()
    * @generated
    * @ordered
@@ -210,7 +210,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
   /**
    * The cached value of the '{@link #getConfiguration() <em>Configuration</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getConfiguration()
    * @generated
    * @ordered
@@ -219,7 +219,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected NotifierImpl() {
@@ -228,7 +228,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -238,7 +238,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getType() {
@@ -247,7 +247,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setType(String newType) {
@@ -261,7 +261,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetType() {
@@ -276,7 +276,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetType() {
@@ -285,7 +285,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSendOnError() {
@@ -294,7 +294,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSendOnError(String newSendOnError) {
@@ -309,7 +309,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSendOnError() {
@@ -324,7 +324,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSendOnError() {
@@ -333,7 +333,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSendOnFailure() {
@@ -342,7 +342,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSendOnFailure(String newSendOnFailure) {
@@ -357,7 +357,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSendOnFailure() {
@@ -372,7 +372,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSendOnFailure() {
@@ -381,7 +381,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSendOnSuccess() {
@@ -390,7 +390,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSendOnSuccess(String newSendOnSuccess) {
@@ -405,7 +405,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSendOnSuccess() {
@@ -420,7 +420,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSendOnSuccess() {
@@ -429,7 +429,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getSendOnWarning() {
@@ -438,7 +438,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSendOnWarning(String newSendOnWarning) {
@@ -453,7 +453,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSendOnWarning() {
@@ -468,7 +468,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSendOnWarning() {
@@ -477,7 +477,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getAddress() {
@@ -486,7 +486,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setAddress(String newAddress) {
@@ -498,7 +498,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<PropertyElement> getConfiguration() {
@@ -511,7 +511,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetConfiguration() {
@@ -521,7 +521,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetConfiguration() {
@@ -530,7 +530,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -544,7 +544,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -570,7 +570,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -605,7 +605,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -638,7 +638,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -664,7 +664,7 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/OrganizationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/OrganizationImpl.java
@@ -31,14 +31,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.OrganizationImpl#getUrl <em>Url </em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class OrganizationImpl extends EObjectImpl implements Organization {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -47,7 +47,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -56,7 +56,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -65,7 +65,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -74,7 +74,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected OrganizationImpl() {
@@ -83,7 +83,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -93,7 +93,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -102,7 +102,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -114,7 +114,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -123,7 +123,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -135,7 +135,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -151,7 +151,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -169,7 +169,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -187,7 +187,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -203,7 +203,7 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ParentImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ParentImpl.java
@@ -33,14 +33,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ParentImpl#getRelativePath <em> Relative Path</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -50,7 +50,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -60,7 +60,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -70,7 +70,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -80,7 +80,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -90,7 +90,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -100,7 +100,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The default value of the '{@link #getRelativePath() <em>Relative Path</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getRelativePath()
    * @generated
    * @ordered
@@ -110,7 +110,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
   /**
    * The cached value of the '{@link #getRelativePath() <em>Relative Path</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getRelativePath()
    * @generated
    * @ordered
@@ -119,7 +119,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ParentImpl() {
@@ -128,7 +128,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -138,7 +138,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -147,7 +147,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -159,7 +159,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -168,7 +168,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -180,7 +180,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -189,7 +189,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -201,7 +201,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getRelativePath() {
@@ -210,7 +210,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setRelativePath(String newRelativePath) {
@@ -223,7 +223,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -243,7 +243,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -267,7 +267,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -291,7 +291,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -311,7 +311,7 @@ public class ParentImpl extends EObjectImpl implements Parent {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginExecutionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginExecutionImpl.java
@@ -43,13 +43,13 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * {@link org.eclipse.m2e.model.edit.pom.impl.PluginExecutionImpl#getConfiguration <em>Configuration</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class PluginExecutionImpl extends EObjectImpl implements PluginExecution {
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -58,7 +58,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -67,7 +67,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * This is true if the Id attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -76,7 +76,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
   /**
    * The default value of the '{@link #getPhase() <em>Phase</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getPhase()
    * @generated
    * @ordered
@@ -86,7 +86,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
   /**
    * The cached value of the '{@link #getPhase() <em>Phase</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getPhase()
    * @generated
    * @ordered
@@ -96,7 +96,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
   /**
    * The default value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -106,7 +106,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
   /**
    * The cached value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -116,7 +116,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
   /**
    * The cached value of the '{@link #getGoals() <em>Goals</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGoals()
    * @generated
    * @ordered
@@ -126,7 +126,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
   /**
    * The cached value of the '{@link #getConfiguration() <em>Configuration</em>}' reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getConfiguration()
    * @generated
    * @ordered
@@ -135,7 +135,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PluginExecutionImpl() {
@@ -144,7 +144,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -154,7 +154,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -163,7 +163,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -177,7 +177,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetId() {
@@ -192,7 +192,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetId() {
@@ -201,7 +201,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getPhase() {
@@ -210,7 +210,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setPhase(String newPhase) {
@@ -222,7 +222,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getInherited() {
@@ -231,7 +231,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setInherited(String newInherited) {
@@ -244,7 +244,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getGoals() {
@@ -256,7 +256,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration getConfiguration() {
@@ -274,7 +274,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration basicGetConfiguration() {
@@ -283,7 +283,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setConfiguration(Configuration newConfiguration) {
@@ -296,7 +296,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -320,7 +320,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -349,7 +349,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -376,7 +376,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -398,7 +398,7 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginImpl.java
@@ -47,14 +47,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.PluginImpl#getConfiguration <em> Configuration</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -64,7 +64,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -73,7 +73,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * This is true if the Group Id attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -82,7 +82,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -92,7 +92,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -102,7 +102,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -112,7 +112,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -122,7 +122,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The default value of the '{@link #getExtensions() <em>Extensions</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getExtensions()
    * @generated
    * @ordered
@@ -132,7 +132,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getExtensions() <em>Extensions</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getExtensions()
    * @generated
    * @ordered
@@ -141,7 +141,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * This is true if the Extensions attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -150,7 +150,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getExecutions() <em>Executions</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getExecutions()
    * @generated
    * @ordered
@@ -160,7 +160,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getDependencies() <em>Dependencies</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDependencies()
    * @generated
    * @ordered
@@ -170,7 +170,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The default value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -180,7 +180,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -190,7 +190,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
   /**
    * The cached value of the '{@link #getConfiguration() <em>Configuration</em>}' reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getConfiguration()
    * @generated
    * @ordered
@@ -199,7 +199,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PluginImpl() {
@@ -208,7 +208,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -218,7 +218,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -227,7 +227,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -242,7 +242,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetGroupId() {
@@ -257,7 +257,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetGroupId() {
@@ -266,7 +266,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -275,7 +275,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -287,7 +287,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -296,7 +296,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -308,7 +308,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getExtensions() {
@@ -317,7 +317,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setExtensions(String newExtensions) {
@@ -332,7 +332,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetExtensions() {
@@ -347,7 +347,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetExtensions() {
@@ -356,7 +356,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<PluginExecution> getExecutions() {
@@ -369,7 +369,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetExecutions() {
@@ -379,7 +379,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetExecutions() {
@@ -388,7 +388,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Dependency> getDependencies() {
@@ -401,7 +401,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDependencies() {
@@ -411,7 +411,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDependencies() {
@@ -420,7 +420,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getInherited() {
@@ -429,7 +429,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setInherited(String newInherited) {
@@ -441,7 +441,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration getConfiguration() {
@@ -459,7 +459,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration basicGetConfiguration() {
@@ -468,7 +468,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setConfiguration(Configuration newConfiguration) {
@@ -481,7 +481,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -497,7 +497,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -527,7 +527,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -566,7 +566,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -602,7 +602,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -630,7 +630,7 @@ public class PluginImpl extends EObjectImpl implements Plugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PluginManagementImpl.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.PluginManagementImpl#getPlugins <em>Plugins</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class PluginManagementImpl extends EObjectImpl implements PluginManagement {
   /**
    * The cached value of the '{@link #getPlugins() <em>Plugins</em>}' containment reference list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPlugins()
    * @generated
    * @ordered
@@ -53,7 +53,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PluginManagementImpl() {
@@ -62,7 +62,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -72,7 +72,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Plugin> getPlugins() {
@@ -84,7 +84,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -98,7 +98,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -112,7 +112,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -129,7 +129,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -144,7 +144,7 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PomFactoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PomFactoryImpl.java
@@ -64,13 +64,13 @@ import org.eclipse.m2e.model.edit.pom.Site;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
   /**
    * Creates the default factory implementation. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public static PomFactory init() {
@@ -88,7 +88,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomFactoryImpl() {
@@ -97,7 +97,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -189,7 +189,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Activation createActivation() {
@@ -199,7 +199,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationFile createActivationFile() {
@@ -209,7 +209,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationOS createActivationOS() {
@@ -219,7 +219,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationProperty createActivationProperty() {
@@ -229,7 +229,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Build createBuild() {
@@ -239,7 +239,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public BuildBase createBuildBase() {
@@ -249,7 +249,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public CiManagement createCiManagement() {
@@ -259,7 +259,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Contributor createContributor() {
@@ -269,7 +269,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Dependency createDependency() {
@@ -279,7 +279,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DependencyManagement createDependencyManagement() {
@@ -289,7 +289,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DeploymentRepository createDeploymentRepository() {
@@ -299,7 +299,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Developer createDeveloper() {
@@ -309,7 +309,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DistributionManagement createDistributionManagement() {
@@ -319,7 +319,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DocumentRoot createDocumentRoot() {
@@ -329,7 +329,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Exclusion createExclusion() {
@@ -339,7 +339,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Extension createExtension() {
@@ -349,7 +349,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public IssueManagement createIssueManagement() {
@@ -359,7 +359,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public License createLicense() {
@@ -369,7 +369,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public MailingList createMailingList() {
@@ -379,7 +379,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Model createModel() {
@@ -389,7 +389,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Notifier createNotifier() {
@@ -399,7 +399,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Organization createOrganization() {
@@ -409,7 +409,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Parent createParent() {
@@ -419,7 +419,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Plugin createPlugin() {
@@ -429,7 +429,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PluginExecution createPluginExecution() {
@@ -439,7 +439,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PluginManagement createPluginManagement() {
@@ -449,7 +449,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Prerequisites createPrerequisites() {
@@ -459,7 +459,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Profile createProfile() {
@@ -469,7 +469,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Relocation createRelocation() {
@@ -479,7 +479,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Reporting createReporting() {
@@ -489,7 +489,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ReportPlugin createReportPlugin() {
@@ -499,7 +499,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ReportSet createReportSet() {
@@ -509,7 +509,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Repository createRepository() {
@@ -519,7 +519,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public RepositoryPolicy createRepositoryPolicy() {
@@ -529,7 +529,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Resource createResource() {
@@ -539,7 +539,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Scm createScm() {
@@ -549,7 +549,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Site createSite() {
@@ -559,7 +559,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PropertyElement createPropertyElement() {
@@ -569,7 +569,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration createConfiguration() {
@@ -579,7 +579,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomPackage getPomPackage() {
@@ -588,7 +588,7 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @deprecated
    * @generated
    */

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PomPackageImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PomPackageImpl.java
@@ -65,279 +65,279 @@ import org.eclipse.m2e.model.edit.pom.Site;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class PomPackageImpl extends EPackageImpl implements PomPackage {
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass activationEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass activationFileEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass activationOSEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass activationPropertyEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass buildEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass buildBaseEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass ciManagementEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass contributorEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass dependencyEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass dependencyManagementEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass deploymentRepositoryEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass developerEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass distributionManagementEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass documentRootEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass exclusionEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass extensionEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass issueManagementEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass licenseEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass mailingListEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass modelEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass notifierEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass organizationEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass parentEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass pluginEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass pluginExecutionEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass pluginManagementEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass prerequisitesEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass profileEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass relocationEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass reportingEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass reportPluginEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass reportSetEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass repositoryEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass repositoryPolicyEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass resourceEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass scmEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass siteEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass propertyElementEClass = null;
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private EClass configurationEClass = null;
@@ -349,7 +349,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
    * Note: the correct way to create the package is via the static factory method {@link #init init()}, which also
    * performs initialization of the package, or returns the registered package, if one already exists. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see org.eclipse.emf.ecore.EPackage.Registry
    * @see org.eclipse.m2e.model.edit.pom.PomPackage#eNS_URI
    * @see #init()
@@ -361,7 +361,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private static boolean isInited = false;
@@ -378,7 +378,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
    * <p>
    * Invocation of this method will not affect any packages that have already been initialized. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #eNS_URI
    * @see #createPackageContents()
    * @see #initializePackageContents()
@@ -411,7 +411,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getActivation() {
@@ -420,7 +420,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivation_ActiveByDefault() {
@@ -429,7 +429,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivation_Jdk() {
@@ -438,7 +438,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getActivation_Os() {
@@ -447,7 +447,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getActivation_Property() {
@@ -456,7 +456,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getActivation_File() {
@@ -465,7 +465,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getActivationFile() {
@@ -474,7 +474,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationFile_Missing() {
@@ -483,7 +483,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationFile_Exists() {
@@ -492,7 +492,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getActivationOS() {
@@ -501,7 +501,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationOS_Name() {
@@ -510,7 +510,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationOS_Family() {
@@ -519,7 +519,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationOS_Arch() {
@@ -528,7 +528,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationOS_Version() {
@@ -537,7 +537,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getActivationProperty() {
@@ -546,7 +546,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationProperty_Name() {
@@ -555,7 +555,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getActivationProperty_Value() {
@@ -564,7 +564,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getBuild() {
@@ -573,7 +573,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuild_SourceDirectory() {
@@ -582,7 +582,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuild_ScriptSourceDirectory() {
@@ -591,7 +591,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuild_TestSourceDirectory() {
@@ -600,7 +600,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuild_OutputDirectory() {
@@ -609,7 +609,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuild_TestOutputDirectory() {
@@ -618,7 +618,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getBuild_Extensions() {
@@ -627,7 +627,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getBuildBase() {
@@ -636,7 +636,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuildBase_DefaultGoal() {
@@ -645,7 +645,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getBuildBase_Resources() {
@@ -654,7 +654,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getBuildBase_TestResources() {
@@ -663,7 +663,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuildBase_Directory() {
@@ -672,7 +672,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuildBase_FinalName() {
@@ -681,7 +681,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getBuildBase_PluginManagement() {
@@ -690,7 +690,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getBuildBase_Plugins() {
@@ -699,7 +699,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getBuildBase_Filters() {
@@ -708,7 +708,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getCiManagement() {
@@ -717,7 +717,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getCiManagement_System() {
@@ -726,7 +726,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getCiManagement_Url() {
@@ -735,7 +735,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getCiManagement_Notifiers() {
@@ -744,7 +744,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getContributor() {
@@ -753,7 +753,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_Name() {
@@ -762,7 +762,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_Email() {
@@ -771,7 +771,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_Url() {
@@ -780,7 +780,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_Organization() {
@@ -789,7 +789,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_OrganizationUrl() {
@@ -798,7 +798,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_Timezone() {
@@ -807,7 +807,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getContributor_Properties() {
@@ -816,7 +816,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getContributor_Roles() {
@@ -825,7 +825,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getDependency() {
@@ -834,7 +834,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_GroupId() {
@@ -843,7 +843,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_ArtifactId() {
@@ -852,7 +852,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_Version() {
@@ -861,7 +861,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_Type() {
@@ -870,7 +870,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_Classifier() {
@@ -879,7 +879,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_Scope() {
@@ -888,7 +888,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_SystemPath() {
@@ -897,7 +897,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDependency_Exclusions() {
@@ -906,7 +906,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDependency_Optional() {
@@ -915,7 +915,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getDependencyManagement() {
@@ -924,7 +924,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDependencyManagement_Dependencies() {
@@ -933,7 +933,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getDeploymentRepository() {
@@ -942,7 +942,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeploymentRepository_UniqueVersion() {
@@ -951,7 +951,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeploymentRepository_Id() {
@@ -960,7 +960,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeploymentRepository_Name() {
@@ -969,7 +969,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeploymentRepository_Url() {
@@ -978,7 +978,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeploymentRepository_Layout() {
@@ -987,7 +987,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getDeveloper() {
@@ -996,7 +996,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Id() {
@@ -1005,7 +1005,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Name() {
@@ -1014,7 +1014,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Email() {
@@ -1023,7 +1023,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Url() {
@@ -1032,7 +1032,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Organization() {
@@ -1041,7 +1041,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_OrganizationUrl() {
@@ -1050,7 +1050,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Timezone() {
@@ -1059,7 +1059,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDeveloper_Properties() {
@@ -1068,7 +1068,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDeveloper_Roles() {
@@ -1077,7 +1077,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getDistributionManagement() {
@@ -1086,7 +1086,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDistributionManagement_Repository() {
@@ -1095,7 +1095,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDistributionManagement_SnapshotRepository() {
@@ -1104,7 +1104,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDistributionManagement_Site() {
@@ -1113,7 +1113,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDistributionManagement_DownloadUrl() {
@@ -1122,7 +1122,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDistributionManagement_Relocation() {
@@ -1131,7 +1131,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDistributionManagement_Status() {
@@ -1140,7 +1140,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getDocumentRoot() {
@@ -1149,7 +1149,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getDocumentRoot_Mixed() {
@@ -1158,7 +1158,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDocumentRoot_XMLNSPrefixMap() {
@@ -1167,7 +1167,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDocumentRoot_XSISchemaLocation() {
@@ -1176,7 +1176,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getDocumentRoot_Project() {
@@ -1185,7 +1185,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getExclusion() {
@@ -1194,7 +1194,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getExclusion_ArtifactId() {
@@ -1203,7 +1203,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getExclusion_GroupId() {
@@ -1212,7 +1212,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getExtension() {
@@ -1221,7 +1221,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getExtension_GroupId() {
@@ -1230,7 +1230,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getExtension_ArtifactId() {
@@ -1239,7 +1239,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getExtension_Version() {
@@ -1248,7 +1248,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getIssueManagement() {
@@ -1257,7 +1257,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getIssueManagement_System() {
@@ -1266,7 +1266,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getIssueManagement_Url() {
@@ -1275,7 +1275,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getLicense() {
@@ -1284,7 +1284,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getLicense_Name() {
@@ -1293,7 +1293,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getLicense_Url() {
@@ -1302,7 +1302,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getLicense_Distribution() {
@@ -1311,7 +1311,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getLicense_Comments() {
@@ -1320,7 +1320,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getMailingList() {
@@ -1329,7 +1329,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getMailingList_Name() {
@@ -1338,7 +1338,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getMailingList_Subscribe() {
@@ -1347,7 +1347,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getMailingList_Unsubscribe() {
@@ -1356,7 +1356,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getMailingList_Post() {
@@ -1365,7 +1365,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getMailingList_Archive() {
@@ -1374,7 +1374,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getMailingList_OtherArchives() {
@@ -1383,7 +1383,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getModel() {
@@ -1392,7 +1392,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Parent() {
@@ -1401,7 +1401,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_ModelVersion() {
@@ -1410,7 +1410,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_GroupId() {
@@ -1419,7 +1419,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_ArtifactId() {
@@ -1428,7 +1428,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_Packaging() {
@@ -1437,7 +1437,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_Name() {
@@ -1446,7 +1446,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_Version() {
@@ -1455,7 +1455,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_Description() {
@@ -1464,7 +1464,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_Url() {
@@ -1473,7 +1473,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Prerequisites() {
@@ -1482,7 +1482,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_IssueManagement() {
@@ -1491,7 +1491,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_CiManagement() {
@@ -1500,7 +1500,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_InceptionYear() {
@@ -1509,7 +1509,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_MailingLists() {
@@ -1518,7 +1518,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Developers() {
@@ -1527,7 +1527,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Contributors() {
@@ -1536,7 +1536,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Licenses() {
@@ -1545,7 +1545,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Scm() {
@@ -1554,7 +1554,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Organization() {
@@ -1563,7 +1563,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Build() {
@@ -1572,7 +1572,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Profiles() {
@@ -1581,7 +1581,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Repositories() {
@@ -1590,7 +1590,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_PluginRepositories() {
@@ -1599,7 +1599,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Dependencies() {
@@ -1608,7 +1608,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Reporting() {
@@ -1617,7 +1617,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_DependencyManagement() {
@@ -1626,7 +1626,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_DistributionManagement() {
@@ -1635,7 +1635,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getModel_Properties() {
@@ -1644,7 +1644,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getModel_Modules() {
@@ -1653,7 +1653,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getNotifier() {
@@ -1662,7 +1662,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getNotifier_Type() {
@@ -1671,7 +1671,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getNotifier_SendOnError() {
@@ -1680,7 +1680,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getNotifier_SendOnFailure() {
@@ -1689,7 +1689,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getNotifier_SendOnSuccess() {
@@ -1698,7 +1698,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getNotifier_SendOnWarning() {
@@ -1707,7 +1707,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getNotifier_Address() {
@@ -1716,7 +1716,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getNotifier_Configuration() {
@@ -1725,7 +1725,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getOrganization() {
@@ -1734,7 +1734,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getOrganization_Name() {
@@ -1743,7 +1743,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getOrganization_Url() {
@@ -1752,7 +1752,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getParent() {
@@ -1761,7 +1761,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getParent_ArtifactId() {
@@ -1770,7 +1770,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getParent_GroupId() {
@@ -1779,7 +1779,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getParent_Version() {
@@ -1788,7 +1788,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getParent_RelativePath() {
@@ -1797,7 +1797,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getPlugin() {
@@ -1806,7 +1806,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPlugin_GroupId() {
@@ -1815,7 +1815,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPlugin_ArtifactId() {
@@ -1824,7 +1824,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPlugin_Version() {
@@ -1833,7 +1833,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPlugin_Extensions() {
@@ -1842,7 +1842,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getPlugin_Executions() {
@@ -1851,7 +1851,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getPlugin_Dependencies() {
@@ -1860,7 +1860,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPlugin_Inherited() {
@@ -1869,7 +1869,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getPlugin_Configuration() {
@@ -1878,7 +1878,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getPluginExecution() {
@@ -1887,7 +1887,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPluginExecution_Id() {
@@ -1896,7 +1896,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPluginExecution_Phase() {
@@ -1905,7 +1905,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPluginExecution_Inherited() {
@@ -1914,7 +1914,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPluginExecution_Goals() {
@@ -1923,7 +1923,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getPluginExecution_Configuration() {
@@ -1932,7 +1932,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getPluginManagement() {
@@ -1941,7 +1941,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getPluginManagement_Plugins() {
@@ -1950,7 +1950,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getPrerequisites() {
@@ -1959,7 +1959,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPrerequisites_Maven() {
@@ -1968,7 +1968,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getProfile() {
@@ -1977,7 +1977,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getProfile_Id() {
@@ -1986,7 +1986,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Activation() {
@@ -1995,7 +1995,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Build() {
@@ -2004,7 +2004,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Repositories() {
@@ -2013,7 +2013,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_PluginRepositories() {
@@ -2022,7 +2022,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Dependencies() {
@@ -2031,7 +2031,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Reports() {
@@ -2040,7 +2040,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_DependencyManagement() {
@@ -2049,7 +2049,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_DistributionManagement() {
@@ -2058,7 +2058,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Properties() {
@@ -2067,7 +2067,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getProfile_Modules() {
@@ -2076,7 +2076,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getProfile_Reporting() {
@@ -2085,7 +2085,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getRelocation() {
@@ -2094,7 +2094,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRelocation_GroupId() {
@@ -2103,7 +2103,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRelocation_ArtifactId() {
@@ -2112,7 +2112,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRelocation_Version() {
@@ -2121,7 +2121,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRelocation_Message() {
@@ -2130,7 +2130,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getReporting() {
@@ -2139,7 +2139,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReporting_ExcludeDefaults() {
@@ -2148,7 +2148,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReporting_OutputDirectory() {
@@ -2157,7 +2157,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getReporting_Plugins() {
@@ -2166,7 +2166,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getReportPlugin() {
@@ -2175,7 +2175,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportPlugin_GroupId() {
@@ -2184,7 +2184,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportPlugin_ArtifactId() {
@@ -2193,7 +2193,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportPlugin_Version() {
@@ -2202,7 +2202,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportPlugin_Inherited() {
@@ -2211,7 +2211,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getReportPlugin_ReportSets() {
@@ -2220,7 +2220,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getReportPlugin_Configuration() {
@@ -2229,7 +2229,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getReportSet() {
@@ -2238,7 +2238,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportSet_Id() {
@@ -2247,7 +2247,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportSet_Inherited() {
@@ -2256,7 +2256,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getReportSet_Reports() {
@@ -2265,7 +2265,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getReportSet_Configuration() {
@@ -2274,7 +2274,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getRepository() {
@@ -2283,7 +2283,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getRepository_Releases() {
@@ -2292,7 +2292,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EReference getRepository_Snapshots() {
@@ -2301,7 +2301,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepository_Id() {
@@ -2310,7 +2310,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepository_Name() {
@@ -2319,7 +2319,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepository_Url() {
@@ -2328,7 +2328,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepository_Layout() {
@@ -2337,7 +2337,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getRepositoryPolicy() {
@@ -2346,7 +2346,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepositoryPolicy_Enabled() {
@@ -2355,7 +2355,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepositoryPolicy_UpdatePolicy() {
@@ -2364,7 +2364,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getRepositoryPolicy_ChecksumPolicy() {
@@ -2373,7 +2373,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getResource() {
@@ -2382,7 +2382,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getResource_TargetPath() {
@@ -2391,7 +2391,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getResource_Filtering() {
@@ -2400,7 +2400,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getResource_Directory() {
@@ -2409,7 +2409,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getResource_Includes() {
@@ -2418,7 +2418,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getResource_Excludes() {
@@ -2427,7 +2427,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getScm() {
@@ -2436,7 +2436,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getScm_Connection() {
@@ -2445,7 +2445,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getScm_DeveloperConnection() {
@@ -2454,7 +2454,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getScm_Tag() {
@@ -2463,7 +2463,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getScm_Url() {
@@ -2472,7 +2472,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getSite() {
@@ -2481,7 +2481,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getSite_Id() {
@@ -2490,7 +2490,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getSite_Name() {
@@ -2499,7 +2499,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getSite_Url() {
@@ -2508,7 +2508,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getPropertyElement() {
@@ -2517,7 +2517,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPropertyElement_Name() {
@@ -2526,7 +2526,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EAttribute getPropertyElement_Value() {
@@ -2535,7 +2535,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EClass getConfiguration() {
@@ -2544,7 +2544,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public PomFactory getPomFactory() {
@@ -2553,7 +2553,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private boolean isCreated = false;
@@ -2561,7 +2561,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
   /**
    * Creates the meta-model objects for the package. This method is guarded to have no affect on any invocation but its
    * first. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void createPackageContents() {
@@ -2849,7 +2849,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   private boolean isInitialized = false;
@@ -2857,7 +2857,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
   /**
    * Complete the initialization of the package and its meta-model. This method is guarded to have no affect on any
    * invocation but its first. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void initializePackageContents() {
@@ -3496,7 +3496,7 @@ public class PomPackageImpl extends EPackageImpl implements PomPackage {
   /**
    * Initializes the annotations for <b>http:///org/eclipse/emf/ecore/util/ExtendedMetaData</b>. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void createExtendedMetaDataAnnotations() {

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PrerequisitesImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PrerequisitesImpl.java
@@ -30,14 +30,14 @@ import org.eclipse.m2e.model.edit.pom.Prerequisites;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.PrerequisitesImpl#getMaven <em> Maven</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
   /**
    * The default value of the '{@link #getMaven() <em>Maven</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getMaven()
    * @generated
    * @ordered
@@ -47,7 +47,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
   /**
    * The cached value of the '{@link #getMaven() <em>Maven</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getMaven()
    * @generated
    * @ordered
@@ -56,7 +56,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * This is true if the Maven attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -64,7 +64,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PrerequisitesImpl() {
@@ -73,7 +73,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -83,7 +83,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getMaven() {
@@ -92,7 +92,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setMaven(String newMaven) {
@@ -107,7 +107,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetMaven() {
@@ -122,7 +122,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetMaven() {
@@ -131,7 +131,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -145,7 +145,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -160,7 +160,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -175,7 +175,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -189,7 +189,7 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ProfileImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ProfileImpl.java
@@ -62,13 +62,13 @@ import org.eclipse.m2e.model.edit.pom.Repository;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ProfileImpl#getReporting <em> Reporting</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -77,7 +77,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -87,7 +87,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getActivation() <em>Activation</em>}' containment reference. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getActivation()
    * @generated
    * @ordered
@@ -96,7 +96,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * This is true if the Activation containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -105,7 +105,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getBuild() <em>Build</em>}' containment reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getBuild()
    * @generated
    * @ordered
@@ -114,7 +114,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * This is true if the Build containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -123,7 +123,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getRepositories() <em>Repositories</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getRepositories()
    * @generated
    * @ordered
@@ -133,7 +133,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getPluginRepositories() <em>Plugin Repositories</em>}' containment reference list.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPluginRepositories()
    * @generated
    * @ordered
@@ -143,7 +143,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getDependencies() <em>Dependencies</em>} ' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDependencies()
    * @generated
    * @ordered
@@ -153,7 +153,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getReports() <em>Reports</em>}' containment reference list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getReports()
    * @generated
    * @ordered
@@ -163,7 +163,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getDependencyManagement() <em>Dependency Management</em>}' containment reference.
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDependencyManagement()
    * @generated
    * @ordered
@@ -173,7 +173,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * This is true if the Dependency Management containment reference has been set. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -182,7 +182,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getDistributionManagement() <em>Distribution Management</em>}' containment
    * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDistributionManagement()
    * @generated
    * @ordered
@@ -192,7 +192,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * This is true if the Distribution Management containment reference has been set. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -201,7 +201,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getProperties() <em>Properties</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getProperties()
    * @generated
    * @ordered
@@ -211,7 +211,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getModules() <em>Modules</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getModules()
    * @generated
    * @ordered
@@ -221,7 +221,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
   /**
    * The cached value of the '{@link #getReporting() <em>Reporting</em>}' reference. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getReporting()
    * @generated
    * @ordered
@@ -230,7 +230,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ProfileImpl() {
@@ -239,7 +239,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -249,7 +249,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -258,7 +258,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -270,7 +270,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Activation getActivation() {
@@ -279,7 +279,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetActivation(Activation newActivation, NotificationChain msgs) {
@@ -300,7 +300,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setActivation(Activation newActivation) {
@@ -326,7 +326,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetActivation(NotificationChain msgs) {
@@ -347,7 +347,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetActivation() {
@@ -369,7 +369,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetActivation() {
@@ -378,7 +378,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public BuildBase getBuild() {
@@ -387,7 +387,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetBuild(BuildBase newBuild, NotificationChain msgs) {
@@ -408,7 +408,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setBuild(BuildBase newBuild) {
@@ -434,7 +434,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetBuild(NotificationChain msgs) {
@@ -455,7 +455,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetBuild() {
@@ -476,7 +476,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetBuild() {
@@ -485,7 +485,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Repository> getRepositories() {
@@ -498,7 +498,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetRepositories() {
@@ -508,7 +508,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetRepositories() {
@@ -517,7 +517,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Repository> getPluginRepositories() {
@@ -530,7 +530,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPluginRepositories() {
@@ -540,7 +540,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPluginRepositories() {
@@ -549,7 +549,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<Dependency> getDependencies() {
@@ -562,7 +562,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDependencies() {
@@ -572,7 +572,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDependencies() {
@@ -581,7 +581,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<ReportPlugin> getReports() {
@@ -594,7 +594,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetReports() {
@@ -604,7 +604,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetReports() {
@@ -613,7 +613,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DependencyManagement getDependencyManagement() {
@@ -622,7 +622,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetDependencyManagement(DependencyManagement newDependencyManagement,
@@ -645,7 +645,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDependencyManagement(DependencyManagement newDependencyManagement) {
@@ -671,7 +671,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetDependencyManagement(NotificationChain msgs) {
@@ -692,7 +692,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDependencyManagement() {
@@ -714,7 +714,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDependencyManagement() {
@@ -723,7 +723,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public DistributionManagement getDistributionManagement() {
@@ -732,7 +732,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetDistributionManagement(DistributionManagement newDistributionManagement,
@@ -755,7 +755,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDistributionManagement(DistributionManagement newDistributionManagement) {
@@ -781,7 +781,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetDistributionManagement(NotificationChain msgs) {
@@ -802,7 +802,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetDistributionManagement() {
@@ -824,7 +824,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetDistributionManagement() {
@@ -833,7 +833,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<PropertyElement> getProperties() {
@@ -846,7 +846,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetProperties() {
@@ -856,7 +856,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetProperties() {
@@ -865,7 +865,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getModules() {
@@ -877,7 +877,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Reporting getReporting() {
@@ -895,7 +895,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Reporting basicGetReporting() {
@@ -904,7 +904,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setReporting(Reporting newReporting) {
@@ -916,7 +916,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -946,7 +946,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -984,7 +984,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -1039,7 +1039,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -1087,7 +1087,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -1123,7 +1123,7 @@ public class ProfileImpl extends EObjectImpl implements Profile {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PropertyElementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/PropertyElementImpl.java
@@ -32,14 +32,14 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.PropertyElementImpl#getValue <em>Value</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class PropertyElementImpl extends EObjectImpl implements PropertyElement {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -48,7 +48,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -58,7 +58,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
   /**
    * The default value of the '{@link #getValue() <em>Value</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getValue()
    * @generated
    * @ordered
@@ -68,7 +68,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
   /**
    * The cached value of the '{@link #getValue() <em>Value</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getValue()
    * @generated
    * @ordered
@@ -77,7 +77,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected PropertyElementImpl() {
@@ -86,7 +86,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -96,7 +96,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -105,7 +105,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -117,7 +117,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getValue() {
@@ -126,7 +126,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setValue(String newValue) {
@@ -138,7 +138,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -154,7 +154,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -172,7 +172,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -190,7 +190,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -206,7 +206,7 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/RelocationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/RelocationImpl.java
@@ -33,14 +33,14 @@ import org.eclipse.m2e.model.edit.pom.Relocation;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.RelocationImpl#getMessage <em> Message</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -50,7 +50,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -60,7 +60,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -70,7 +70,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -80,7 +80,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -90,7 +90,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -100,7 +100,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The default value of the '{@link #getMessage() <em>Message</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getMessage()
    * @generated
    * @ordered
@@ -110,7 +110,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
   /**
    * The cached value of the '{@link #getMessage() <em>Message</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getMessage()
    * @generated
    * @ordered
@@ -119,7 +119,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected RelocationImpl() {
@@ -128,7 +128,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -138,7 +138,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -147,7 +147,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -159,7 +159,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -168,7 +168,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -181,7 +181,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -190,7 +190,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -202,7 +202,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getMessage() {
@@ -211,7 +211,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setMessage(String newMessage) {
@@ -223,7 +223,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -243,7 +243,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -267,7 +267,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -291,7 +291,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -311,7 +311,7 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportPluginImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportPluginImpl.java
@@ -45,14 +45,14 @@ import org.eclipse.m2e.model.edit.pom.ReportSet;
  * {@link org.eclipse.m2e.model.edit.pom.impl.ReportPluginImpl#getConfiguration <em>Configuration</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The default value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -62,7 +62,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The cached value of the '{@link #getGroupId() <em>Group Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getGroupId()
    * @generated
    * @ordered
@@ -71,7 +71,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * This is true if the Group Id attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -80,7 +80,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The default value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -90,7 +90,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The cached value of the '{@link #getArtifactId() <em>Artifact Id</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getArtifactId()
    * @generated
    * @ordered
@@ -100,7 +100,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The default value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -110,7 +110,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getVersion()
    * @generated
    * @ordered
@@ -120,7 +120,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The default value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -130,7 +130,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The cached value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -140,7 +140,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The cached value of the '{@link #getReportSets() <em>Report Sets</em>}' containment reference list. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getReportSets()
    * @generated
    * @ordered
@@ -150,7 +150,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
   /**
    * The cached value of the '{@link #getConfiguration() <em>Configuration</em>}' reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getConfiguration()
    * @generated
    * @ordered
@@ -159,7 +159,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ReportPluginImpl() {
@@ -168,7 +168,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -178,7 +178,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getGroupId() {
@@ -187,7 +187,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setGroupId(String newGroupId) {
@@ -202,7 +202,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetGroupId() {
@@ -217,7 +217,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetGroupId() {
@@ -226,7 +226,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getArtifactId() {
@@ -235,7 +235,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setArtifactId(String newArtifactId) {
@@ -248,7 +248,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getVersion() {
@@ -257,7 +257,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setVersion(String newVersion) {
@@ -269,7 +269,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getInherited() {
@@ -278,7 +278,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setInherited(String newInherited) {
@@ -291,7 +291,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<ReportSet> getReportSets() {
@@ -304,7 +304,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetReportSets() {
@@ -314,7 +314,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetReportSets() {
@@ -323,7 +323,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration getConfiguration() {
@@ -341,7 +341,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration basicGetConfiguration() {
@@ -350,7 +350,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setConfiguration(Configuration newConfiguration) {
@@ -363,7 +363,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -377,7 +377,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -403,7 +403,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -435,7 +435,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -465,7 +465,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -489,7 +489,7 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportSetImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportSetImpl.java
@@ -39,13 +39,13 @@ import org.eclipse.m2e.model.edit.pom.ReportSet;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ReportSetImpl#getConfiguration <em>Configuration</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ReportSetImpl extends EObjectImpl implements ReportSet {
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -54,7 +54,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -63,7 +63,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * This is true if the Id attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -72,7 +72,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
   /**
    * The default value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -82,7 +82,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
   /**
    * The cached value of the '{@link #getInherited() <em>Inherited</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getInherited()
    * @generated
    * @ordered
@@ -92,7 +92,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
   /**
    * The cached value of the '{@link #getReports() <em>Reports</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getReports()
    * @generated
    * @ordered
@@ -102,7 +102,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
   /**
    * The cached value of the '{@link #getConfiguration() <em>Configuration</em>}' reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getConfiguration()
    * @generated
    * @ordered
@@ -111,7 +111,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ReportSetImpl() {
@@ -120,7 +120,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -130,7 +130,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -139,7 +139,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -153,7 +153,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetId() {
@@ -167,7 +167,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetId() {
@@ -176,7 +176,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getInherited() {
@@ -185,7 +185,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setInherited(String newInherited) {
@@ -197,7 +197,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getReports() {
@@ -209,7 +209,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration getConfiguration() {
@@ -227,7 +227,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public Configuration basicGetConfiguration() {
@@ -236,7 +236,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setConfiguration(Configuration newConfiguration) {
@@ -249,7 +249,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -271,7 +271,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -297,7 +297,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -321,7 +321,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -341,7 +341,7 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportingImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ReportingImpl.java
@@ -42,14 +42,14 @@ import org.eclipse.m2e.model.edit.pom.Reporting;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ReportingImpl#getPlugins <em> Plugins</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ReportingImpl extends EObjectImpl implements Reporting {
   /**
    * The default value of the '{@link #getExcludeDefaults() <em>Exclude Defaults</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getExcludeDefaults()
    * @generated
    * @ordered
@@ -59,7 +59,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
   /**
    * The cached value of the '{@link #getExcludeDefaults() <em>Exclude Defaults</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getExcludeDefaults()
    * @generated
    * @ordered
@@ -68,7 +68,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * This is true if the Exclude Defaults attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -77,7 +77,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
   /**
    * The default value of the '{@link #getOutputDirectory() <em>Output Directory</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOutputDirectory()
    * @generated
    * @ordered
@@ -87,7 +87,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
   /**
    * The cached value of the '{@link #getOutputDirectory() <em>Output Directory</em>}' attribute. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getOutputDirectory()
    * @generated
    * @ordered
@@ -97,7 +97,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
   /**
    * The cached value of the '{@link #getPlugins() <em>Plugins</em>}' containment reference list. <!-- begin-user-doc
    * --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getPlugins()
    * @generated
    * @ordered
@@ -106,7 +106,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ReportingImpl() {
@@ -115,7 +115,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -125,7 +125,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getExcludeDefaults() {
@@ -134,7 +134,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setExcludeDefaults(String newExcludeDefaults) {
@@ -149,7 +149,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetExcludeDefaults() {
@@ -164,7 +164,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetExcludeDefaults() {
@@ -173,7 +173,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getOutputDirectory() {
@@ -182,7 +182,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setOutputDirectory(String newOutputDirectory) {
@@ -195,7 +195,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<ReportPlugin> getPlugins() {
@@ -208,7 +208,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetPlugins() {
@@ -218,7 +218,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetPlugins() {
@@ -227,7 +227,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -241,7 +241,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -259,7 +259,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -282,7 +282,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -303,7 +303,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -322,7 +322,7 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/RepositoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/RepositoryImpl.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.RepositoryPolicy;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.RepositoryImpl#getLayout <em> Layout</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class RepositoryImpl extends EObjectImpl implements Repository {
   /**
    * The cached value of the '{@link #getReleases() <em>Releases</em>}' containment reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getReleases()
    * @generated
    * @ordered
@@ -54,7 +54,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * This is true if the Releases containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -63,7 +63,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
   /**
    * The cached value of the '{@link #getSnapshots() <em>Snapshots</em>}' containment reference. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getSnapshots()
    * @generated
    * @ordered
@@ -72,7 +72,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * This is true if the Snapshots containment reference has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -80,7 +80,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -89,7 +89,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -99,7 +99,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -108,7 +108,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -117,7 +117,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -126,7 +126,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -136,7 +136,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
   /**
    * The default value of the '{@link #getLayout() <em>Layout</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getLayout()
    * @generated
    * @ordered
@@ -146,7 +146,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
   /**
    * The cached value of the '{@link #getLayout() <em>Layout</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getLayout()
    * @generated
    * @ordered
@@ -155,7 +155,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * This is true if the Layout attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -163,7 +163,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected RepositoryImpl() {
@@ -172,7 +172,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -182,7 +182,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public RepositoryPolicy getReleases() {
@@ -191,7 +191,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetReleases(RepositoryPolicy newReleases, NotificationChain msgs) {
@@ -212,7 +212,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setReleases(RepositoryPolicy newReleases) {
@@ -238,7 +238,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetReleases(NotificationChain msgs) {
@@ -259,7 +259,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetReleases() {
@@ -281,7 +281,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetReleases() {
@@ -290,7 +290,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public RepositoryPolicy getSnapshots() {
@@ -299,7 +299,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicSetSnapshots(RepositoryPolicy newSnapshots, NotificationChain msgs) {
@@ -320,7 +320,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setSnapshots(RepositoryPolicy newSnapshots) {
@@ -346,7 +346,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public NotificationChain basicUnsetSnapshots(NotificationChain msgs) {
@@ -367,7 +367,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetSnapshots() {
@@ -389,7 +389,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetSnapshots() {
@@ -398,7 +398,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -407,7 +407,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -419,7 +419,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -428,7 +428,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -440,7 +440,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -449,7 +449,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -461,7 +461,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getLayout() {
@@ -470,7 +470,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setLayout(String newLayout) {
@@ -485,7 +485,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetLayout() {
@@ -500,7 +500,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetLayout() {
@@ -509,7 +509,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -525,7 +525,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -549,7 +549,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -579,7 +579,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -609,7 +609,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -633,7 +633,7 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/RepositoryPolicyImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/RepositoryPolicyImpl.java
@@ -35,14 +35,14 @@ import org.eclipse.m2e.model.edit.pom.RepositoryPolicy;
  * {@link org.eclipse.m2e.model.edit.pom.impl.RepositoryPolicyImpl#getChecksumPolicy <em>Checksum Policy</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolicy {
   /**
    * The default value of the '{@link #getEnabled() <em>Enabled</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getEnabled()
    * @generated
    * @ordered
@@ -52,7 +52,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
   /**
    * The cached value of the '{@link #getEnabled() <em>Enabled</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getEnabled()
    * @generated
    * @ordered
@@ -61,7 +61,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * This is true if the Enabled attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -70,7 +70,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
   /**
    * The default value of the '{@link #getUpdatePolicy() <em>Update Policy</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getUpdatePolicy()
    * @generated
    * @ordered
@@ -80,7 +80,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
   /**
    * The cached value of the '{@link #getUpdatePolicy() <em>Update Policy</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getUpdatePolicy()
    * @generated
    * @ordered
@@ -90,7 +90,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
   /**
    * The default value of the '{@link #getChecksumPolicy() <em>Checksum Policy</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getChecksumPolicy()
    * @generated
    * @ordered
@@ -100,7 +100,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
   /**
    * The cached value of the '{@link #getChecksumPolicy() <em>Checksum Policy</em>}' attribute. <!-- begin-user-doc -->
    * <!-- end-user-doc -->
-   * 
+   *
    * @see #getChecksumPolicy()
    * @generated
    * @ordered
@@ -109,7 +109,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected RepositoryPolicyImpl() {
@@ -118,7 +118,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -128,7 +128,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getEnabled() {
@@ -137,7 +137,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setEnabled(String newEnabled) {
@@ -152,7 +152,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetEnabled() {
@@ -167,7 +167,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetEnabled() {
@@ -176,7 +176,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUpdatePolicy() {
@@ -185,7 +185,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUpdatePolicy(String newUpdatePolicy) {
@@ -198,7 +198,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getChecksumPolicy() {
@@ -207,7 +207,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setChecksumPolicy(String newChecksumPolicy) {
@@ -220,7 +220,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -238,7 +238,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -259,7 +259,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -280,7 +280,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -299,7 +299,7 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ResourceImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ResourceImpl.java
@@ -38,14 +38,14 @@ import org.eclipse.m2e.model.edit.pom.Resource;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ResourceImpl#getExcludes <em> Excludes</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The default value of the '{@link #getTargetPath() <em>Target Path</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getTargetPath()
    * @generated
    * @ordered
@@ -55,7 +55,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The cached value of the '{@link #getTargetPath() <em>Target Path</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getTargetPath()
    * @generated
    * @ordered
@@ -65,7 +65,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The default value of the '{@link #getFiltering() <em>Filtering</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFiltering()
    * @generated
    * @ordered
@@ -75,7 +75,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The cached value of the '{@link #getFiltering() <em>Filtering</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getFiltering()
    * @generated
    * @ordered
@@ -84,7 +84,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * This is true if the Filtering attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -93,7 +93,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The default value of the '{@link #getDirectory() <em>Directory</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDirectory()
    * @generated
    * @ordered
@@ -103,7 +103,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The cached value of the '{@link #getDirectory() <em>Directory</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getDirectory()
    * @generated
    * @ordered
@@ -113,7 +113,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The cached value of the '{@link #getIncludes() <em>Includes</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getIncludes()
    * @generated
    * @ordered
@@ -123,7 +123,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
   /**
    * The cached value of the '{@link #getExcludes() <em>Excludes</em>}' attribute list. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getExcludes()
    * @generated
    * @ordered
@@ -132,7 +132,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ResourceImpl() {
@@ -141,7 +141,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -151,7 +151,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getTargetPath() {
@@ -160,7 +160,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setTargetPath(String newTargetPath) {
@@ -172,7 +172,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getFiltering() {
@@ -181,7 +181,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setFiltering(String newFiltering) {
@@ -196,7 +196,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetFiltering() {
@@ -211,7 +211,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetFiltering() {
@@ -220,7 +220,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDirectory() {
@@ -229,7 +229,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDirectory(String newDirectory) {
@@ -241,7 +241,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getIncludes() {
@@ -253,7 +253,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public EList<String> getExcludes() {
@@ -265,7 +265,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -287,7 +287,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @SuppressWarnings("unchecked")
@@ -317,7 +317,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -344,7 +344,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -366,7 +366,7 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ScmImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/ScmImpl.java
@@ -33,14 +33,14 @@ import org.eclipse.m2e.model.edit.pom.Scm;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.ScmImpl#getUrl <em>Url</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ScmImpl extends EObjectImpl implements Scm {
   /**
    * The default value of the '{@link #getConnection() <em>Connection</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getConnection()
    * @generated
    * @ordered
@@ -50,7 +50,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
   /**
    * The cached value of the '{@link #getConnection() <em>Connection</em>}' attribute. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @see #getConnection()
    * @generated
    * @ordered
@@ -60,7 +60,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
   /**
    * The default value of the '{@link #getDeveloperConnection() <em>Developer Connection</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDeveloperConnection()
    * @generated
    * @ordered
@@ -70,7 +70,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
   /**
    * The cached value of the '{@link #getDeveloperConnection() <em>Developer Connection</em>}' attribute. <!--
    * begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getDeveloperConnection()
    * @generated
    * @ordered
@@ -79,7 +79,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * The default value of the '{@link #getTag() <em>Tag</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTag()
    * @generated
    * @ordered
@@ -88,7 +88,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * The cached value of the '{@link #getTag() <em>Tag</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getTag()
    * @generated
    * @ordered
@@ -97,7 +97,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * This is true if the Tag attribute has been set. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    * @ordered
    */
@@ -105,7 +105,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -114,7 +114,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -123,7 +123,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected ScmImpl() {
@@ -132,7 +132,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -142,7 +142,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getConnection() {
@@ -151,7 +151,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setConnection(String newConnection) {
@@ -163,7 +163,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getDeveloperConnection() {
@@ -172,7 +172,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setDeveloperConnection(String newDeveloperConnection) {
@@ -185,7 +185,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getTag() {
@@ -194,7 +194,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setTag(String newTag) {
@@ -208,7 +208,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void unsetTag() {
@@ -222,7 +222,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public boolean isSetTag() {
@@ -231,7 +231,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -240,7 +240,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -252,7 +252,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -272,7 +272,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -296,7 +296,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -320,7 +320,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -341,7 +341,7 @@ public class ScmImpl extends EObjectImpl implements Scm {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/SiteImpl.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/impl/SiteImpl.java
@@ -32,13 +32,13 @@ import org.eclipse.m2e.model.edit.pom.Site;
  * <li>{@link org.eclipse.m2e.model.edit.pom.impl.SiteImpl#getUrl <em>Url</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class SiteImpl extends EObjectImpl implements Site {
   /**
    * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -47,7 +47,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getId()
    * @generated
    * @ordered
@@ -57,7 +57,7 @@ public class SiteImpl extends EObjectImpl implements Site {
   /**
    * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
    * -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -66,7 +66,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getName()
    * @generated
    * @ordered
@@ -75,7 +75,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * The default value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -84,7 +84,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * The cached value of the '{@link #getUrl() <em>Url</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @see #getUrl()
    * @generated
    * @ordered
@@ -93,7 +93,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected SiteImpl() {
@@ -102,7 +102,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -112,7 +112,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getId() {
@@ -121,7 +121,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setId(String newId) {
@@ -133,7 +133,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getName() {
@@ -142,7 +142,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setName(String newName) {
@@ -154,7 +154,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public String getUrl() {
@@ -163,7 +163,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public void setUrl(String newUrl) {
@@ -175,7 +175,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -193,7 +193,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -214,7 +214,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -235,7 +235,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -253,7 +253,7 @@ public class SiteImpl extends EObjectImpl implements Site {
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationFileItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationFileItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.ActivationFile} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ActivationFileItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationFileItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -69,7 +69,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
 
   /**
    * This adds a property descriptor for the Missing feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addMissingPropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
 
   /**
    * This adds a property descriptor for the Exists feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addExistsPropertyDescriptor(Object object) {
@@ -101,7 +101,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
 
   /**
    * This returns ActivationFile.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -111,7 +111,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -124,7 +124,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -143,7 +143,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -153,7 +153,7 @@ public class ActivationFileItemProvider extends ItemProviderAdapter implements I
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationItemProvider.java
@@ -39,14 +39,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.Activation} object. <!-- begin-user-doc
  * --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ActivationItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationItemProvider(AdapterFactory adapterFactory) {
@@ -55,7 +55,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Active By Default feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addActiveByDefaultPropertyDescriptor(Object object) {
@@ -87,7 +87,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This adds a property descriptor for the Jdk feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addJdkPropertyDescriptor(Object object) {
@@ -104,7 +104,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
    * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
    * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
    * end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -120,7 +120,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -134,7 +134,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns Activation.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -144,7 +144,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -157,7 +157,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -181,7 +181,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -200,7 +200,7 @@ public class ActivationItemProvider extends ItemProviderAdapter implements IEdit
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationOSItemProvider.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/provider/ActivationOSItemProvider.java
@@ -37,14 +37,14 @@ import org.eclipse.m2e.model.edit.pom.PomPackage;
 /**
  * This is the item provider adapter for a {@link org.eclipse.m2e.model.edit.pom.ActivationOS} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class ActivationOSItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
     IStructuredItemContentProvider, ITreeItemContentProvider, IItemLabelProvider, IItemPropertySource {
   /**
    * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   public ActivationOSItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +53,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -71,7 +71,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Name feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addNamePropertyDescriptor(Object object) {
@@ -85,7 +85,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Family feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addFamilyPropertyDescriptor(Object object) {
@@ -99,7 +99,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Arch feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addArchPropertyDescriptor(Object object) {
@@ -113,7 +113,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This adds a property descriptor for the Version feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   protected void addVersionPropertyDescriptor(Object object) {
@@ -127,7 +127,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns ActivationOS.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -137,7 +137,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -150,7 +150,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating a
    * viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -171,7 +171,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
   /**
    * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under
    * this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override
@@ -181,7 +181,7 @@ public class ActivationOSItemProvider extends ItemProviderAdapter implements IEd
 
   /**
    * Return the resource locator for this item provider's resources. <!-- begin-user-doc --> <!-- end-user-doc -->
-   * 
+   *
    * @generated
    */
   @Override


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>