### PR TITLE
[cleanup] erefactor/EclipseJdt - Replace regular expression replace with plain replace.

### DIFF
--- a/org.eclipse.m2e.jdt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.jdt.tests;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.1.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationTest.java
@@ -48,7 +48,7 @@ public class JavaConfigurationTest extends AbstractMavenProjectTestCase {
       stream.read(bytes);
     }
     String contents = new String(bytes);
-    contents = contents.replaceAll("1\\.8", "11");
+    contents = contents.replace("1.8", "11");
     pomFileWS.setContents(new ByteArrayInputStream(contents.getBytes()), true, false, null);
     waitForJobsToComplete();
     assertEquals("11", javaProject.getOption(JavaCore.COMPILER_SOURCE, false));


### PR DESCRIPTION
EclipseJdt cleanup 'ReplaceRegexpWithPlainReplace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor