### PR TITLE
[cleanup] erefactor/EclipseJdt - Use uppercase for long literal suffix

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/AbstractTransferListenerAdapter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/AbstractTransferListenerAdapter.java
@@ -95,7 +95,7 @@ abstract class AbstractTransferListenerAdapter {
       formatBytes(total, sb);
       if(total > 0) {
         sb.append(" (");
-        sb.append(100l * complete / total);
+        sb.append(100L * complete / total);
         sb.append("%)");
       }
     }


### PR DESCRIPTION
EclipseJdt cleanup 'NumberSuffix' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>