### PR TITLE
[cleanup] erefactor/EclipseJdt - Use modifier 'final' where possible …

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/MavenVersionDecorator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/MavenVersionDecorator.java
@@ -39,7 +39,7 @@ import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
  */
 public class MavenVersionDecorator implements ILabelDecorator {
 
-  private Map<ILabelProviderListener, IMavenProjectChangedListener> listeners = new HashMap<>();
+  private final Map<ILabelProviderListener, IMavenProjectChangedListener> listeners = new HashMap<>();
 
   public Image decorateImage(Image image, Object element) {
     return null;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenDebugOutputAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenDebugOutputAction.java
@@ -28,7 +28,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
  */
 public class MavenDebugOutputAction extends Action {
 
-  private IPropertyChangeListener listener = event -> {
+  private final IPropertyChangeListener listener = event -> {
     if(MavenPreferenceConstants.P_DEBUG_OUTPUT.equals(event.getProperty())) {
       setChecked(isDebug());
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenPomAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenPomAction.java
@@ -386,7 +386,7 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
   }
 
   private static class MavenStorage implements IStorage {
-    private String name;
+    private final String name;
 
     private final String path;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
@@ -119,7 +119,7 @@ public class WorkingSetGroup {
       }
     });
     workingsetComboViewer.setLabelProvider(new LabelProvider() {
-      private ResourceManager images = new LocalResourceManager(JFaceResources.getResources());
+      private final ResourceManager images = new LocalResourceManager(JFaceResources.getResources());
 
       @SuppressWarnings("deprecation")
       public Image getImage(Object element) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
@@ -69,7 +69,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
 
   private static final String TITLE = Messages.MavenConsoleImpl_title;
 
-  private List<IMavenConsoleListener> listeners = new CopyOnWriteArrayList<>();
+  private final List<IMavenConsoleListener> listeners = new CopyOnWriteArrayList<>();
 
   public MavenConsoleImpl(ImageDescriptor imageDescriptor) {
     super(TITLE, imageDescriptor);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/InputHistory.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/InputHistory.java
@@ -27,9 +27,9 @@ public class InputHistory {
   protected IDialogSettings dialogSettings;
 
   /** the Map of field ids to List of comboboxes that share the same history */
-  private Map<String, List<ControlWrapper>> comboMap;
+  private final Map<String, List<ControlWrapper>> comboMap;
 
-  private List<String> privileged;
+  private final List<String> privileged;
 
   public InputHistory(String sectionName) {
     this(sectionName, new String[0]);
@@ -166,7 +166,7 @@ public class InputHistory {
   }
 
   private class ComboWrapper extends ControlWrapper {
-    private Combo combo;
+    private final Combo combo;
 
     protected ComboWrapper(Combo combo) {
       super(combo);
@@ -194,7 +194,7 @@ public class InputHistory {
   }
 
   private class CComboWrapper extends ControlWrapper {
-    private CCombo combo;
+    private final CCombo combo;
 
     protected CComboWrapper(CCombo combo) {
       super(combo);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
@@ -197,9 +197,9 @@ public class MavenRepositorySearchDialog extends AbstractMavenDialog {
 
   private boolean ignoreTextChange = false;
 
-  private IProject project;
+  private final IProject project;
 
-  private MavenProject mavenproject;
+  private final MavenProject mavenproject;
 
   private final boolean showCoords;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddDependencyOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddDependencyOperation.java
@@ -25,7 +25,7 @@ import org.eclipse.m2e.core.ui.internal.editing.PomEdits.Operation;
 
 public class AddDependencyOperation implements Operation {
 
-  private Dependency dependency;
+  private final Dependency dependency;
 
   public AddDependencyOperation(Dependency dependency) {
     this.dependency = dependency;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddExclusionOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddExclusionOperation.java
@@ -35,9 +35,9 @@ import org.eclipse.m2e.core.ui.internal.editing.PomEdits.Operation;
 public class AddExclusionOperation implements Operation {
   private static final Logger log = LoggerFactory.getLogger(AddExclusionOperation.class);
 
-  private Dependency dependency;
+  private final Dependency dependency;
 
-  private ArtifactKey exclusion;
+  private final ArtifactKey exclusion;
 
   public AddExclusionOperation(Dependency dependency, ArtifactKey exclusion) {
     this.dependency = dependency;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
@@ -43,13 +43,13 @@ import org.eclipse.text.edits.TextEditGroup;
 public class ChangeCreator {
   private static final Logger log = LoggerFactory.getLogger(ChangeCreator.class);
 
-  private String label;
+  private final String label;
 
-  private IDocument oldDocument;
+  private final IDocument oldDocument;
 
-  private IDocument newDocument;
+  private final IDocument newDocument;
 
-  private IFile oldFile;
+  private final IFile oldFile;
 
   public ChangeCreator(IFile oldFile, IDocument oldDocument, IDocument newDocument, String label) {
     this.newDocument = newDocument;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/LifecycleMappingOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/LifecycleMappingOperation.java
@@ -62,15 +62,15 @@ public class LifecycleMappingOperation implements Operation {
 
   private static final String LIFECYCLE_PLUGIN_GROUPID = LifecycleMappingFactory.LIFECYCLE_MAPPING_PLUGIN_GROUPID;
 
-  private String version;
+  private final String version;
 
-  private String groupId;
+  private final String groupId;
 
-  private String artifactId;
+  private final String artifactId;
 
-  private PluginExecutionAction action;
+  private final PluginExecutionAction action;
 
-  private String[] goals;
+  private final String[] goals;
 
   /**
    * If set to true, then the lifecycle mapping metadata is created at the top level of the file, rather than within a

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/RemoveDependencyOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/RemoveDependencyOperation.java
@@ -25,7 +25,7 @@ import org.eclipse.m2e.core.ui.internal.editing.PomEdits.Operation;
 
 public class RemoveDependencyOperation implements Operation {
 
-  private Dependency dependency;
+  private final Dependency dependency;
 
   public RemoveDependencyOperation(Dependency dependency) {
     this.dependency = dependency;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/PackagingTypeMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/PackagingTypeMappingLabelProvider.java
@@ -32,9 +32,9 @@ import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.ProjectLifecycle
 @SuppressWarnings("restriction")
 public class PackagingTypeMappingLabelProvider implements ILifecycleMappingLabelProvider {
 
-  private PackagingTypeMappingConfiguration element;
+  private final PackagingTypeMappingConfiguration element;
 
-  private ProjectLifecycleMappingConfiguration prjconf;
+  private final ProjectLifecycleMappingConfiguration prjconf;
 
   public PackagingTypeMappingLabelProvider(ProjectLifecycleMappingConfiguration prjconf,
       PackagingTypeMappingConfiguration element) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingPropertyPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingPropertyPage.java
@@ -25,7 +25,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 
 public class LifecycleMappingPropertyPage extends PropertyPage {
 
-  private LifecycleMappingsViewer mappingsViewer;
+  private final LifecycleMappingsViewer mappingsViewer;
 
   public LifecycleMappingPropertyPage() {
     setMessage(Messages.LifecycleMappingPropertyPage_pageMessage);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LocalArchetypeCatalogDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LocalArchetypeCatalogDialog.java
@@ -61,9 +61,9 @@ public class LocalArchetypeCatalogDialog extends TitleAreaDialog {
 
   private static final int MAX_HISTORY = 15;
 
-  private String title;
+  private final String title;
 
-  private String message;
+  private final String message;
 
   Combo catalogLocationCombo;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenArchetypesPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenArchetypesPreferencePage.java
@@ -289,7 +289,7 @@ public class MavenArchetypesPreferencePage extends FieldEditorPreferencePage imp
 
   class CatalogsLabelProvider implements ITableLabelProvider, IColorProvider {
 
-    private Color disabledColor = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY);
+    private final Color disabledColor = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY);
 
     public String getColumnText(Object element, int columnIndex) {
       ArchetypeCatalogFactory factory = (ArchetypeCatalogFactory) element;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/RemoteArchetypeCatalogDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/RemoteArchetypeCatalogDialog.java
@@ -68,9 +68,9 @@ public class RemoteArchetypeCatalogDialog extends TitleAreaDialog {
 
   private static final int MAX_HISTORY = 15;
 
-  private String title;
+  private final String title;
 
-  private String message;
+  private final String message;
 
   Combo catalogUrlCombo;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/WarningsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/WarningsPreferencePage.java
@@ -58,7 +58,7 @@ public class WarningsPreferencePage extends FieldEditorPreferencePage implements
       P_DUP_OF_PARENT_VERSION_PB, P_NOT_COVERED_MOJO_EXECUTION_PB, P_OUT_OF_DATE_PROJECT_CONFIG_PB,
       P_OVERRIDING_MANAGED_VERSION_PB);
 
-  private Map<String, String> originalValues = new HashMap<>();
+  private final Map<String, String> originalValues = new HashMap<>();
 
   public WarningsPreferencePage() {
     super(GRID);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/launch/MavenInstallationWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/launch/MavenInstallationWizardPage.java
@@ -57,7 +57,7 @@ import org.eclipse.m2e.core.ui.internal.components.MavenProjectLabelProvider;
 @SuppressWarnings("restriction")
 public class MavenInstallationWizardPage extends WizardPage {
 
-  private List<ClasspathEntry> extensions;
+  private final List<ClasspathEntry> extensions;
 
   private Text location;
 
@@ -73,7 +73,7 @@ public class MavenInstallationWizardPage extends WizardPage {
 
   private Text name;
 
-  private AbstractMavenRuntime original;
+  private final AbstractMavenRuntime original;
 
   private Button btnExternal;
 
@@ -81,7 +81,7 @@ public class MavenInstallationWizardPage extends WizardPage {
 
   private Button btnDirectory;
 
-  private Set<String> usedNames;
+  private final Set<String> usedNames;
 
   class TreeContentProvider implements ITreeContentProvider {
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/ControlDecoration.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/ControlDecoration.java
@@ -84,7 +84,7 @@ public class ControlDecoration {
    * The composite on which to render the decoration and hook mouse events, or null if we are hooking all parent
    * composites.
    */
-  private Composite composite;
+  private final Composite composite;
 
   /**
    * The associated image.
@@ -99,7 +99,7 @@ public class ControlDecoration {
   /**
    * The position of the decoration.
    */
-  private int position;
+  private final int position;
 
   /**
    * The decoration's visibility flag
@@ -198,17 +198,17 @@ public class ControlDecoration {
     /**
      * Offset of info hover arrow from the left or right side.
      */
-    private int hao = 10;
+    private final int hao = 10;
 
     /**
      * Width of info hover arrow.
      */
-    private int haw = 8;
+    private final int haw = 8;
 
     /**
      * Height of info hover arrow.
      */
-    private int hah = 10;
+    private final int hah = 10;
 
     /**
      * Margin around info hover text.

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
@@ -109,7 +109,7 @@ public class MavenRepositoryView extends ViewPart {
 
   private static final String MENU_ID = ".repositoryViewMenu"; //$NON-NLS-1$
 
-  private IndexManager indexManager = MavenPlugin.getIndexManager();
+  private final IndexManager indexManager = MavenPlugin.getIndexManager();
 
   private IAction collapseAllAction;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/RepositoryViewLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/RepositoryViewLabelProvider.java
@@ -40,7 +40,7 @@ import org.eclipse.m2e.core.ui.internal.views.nodes.RepositoryNode;
 public class RepositoryViewLabelProvider extends LabelProvider implements IStyledLabelProvider, IColorProvider,
     IFontProvider {
 
-  private Font italicFont;
+  private final Font italicFont;
 
   public RepositoryViewLabelProvider(Font treeFont) {
     int size = 0;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IndexedArtifactFileNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IndexedArtifactFileNode.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.ui.internal.MavenImages;
 @SuppressWarnings("restriction")
 public class IndexedArtifactFileNode extends PlatformObject implements IMavenRepositoryNode, IArtifactNode, IAdaptable {
 
-  private IndexedArtifactFile artifactFile;
+  private final IndexedArtifactFile artifactFile;
 
   public IndexedArtifactFileNode(IndexedArtifactFile artifactFile) {
     this.artifactFile = artifactFile;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IndexedArtifactGroupNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IndexedArtifactGroupNode.java
@@ -33,7 +33,7 @@ import org.eclipse.m2e.core.internal.index.nexus.NexusIndexManager;
  */
 public class IndexedArtifactGroupNode implements IMavenRepositoryNode, IArtifactNode {
 
-  private IndexedArtifactGroup indexedArtifactGroup;
+  private final IndexedArtifactGroup indexedArtifactGroup;
 
   private Object[] kids = null;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IndexedArtifactNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IndexedArtifactNode.java
@@ -32,7 +32,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 @SuppressWarnings("restriction")
 public class IndexedArtifactNode implements IMavenRepositoryNode, IArtifactNode {
 
-  private IndexedArtifact artifact;
+  private final IndexedArtifact artifact;
 
   private Object[] kids = null;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/ProjectRepositoriesNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/ProjectRepositoriesNode.java
@@ -31,9 +31,9 @@ import org.eclipse.m2e.core.ui.internal.Messages;
  */
 public class ProjectRepositoriesNode implements IMavenRepositoryNode {
 
-  private NexusIndexManager indexManager = (NexusIndexManager) MavenPlugin.getIndexManager();
+  private final NexusIndexManager indexManager = (NexusIndexManager) MavenPlugin.getIndexManager();
 
-  private IRepositoryRegistry repositoryRegistry = MavenPlugin.getRepositoryRegistry();
+  private final IRepositoryRegistry repositoryRegistry = MavenPlugin.getRepositoryRegistry();
 
   public Object[] getChildren() {
     ArrayList<Object> nodes = new ArrayList<>();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/AbstractMavenWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/AbstractMavenWizardPage.java
@@ -50,7 +50,7 @@ public abstract class AbstractMavenWizardPage extends WizardPage {
   /**
    * The project import configuration
    */
-  private ProjectImportConfiguration importConfiguration;
+  private final ProjectImportConfiguration importConfiguration;
 
   /** The resolver configuration panel */
   protected ResolverConfigurationComponent resolverConfigurationComponent;
@@ -59,7 +59,7 @@ public abstract class AbstractMavenWizardPage extends WizardPage {
   protected IDialogSettings dialogSettings;
 
   /** the Map of field ids to List of comboboxes that share the same history */
-  private Map<String, List<Combo>> fieldsWithHistory;
+  private final Map<String, List<Combo>> fieldsWithHistory;
 
   private boolean isHistoryLoaded = false;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/CustomArchetypeDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/CustomArchetypeDialog.java
@@ -55,9 +55,9 @@ public class CustomArchetypeDialog extends TitleAreaDialog {
 
   private static final int MAX_HISTORY = 15;
 
-  private String title;
+  private final String title;
 
-  private String message;
+  private final String message;
 
   private Combo archetypeGroupIdCombo;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/ImportMavenProjectsJob.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/ImportMavenProjectsJob.java
@@ -44,11 +44,11 @@ import org.eclipse.m2e.core.ui.internal.Messages;
  */
 public class ImportMavenProjectsJob extends WorkspaceJob {
 
-  private List<IWorkingSet> workingSets;
+  private final List<IWorkingSet> workingSets;
 
-  private Collection<MavenProjectInfo> projects;
+  private final Collection<MavenProjectInfo> projects;
 
-  private ProjectImportConfiguration importConfiguration;
+  private final ProjectImportConfiguration importConfiguration;
 
   public ImportMavenProjectsJob(Collection<MavenProjectInfo> projects, List<IWorkingSet> workingSets,
       ProjectImportConfiguration importConfiguration) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
@@ -120,11 +120,11 @@ public class LifecycleMappingPage extends WizardPage {
 
   private Text license;
 
-  private Set<ILifecycleMappingLabelProvider> ignore = new HashSet<>();
+  private final Set<ILifecycleMappingLabelProvider> ignore = new HashSet<>();
 
-  private Set<ILifecycleMappingLabelProvider> ignoreAtDefinition = new HashSet<>();
+  private final Set<ILifecycleMappingLabelProvider> ignoreAtDefinition = new HashSet<>();
 
-  private Set<ILifecycleMappingLabelProvider> ignoreWorkspace = new HashSet<>();
+  private final Set<ILifecycleMappingLabelProvider> ignoreWorkspace = new HashSet<>();
 
   private Label errorCountLabel;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MappingDiscoveryJob.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MappingDiscoveryJob.java
@@ -38,7 +38,7 @@ import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.LifecycleMapping
  */
 public class MappingDiscoveryJob extends WorkspaceJob {
 
-  private Collection<IProject> projects;
+  private final Collection<IProject> projects;
 
   public MappingDiscoveryJob(Collection<IProject> projects) {
     super("Discover lifecycle mappings");

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenArtifactComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenArtifactComponent.java
@@ -69,17 +69,17 @@ public class MavenArtifactComponent extends Composite {
 
   private ModifyListener modifyingListener;
 
-  private Label groupIdlabel;
+  private final Label groupIdlabel;
 
-  private Label artifactIdLabel;
+  private final Label artifactIdLabel;
 
-  private Label versionLabel;
+  private final Label versionLabel;
 
-  private Label packagingLabel;
+  private final Label packagingLabel;
 
-  private Label nameLabel;
+  private final Label nameLabel;
 
-  private Label descriptionLabel;
+  private final Label descriptionLabel;
 
   /** Creates a new component. */
   public MavenArtifactComponent(Composite parent, int styles) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDependenciesWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDependenciesWizardPage.java
@@ -60,7 +60,7 @@ public class MavenDependenciesWizardPage extends AbstractMavenWizardPage {
   /**
    * Listeners notified about all changes
    */
-  private List<ISelectionChangedListener> listeners = new ArrayList<>();
+  private final List<ISelectionChangedListener> listeners = new ArrayList<>();
 
   boolean showScope = false;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
@@ -83,9 +83,9 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
 
   private boolean initialized = false;
 
-  private LifecycleMappingDiscoveryRequest mappingDiscoveryRequest;
+  private final LifecycleMappingDiscoveryRequest mappingDiscoveryRequest;
 
-  private Collection<IProject> projects;
+  private final Collection<IProject> projects;
 
   private IMavenDiscoveryUI pageFactory;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenImportWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenImportWizardPage.java
@@ -98,7 +98,7 @@ public class MavenImportWizardPage extends AbstractMavenWizardPage {
 
   private List<String> locations;
 
-  private IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+  private final IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
 
   private boolean showLocation = true;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenParentComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenParentComponent.java
@@ -37,13 +37,13 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 public class MavenParentComponent extends Composite {
 
   /** parent artifact id input field */
-  private Combo parentArtifactIdCombo;
+  private final Combo parentArtifactIdCombo;
 
   /** parent group id input field */
-  private Combo parentGroupIdCombo;
+  private final Combo parentGroupIdCombo;
 
   /** parent version input field */
-  private Combo parentVersionCombo;
+  private final Combo parentVersionCombo;
 
   /** the "clear parent section" button */
   private Button parentClearButton;
@@ -51,11 +51,11 @@ public class MavenParentComponent extends Composite {
   /** the "browse..." button */
   private Button parentBrowseButton;
 
-  private Label groupIdLabel;
+  private final Label groupIdLabel;
 
-  private Label artifactIdLabel;
+  private final Label artifactIdLabel;
 
-  private Label versionLabel;
+  private final Label versionLabel;
 
   /** Creates a new panel with parent controls. */
   public MavenParentComponent(Composite parent, int style) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomSelectionComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomSelectionComponent.java
@@ -418,11 +418,11 @@ public class MavenPomSelectionComponent extends Composite {
    */
   private class SearchJob extends Job {
 
-    private IndexManager indexManager;
+    private final IndexManager indexManager;
 
     private String query;
 
-    private String field;
+    private final String field;
 
     private volatile boolean stop = false;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizardPage.java
@@ -45,7 +45,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 public class MavenPomWizardPage extends AbstractMavenWizardPage {
   private Text projectText;
 
-  private ISelection selection;
+  private final ISelection selection;
 
   private MavenArtifactComponent pomComponent;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypePage.java
@@ -139,7 +139,7 @@ public class MavenProjectWizardArchetypePage extends AbstractMavenWizardPage imp
 
   private boolean includeSnapshots;
 
-  private Map<String, List<Archetype>> archetypesCache = new HashMap<>();
+  private final Map<String, List<Archetype>> archetypesCache = new HashMap<>();
 
   ComboViewer catalogsComboViewer;
 
@@ -1055,7 +1055,7 @@ public class MavenProjectWizardArchetypePage extends AbstractMavenWizardPage imp
 
     List<Archetype> catalogArchetypes;
 
-    private ArchetypeCatalogFactory archetypeCatalogFactory;
+    private final ArchetypeCatalogFactory archetypeCatalogFactory;
 
     public RetrievingArchetypesJob(ArchetypeCatalogFactory catalogFactory) {
       super(Messages.wizardProjectPageArchetypeRetrievingArchetypes);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypeParametersPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypeParametersPage.java
@@ -407,7 +407,7 @@ public class MavenProjectWizardArchetypeParametersPage extends AbstractMavenWiza
 
   private static class RequiredPropertiesLoader implements IRunnableWithProgress {
 
-    private Archetype archetype;
+    private final Archetype archetype;
 
     private List<?> properties;
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWorkspaceAssigner.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWorkspaceAssigner.java
@@ -32,7 +32,7 @@ import org.eclipse.m2e.core.ui.internal.WorkingSets;
  */
 public class MavenProjectWorkspaceAssigner implements IProjectCreationListener {
 
-  private List<IWorkingSet> workingSets;
+  private final List<IWorkingSet> workingSets;
 
   public MavenProjectWorkspaceAssigner(List<IWorkingSet> workingSets) {
     this.workingSets = workingSets;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
@@ -101,7 +101,7 @@ public class MavenPluginActivator extends Plugin {
   // The shared instance
   private static MavenPluginActivator plugin;
 
-  private Collection<PlexusContainer> toDisposeContainers = new HashSet<>();
+  private final Collection<PlexusContainer> toDisposeContainers = new HashSet<>();
 
   private MavenModelManager modelManager;
 
@@ -133,9 +133,9 @@ public class MavenPluginActivator extends Plugin {
 
   private IMavenConfiguration mavenConfiguration;
 
-  private BundleListener bundleListener = event -> LifecycleMappingFactory.setBundleMetadataSources(null);
+  private final BundleListener bundleListener = event -> LifecycleMappingFactory.setBundleMetadataSources(null);
 
-  private ISaveParticipant saveParticipant = new ISaveParticipant() {
+  private final ISaveParticipant saveParticipant = new ISaveParticipant() {
 
     @Override
     public void saving(ISaveContext context) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogsWriter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogsWriter.java
@@ -153,9 +153,9 @@ public class ArchetypeCatalogsWriter {
 
   static class ArchetypeCatalogsContentHandler extends DefaultHandler {
 
-    private Collection<ArchetypeCatalogFactory> catalogs;
+    private final Collection<ArchetypeCatalogFactory> catalogs;
 
-    private Map<String, ArchetypeCatalogFactory> existingCatalogs;
+    private final Map<String, ArchetypeCatalogFactory> existingCatalogs;
 
     public ArchetypeCatalogsContentHandler(Collection<ArchetypeCatalogFactory> catalogs,
         Map<String, ArchetypeCatalogFactory> existingCatalogs) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
@@ -160,7 +160,7 @@ public class MavenBuilder extends IncrementalProjectBuilder implements DeltaProv
     }
   }
 
-  private BuildMethod<IProject[]> methodBuild = new BuildMethod<IProject[]>() {
+  private final BuildMethod<IProject[]> methodBuild = new BuildMethod<IProject[]>() {
     @Override
     protected IProject[] method(IMavenExecutionContext context, IMavenProjectFacade projectFacade,
         Map<MojoExecutionKey, List<AbstractBuildParticipant>> buildParticipantsByMojoExecutionKey, int kind,
@@ -177,7 +177,7 @@ public class MavenBuilder extends IncrementalProjectBuilder implements DeltaProv
     }
   };
 
-  private BuildMethod<Void> methodClean = new BuildMethod<Void>() {
+  private final BuildMethod<Void> methodClean = new BuildMethod<Void>() {
     @Override
     protected Void method(IMavenExecutionContext context, IMavenProjectFacade projectFacade,
         Map<MojoExecutionKey, List<AbstractBuildParticipant>> buildParticipantsByMojoExecutionKey, int kind,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/ChangedFileOutputStream.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/ChangedFileOutputStream.java
@@ -40,7 +40,7 @@ public class ChangedFileOutputStream extends OutputStream {
 
   private final OutputStream os;
 
-  private ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
   public ChangedFileOutputStream(File file) throws FileNotFoundException {
     this(file, null);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseLoggerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseLoggerManager.java
@@ -26,7 +26,7 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
  */
 public class EclipseLoggerManager extends AbstractLoggerManager {
 
-  private EclipseLogger logger;
+  private final EclipseLogger logger;
 
   public EclipseLoggerManager(IMavenConfiguration mavenConfiguration) {
     this.logger = new EclipseLogger(mavenConfiguration);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/equinox/EquinoxLocker.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/equinox/EquinoxLocker.java
@@ -29,7 +29,7 @@ public class EquinoxLocker implements org.apache.maven.index.fs.Locker {
 
   private static class EquinoxLock implements org.apache.maven.index.fs.Lock {
 
-    private Locker locker;
+    private final Locker locker;
 
     public EquinoxLock(Locker locker) {
       this.locker = locker;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/ArtifactScanningMonitor.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/ArtifactScanningMonitor.java
@@ -37,7 +37,7 @@ class ArtifactScanningMonitor implements ArtifactScanningListener {
 
   private long timestamp = System.currentTimeMillis();
 
-  private File repositoryDir;
+  private final File repositoryDir;
 
   ArtifactScanningMonitor(File repositoryDir, IProgressMonitor monitor) {
     //this.indexInfo = indexInfo;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/CompositeIndex.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/CompositeIndex.java
@@ -38,7 +38,7 @@ import org.eclipse.m2e.core.internal.index.SearchExpression;
  */
 public class CompositeIndex implements IIndex {
 
-  private List<IIndex> indexes;
+  private final List<IIndex> indexes;
 
   public CompositeIndex(List<IIndex> indexes) {
     this.indexes = indexes;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/NexusIndexManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/NexusIndexManager.java
@@ -159,9 +159,9 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
 
   private final IndexUpdaterJob updaterJob;
 
-  private Properties indexDetails = new Properties();
+  private final Properties indexDetails = new Properties();
 
-  private Set<String> updatingIndexes = new HashSet<>();
+  private final Set<String> updatingIndexes = new HashSet<>();
 
   private final IndexUpdater indexUpdater;
 


### PR DESCRIPTION
…- Private fields

EclipseJdt cleanup 'MakePrivateFieldFinal' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>