### PR TITLE
[cleanup] erefactor/EclipseJdt - Use modifier 'final' where possible …

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/ProjectClasspathEntry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/ProjectClasspathEntry.java
@@ -18,7 +18,7 @@ package org.eclipse.m2e.core.internal.launch;
  */
 public class ProjectClasspathEntry extends ClasspathEntry {
 
-  private String project;
+  private final String project;
 
   public ProjectClasspathEntry(String project) {
     this.project = project;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingResult.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingResult.java
@@ -30,7 +30,7 @@ public class LifecycleMappingResult {
 
   private Map<MojoExecutionKey, List<IPluginExecutionMetadata>> mojoExecutionMapping;
 
-  private List<MavenProblemInfo> problems = new ArrayList<>();
+  private final List<MavenProblemInfo> problems = new ArrayList<>();
 
   private AbstractLifecycleMapping lifecycleMapping;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/ProjectConfigurationElementSorter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/ProjectConfigurationElementSorter.java
@@ -45,9 +45,9 @@ public class ProjectConfigurationElementSorter {
 
   private Set<String> missingRequiredConfigurators;
 
-  private Set<String> allSecondaryConfigurators = new HashSet<>();
+  private final Set<String> allSecondaryConfigurators = new HashSet<>();
 
-  private Map<String, List<String>> primaryConfigurators = new HashMap<>();
+  private final Map<String, List<String>> primaryConfigurators = new HashMap<>();
 
   /**
    * Sorts a list of ids, ordering it by Project Configurator {@link IConfigurationElement}s

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/LifecycleMappingDiscoveryRequest.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/LifecycleMappingDiscoveryRequest.java
@@ -39,7 +39,7 @@ public class LifecycleMappingDiscoveryRequest {
   /**
    * All proposals to satisfy mapping requirements
    */
-  private Map<IMavenProjectFacade, List<ILifecycleMappingRequirement>> allProjects = new LinkedHashMap<>();
+  private final Map<IMavenProjectFacade, List<ILifecycleMappingRequirement>> allProjects = new LinkedHashMap<>();
 
   public Map<IMavenProjectFacade, List<ILifecycleMappingRequirement>> getProjects() {
     return this.allProjects;
@@ -55,7 +55,7 @@ public class LifecycleMappingDiscoveryRequest {
    */
   private final Set<IMavenDiscoveryProposal> selectedProposals = new LinkedHashSet<>();
 
-  private Map<IMavenProjectFacade, Throwable> errors = new LinkedHashMap<>();
+  private final Map<IMavenProjectFacade, Throwable> errors = new LinkedHashMap<>();
 
   public LifecycleMappingDiscoveryRequest() {
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/MojoExecutionMappingConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/MojoExecutionMappingConfiguration.java
@@ -32,7 +32,7 @@ public class MojoExecutionMappingConfiguration implements ILifecycleMappingEleme
   public static class MojoExecutionMappingRequirement implements ILifecycleMappingRequirement {
     private final MojoExecutionKey execution;
 
-    private String executionId;
+    private final String executionId;
 
     private String packaging;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/PackagingTypeMappingConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/PackagingTypeMappingConfiguration.java
@@ -19,7 +19,7 @@ package org.eclipse.m2e.core.internal.lifecyclemapping.discovery;
 public class PackagingTypeMappingConfiguration implements ILifecycleMappingElement {
 
   public static class PackagingTypeMappingRequirement implements ILifecycleMappingRequirement {
-    private String packaging;
+    private final String packaging;
 
     public PackagingTypeMappingRequirement(String packaging) {
       this.packaging = packaging;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/WorkspaceStateWriter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/WorkspaceStateWriter.java
@@ -47,7 +47,7 @@ public class WorkspaceStateWriter implements IMavenProjectChangedListener {
 
   private static final Logger log = LoggerFactory.getLogger(WorkspaceStateWriter.class);
 
-  private MavenProjectManager projectManager;
+  private final MavenProjectManager projectManager;
 
   public WorkspaceStateWriter(MavenProjectManager projectManager) {
     this.projectManager = projectManager;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/EclipseWorkspaceArtifactRepository.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/EclipseWorkspaceArtifactRepository.java
@@ -49,7 +49,7 @@ public final class EclipseWorkspaceArtifactRepository extends LocalArtifactRepos
 
   private static final ThreadLocal<Boolean> disabled = new ThreadLocal<>();
 
-  private WorkspaceRepository workspaceRepository;
+  private final WorkspaceRepository workspaceRepository;
 
   public EclipseWorkspaceArtifactRepository(ProjectRegistryManager.Context context) {
     this.context = context;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryInfo.java
@@ -46,7 +46,7 @@ public class RepositoryInfo implements IRepository {
 
   private String mirrorOf;
 
-  private Set<IPath> projects = new HashSet<>();
+  private final Set<IPath> projects = new HashSet<>();
 
   public RepositoryInfo(String id, String repositoryUrl, int scope, AuthenticationInfo authInfo) {
     this(id, repositoryUrl, getBasedir(repositoryUrl), scope, authInfo);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryRegistry.java
@@ -74,9 +74,9 @@ public class RepositoryRegistry implements IRepositoryRegistry, IMavenProjectCha
 
   private final RepositoryInfo workspaceRepository;
 
-  private ArrayList<IRepositoryIndexer> indexers = new ArrayList<>();
+  private final ArrayList<IRepositoryIndexer> indexers = new ArrayList<>();
 
-  private ArrayList<IRepositoryDiscoverer> discoverers = new ArrayList<>();
+  private final ArrayList<IRepositoryDiscoverer> discoverers = new ArrayList<>();
 
   private final RepositoryRegistryUpdateJob job = new RepositoryRegistryUpdateJob(this);
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
@@ -50,7 +50,7 @@ public class LocalProjectScanner extends AbstractProjectScanner<MavenProjectInfo
 
   private final boolean basedirRemameRequired;
 
-  private Set<File> scannedFolders = new HashSet<>();
+  private final Set<File> scannedFolders = new HashSet<>();
 
   private final MavenModelManager modelManager;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ProjectImportConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ProjectImportConfiguration.java
@@ -44,7 +44,7 @@ public class ProjectImportConfiguration {
   private static final String NAME = "\\[name\\]"; //$NON-NLS-1$
 
   /** resolver configuration bean */
-  private ResolverConfiguration resolverConfiguration;
+  private final ResolverConfiguration resolverConfiguration;
 
   /** the project name template */
   private String projectNameTemplate = ""; //$NON-NLS-1$

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/operation/MavenDiscoveryInstallOperation.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/operation/MavenDiscoveryInstallOperation.java
@@ -56,23 +56,23 @@ import org.eclipse.m2e.internal.discovery.Messages;
  */
 @SuppressWarnings("restriction")
 public class MavenDiscoveryInstallOperation implements IRunnableWithProgress {
-  private Collection<CatalogItem> installableConnectors;
+  private final Collection<CatalogItem> installableConnectors;
 
-  private ProvisioningSession session;
+  private final ProvisioningSession session;
 
   private Set<URI> repositoryLocations;
 
   private final boolean restart;
 
-  private List<IStatus> statuses = new ArrayList<>();
+  private final List<IStatus> statuses = new ArrayList<>();
 
   private RestartInstallOperation operation;
 
   private final IRunnableWithProgress postInstallHook;
 
-  private Collection<String> projectsToConfigure;
+  private final Collection<String> projectsToConfigure;
 
-  private boolean shouldResolve;
+  private final boolean shouldResolve;
 
   public MavenDiscoveryInstallOperation(Collection<CatalogItem> installableConnectors,
       IRunnableWithProgress postInstallHook, boolean restart) {

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/operation/RestartInstallOperation.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/operation/RestartInstallOperation.java
@@ -43,7 +43,7 @@ public class RestartInstallOperation extends InstallOperation {
 
   private final IRunnableWithProgress postInstallHook;
 
-  private Collection<String> projectsToConfigure;
+  private final Collection<String> projectsToConfigure;
 
   public RestartInstallOperation(ProvisioningSession session, Collection<IInstallableUnit> toInstall,
       IRunnableWithProgress postInstallHook) {
@@ -97,11 +97,11 @@ public class RestartInstallOperation extends InstallOperation {
    */
   private static class UpdateMavenConfigurationProvisioningJob extends ProfileModificationJob {
 
-    private ProfileModificationJob job;
+    private final ProfileModificationJob job;
 
     private final IRunnableWithProgress postInstallHook;
 
-    private Collection<String> projectsToConfigure;
+    private final Collection<String> projectsToConfigure;
 
     public UpdateMavenConfigurationProvisioningJob(ProfileModificationJob job, ProvisioningSession session,
         IRunnableWithProgress postInstallHook, Collection<String> projectsToConfigure) {

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/strategy/M2EConnectorDiscoveryExtensionReader.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/strategy/M2EConnectorDiscoveryExtensionReader.java
@@ -40,7 +40,7 @@ import org.eclipse.m2e.internal.discovery.Messages;
 @SuppressWarnings("restriction")
 public class M2EConnectorDiscoveryExtensionReader extends ConnectorDiscoveryExtensionReader {
 
-  private Map<String, Tag> tagById = new HashMap<>();
+  private final Map<String, Tag> tagById = new HashMap<>();
 
   public Set<Tag> getTags() {
     return new HashSet<>(tagById.values());

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/wizards/MavenDiscoveryInstallWizard.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/wizards/MavenDiscoveryInstallWizard.java
@@ -38,7 +38,7 @@ public class MavenDiscoveryInstallWizard extends PreselectedIUInstallWizard {
 
   private boolean waitingForOtherJobs;
 
-  private RestartInstallOperation originalOperation;
+  private final RestartInstallOperation originalOperation;
 
   public MavenDiscoveryInstallWizard(ProvisioningUI ui, RestartInstallOperation operation,
       Collection<IInstallableUnit> initialSelections, LoadMetadataRepositoryJob job) {

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/wizards/MavenDiscoveryUi.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/wizards/MavenDiscoveryUi.java
@@ -101,9 +101,9 @@ public abstract class MavenDiscoveryUi {
 
     private int status;
 
-    private RestartInstallOperation operation;
+    private final RestartInstallOperation operation;
 
-    private boolean blockOnOpen;
+    private final boolean blockOnOpen;
 
     public OpenInstallWizardRunner(RestartInstallOperation operation, boolean blockOnOpen) {
       this.operation = operation;

--- a/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/InsertArtifactProposal.java
+++ b/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/InsertArtifactProposal.java
@@ -76,15 +76,15 @@ public class InsertArtifactProposal implements ICompletionProposal, ICompletionP
     ICompletionProposalExtension5 {
   private static final Logger log = LoggerFactory.getLogger(InsertArtifactProposal.class);
 
-  private ITextViewer sourceViewer;
+  private final ITextViewer sourceViewer;
 
-  private Region region;
+  private final Region region;
 
   private int generatedLength = 0;
 
   private int generatedOffset;
 
-  private Configuration config;
+  private final Configuration config;
 
   public InsertArtifactProposal(ITextViewer sourceViewer, Region region, Configuration config) {
     this.sourceViewer = sourceViewer;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/DependenciesComposite.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/DependenciesComposite.java
@@ -111,7 +111,7 @@ public class DependenciesComposite extends Composite {
 
   MavenPomEditor pomEditor;
 
-  private FormToolkit toolkit = new FormToolkit(Display.getCurrent());
+  private final FormToolkit toolkit = new FormToolkit(Display.getCurrent());
 
   // controls
 
@@ -607,7 +607,7 @@ public class DependenciesComposite extends Composite {
   }
 
   public static class DependencyFilter extends ViewerFilter {
-    private SearchMatcher searchMatcher;
+    private final SearchMatcher searchMatcher;
 
     public DependencyFilter(SearchMatcher searchMatcher) {
       this.searchMatcher = searchMatcher;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/SectionExpansionAdapter.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/SectionExpansionAdapter.java
@@ -24,7 +24,7 @@ import org.eclipse.ui.forms.widgets.Section;
 public class SectionExpansionAdapter extends ExpansionAdapter {
   private boolean inProgress = false;
 
-  private Section[] sections;
+  private final Section[] sections;
 
   public SectionExpansionAdapter(Section[] sections) {
     this.sections = sections;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/dialogs/ManageDependenciesDialog.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/dialogs/ManageDependenciesDialog.java
@@ -101,9 +101,9 @@ public class ManageDependenciesDialog extends AbstractMavenDialog {
 
   private IStatus status;
 
-  private List<Object> originalSelection;
+  private final List<Object> originalSelection;
 
-  private ValueProvider<List<Dependency>> modelVProvider;
+  private final ValueProvider<List<Dependency>> modelVProvider;
 
   /**
    * Hierarchy is a LinkedList representing the hierarchy relationship between POM represented by model and its parents.

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/dialogs/MavenModuleSelectionDialog.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/dialogs/MavenModuleSelectionDialog.java
@@ -66,7 +66,7 @@ public class MavenModuleSelectionDialog extends MavenProjectSelectionDialog {
   }
 
   protected class ProjectLabelProvider extends LabelProvider implements IColorProvider {
-    private ILabelProvider labelProvider = WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider();
+    private final ILabelProvider labelProvider = WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider();
 
     @Override
     public String getText(Object element) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/MarkerHoverControl.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/MarkerHoverControl.java
@@ -570,7 +570,7 @@ public class MarkerHoverControl extends AbstractInformationControl
 
     private final IInformationControl infoControl;
 
-    private String prefsId;
+    private final String prefsId;
 
     public OpenPreferencesAction(IInformationControl infoControl, ImageDescriptor imageDesc, String tooltip,
         String prefsId) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/LifecycleMappingDialog.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/LifecycleMappingDialog.java
@@ -50,13 +50,13 @@ public class LifecycleMappingDialog extends Dialog implements ISelectionChangedL
 
   private IFile pomFile;
 
-  private IMavenProjectFacade facade;
+  private final IMavenProjectFacade facade;
 
-  private String pluginGroupId;
+  private final String pluginGroupId;
 
-  private String pluginArtifactId;
+  private final String pluginArtifactId;
 
-  private String goal;
+  private final String goal;
 
   private ParentHierarchyEntry pluginProject;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/MojoParameter.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/MojoParameter.java
@@ -22,9 +22,9 @@ import java.util.List;
  */
 public class MojoParameter {
 
-  private String name;
+  private final String name;
 
-  private String type;
+  private final String type;
 
   private boolean required;
 
@@ -34,7 +34,7 @@ public class MojoParameter {
 
   private String defaultValue;
 
-  private List<MojoParameter> nested;
+  private final List<MojoParameter> nested;
 
   private boolean multiple;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
@@ -59,7 +59,7 @@ public class PlexusConfigHelper {
 
   private static final Logger log = LoggerFactory.getLogger(PlexusConfigHelper.class);
 
-  private Map<Class<?>, List<MojoParameter>> processedClasses;
+  private final Map<Class<?>, List<MojoParameter>> processedClasses;
 
   public PlexusConfigHelper() {
     processedClasses = new HashMap<>();

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/ElementValueProvider.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/ElementValueProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.m2e.core.ui.internal.editing.PomEdits;
 
 public final class ElementValueProvider {
 
-  private String[] path;
+  private final String[] path;
 
   private String defaultValue;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
@@ -132,9 +132,9 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
 
   ITextEditor effectivePomSourcePage;
 
-  private List<MavenPomEditorPage> mavenpomEditorPages = new ArrayList<>();
+  private final List<MavenPomEditorPage> mavenpomEditorPages = new ArrayList<>();
 
-  private Map<String, org.eclipse.aether.graph.DependencyNode> rootNodes = new HashMap<>();
+  private final Map<String, org.eclipse.aether.graph.DependencyNode> rootNodes = new HashMap<>();
 
   IDOMModel structuredModel;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
@@ -113,11 +113,11 @@ public abstract class MavenPomEditorPage extends FormPage {
   // have we loaded data?
   private boolean dataLoaded;
 
-  private InputHistory inputHistory;
+  private final InputHistory inputHistory;
 
   private Action selectParentAction;
 
-  private IModelStateListener listener;
+  private final IModelStateListener listener;
 
   private boolean alreadyShown = false;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
@@ -612,9 +612,9 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
 
     final String property;
 
-    private int length;
+    private final int length;
 
-    private int offset;
+    private final int offset;
 
     final MavenProject project;
 
@@ -637,9 +637,9 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
 
   public static class ManagedArtifactRegion implements IRegion {
 
-    private int length;
+    private final int length;
 
-    private int offset;
+    private final int offset;
 
     final MavenProject project;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTextHover.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTextHover.java
@@ -194,7 +194,7 @@ public class PomTextHover implements ITextHover, ITextHoverExtension, ITextHover
 
     private int offset = Integer.MAX_VALUE;
 
-    private List<IRegion> regions = new ArrayList<>();
+    private final List<IRegion> regions = new ArrayList<>();
 
     public final ITextViewer textViewer;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PropertiesSection.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PropertiesSection.java
@@ -67,15 +67,15 @@ public class PropertiesSection {
 
   private final MavenPomEditorPage page;
 
-  private FormToolkit toolkit;
+  private final FormToolkit toolkit;
 
-  private Composite composite;
+  private final Composite composite;
 
   private Section propertiesSection;
 
   ListEditorComposite<PropertyElement> propertiesEditor;
 
-  private VerifyListener listener = e -> e.doit = XMLChar.isValidName(e.text);
+  private final VerifyListener listener = e -> e.doit = XMLChar.isValidName(e.text);
 
   private GridData propertiesSectionData;
 

--- a/org.eclipse.m2e.importer/src/org/eclipse/m2e/importer/internal/MavenProjectConfigurator.java
+++ b/org.eclipse.m2e.importer/src/org/eclipse/m2e/importer/internal/MavenProjectConfigurator.java
@@ -54,7 +54,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
 
     private static class CumulativeMappingDiscoveryJob extends MappingDiscoveryJob {
         private static CumulativeMappingDiscoveryJob INSTANCE;
-        private Set<IProject> toProcess;
+        private final Set<IProject> toProcess;
         private boolean started;
 
         public synchronized static CumulativeMappingDiscoveryJob getInstance() {
@@ -121,7 +121,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
     public static class UpdateMavenConfigurationJob extends Job implements IBackgroundProcessingQueue {
 
         private static UpdateMavenConfigurationJob INSTANCE;
-        private Set<IProject> toProcess;
+        private final Set<IProject> toProcess;
 
         public synchronized static UpdateMavenConfigurationJob getInstance() {
             if (INSTANCE == null) {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
@@ -959,7 +959,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
 
   static class ModuleInfoDetector implements IResourceDeltaVisitor {
 
-    private Collection<IProject> affectedProjects;
+    private final Collection<IProject> affectedProjects;
 
     public ModuleInfoDetector(Collection<IProject> affectedProjects) {
       this.affectedProjects = affectedProjects;

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClassifierManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClassifierManager.java
@@ -72,7 +72,7 @@ public class MavenClassifierManager implements IMavenClassifierManager {
 
   private static class WorkspaceClassifierResolverDelegatingProvider extends AbstractClassifierClasspathProvider {
 
-    private IPath path;
+    private final IPath path;
 
     public WorkspaceClassifierResolverDelegatingProvider(IPath path) {
       this.path = path;

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLauncherConfigurationHandler.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLauncherConfigurationHandler.java
@@ -49,7 +49,7 @@ public class MavenLauncherConfigurationHandler implements IMavenLauncherConfigur
 
   private String mainRealm;
 
-  private LinkedHashMap<String, List<String>> realms = new LinkedHashMap<>();
+  private final LinkedHashMap<String, List<String>> realms = new LinkedHashMap<>();
 
   private List<String> curEntries;
 

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenJRETab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenJRETab.java
@@ -30,7 +30,7 @@ import org.eclipse.swt.widgets.Composite;
 @SuppressWarnings("restriction")
 public class MavenJRETab extends JavaJRETab {
 
-  private VMArgumentsBlock vmArgumentsBlock = new VMArgumentsBlock();
+  private final VMArgumentsBlock vmArgumentsBlock = new VMArgumentsBlock();
 
   /* (non-Javadoc)
    * @see org.eclipse.debug.ui.ILaunchConfigurationTab#createControl(org.eclipse.swt.widgets.Composite)

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
@@ -606,7 +606,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
   }
 
   private static final class GoalsFocusListener extends FocusAdapter {
-    private Text text;
+    private final Text text;
 
     public GoalsFocusListener(Text text) {
       this.text = text;
@@ -620,9 +620,9 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
   private class BrowseWorkspaceDirAction extends SelectionAdapter {
 
-    private Text target;
+    private final Text target;
 
-    private String label;
+    private final String label;
 
     public BrowseWorkspaceDirAction(Text target, String label) {
       this.target = target;
@@ -649,9 +649,9 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
   private class BrowseWorkspaceFileAction extends SelectionAdapter {
 
-    private Text target;
+    private final Text target;
 
-    private String label;
+    private final String label;
 
     public BrowseWorkspaceFileAction(Text target, String label) {
       this.target = target;
@@ -679,7 +679,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
   private class BrowseDirAction extends SelectionAdapter {
 
-    private Text target;
+    private final Text target;
 
     public BrowseDirAction(Text target) {
       this.target = target;
@@ -698,9 +698,9 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
   private class BrowseFileAction extends SelectionAdapter {
 
-    private Text target;
+    private final Text target;
 
-    private String[] filter;
+    private final String[] filter;
 
     public BrowseFileAction(Text target, String[] filter) {
       this.target = target;
@@ -721,7 +721,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
   private class VariablesAction extends SelectionAdapter {
 
-    private Text target;
+    private final Text target;
 
     public VariablesAction(Text target) {
       this.target = target;

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ConfigurationAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ConfigurationAdapter.java
@@ -29,7 +29,7 @@ import org.eclipse.m2e.model.edit.pom.impl.ConfigurationImpl;
  */
 class ConfigurationAdapter extends TranslatorAdapter implements INodeAdapter {
 
-  private Configuration modelObject;
+  private final Configuration modelObject;
 
   public ConfigurationAdapter(SSESyncResource resource, Element node, Configuration object) {
     super(resource);

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ListAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ListAdapter.java
@@ -39,7 +39,7 @@ import org.eclipse.m2e.model.edit.pom.PomFactory;
 public class ListAdapter extends TranslatorAdapter {
   protected List list;
 
-  private EClass elementType;
+  private final EClass elementType;
 
   public ListAdapter(SSESyncResource resc, Element containerNode, List<?> list, EClass elementType) {
     super(resc);

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ModelObjectAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ModelObjectAdapter.java
@@ -45,13 +45,13 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
  * @author Mike Poindexter
  */
 public class ModelObjectAdapter extends TranslatorAdapter implements Adapter, INodeAdapter {
-  private SSESyncResource resource;
+  private final SSESyncResource resource;
 
-  private EObject eobject;
+  private final EObject eobject;
 
   private Notifier target;
 
-  private Map<EStructuralFeature, TranslatorAdapter> childAdapters = new LinkedHashMap<>();
+  private final Map<EStructuralFeature, TranslatorAdapter> childAdapters = new LinkedHashMap<>();
 
   public ModelObjectAdapter(SSESyncResource resource, EObject eobject, Element node) {
     super(resource);

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/PropertiesAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/PropertiesAdapter.java
@@ -163,7 +163,7 @@ public class PropertiesAdapter extends ListAdapter {
   private class PropertyChildAdapter implements Adapter {
     private Notifier target;
 
-    private PropertyElement property;
+    private final PropertyElement property;
 
     private Element element;
 

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ValueUpdateAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/translators/ValueUpdateAdapter.java
@@ -39,9 +39,9 @@ class ValueUpdateAdapter extends TranslatorAdapter implements INodeAdapter {
   /**
      *
      */
-  private EObject modelObject;
+  private final EObject modelObject;
 
-  private EStructuralFeature feature;
+  private final EStructuralFeature feature;
 
   private List<Node> linkedWhitespaceNodes = Collections.emptyList();
 

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
@@ -26,8 +26,8 @@ public class BNDInstructions {
 
 	private static final String BND_DEFAULT_PROPERTIES_PATH = "bnd-default.properties";
 	public static final BNDInstructions EMPTY = new BNDInstructions("", null);
-	private String key;
-	private String instructions;
+	private final String key;
+	private final String instructions;
 
 	public BNDInstructions(String key, String instructions) {
 		this.key = key;

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -53,7 +53,7 @@ public class CacheManager {
 
 	private volatile boolean invalidated;
 
-	private File folder;
+	private final File folder;
 
 	private CacheManager(File folder) {
 		this.folder = folder;

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetBundle.java
@@ -35,7 +35,7 @@ public class MavenTargetBundle extends TargetBundle {
 
 	private TargetBundle bundle;
 	private IStatus status;
-	private BundleInfo bundleInfo;
+	private final BundleInfo bundleInfo;
 	private boolean isWrapped;
 
 	@Override

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
@@ -81,11 +81,11 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	private final MissingMetadataMode metadataMode;
 	private List<TargetBundle> targetBundles;
 	private List<DependencyNode> dependencyNodes;
-	private Set<Artifact> ignoredArtifacts = new HashSet<>();
+	private final Set<Artifact> ignoredArtifacts = new HashSet<>();
 
-	private Set<Artifact> failedArtifacts = new HashSet<>();
-	private Map<String, BNDInstructions> instructionsMap = new LinkedHashMap<>();
-	private boolean includeSource;
+	private final Set<Artifact> failedArtifacts = new HashSet<>();
+	private final Map<String, BNDInstructions> instructionsMap = new LinkedHashMap<>();
+	private final boolean includeSource;
 
 	public MavenTargetLocation(String groupId, String artifactId, String version, String artifactType,
 			String classifier, MissingMetadataMode metadataMode, String dependencyScope,

--- a/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/actions/ProfileSelectionHandler.java
+++ b/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/actions/ProfileSelectionHandler.java
@@ -170,9 +170,9 @@ public class ProfileSelectionHandler extends AbstractHandler {
 
   class GetProfilesJob extends Job {
 
-    private IProfileManager profileManager;
+    private final IProfileManager profileManager;
 
-    private Set<IMavenProjectFacade> facades;
+    private final Set<IMavenProjectFacade> facades;
 
     private Map<IMavenProjectFacade, List<ProfileData>> allProfiles;
 
@@ -289,13 +289,13 @@ public class ProfileSelectionHandler extends AbstractHandler {
 
   class UpdateProfilesJob extends WorkspaceJob {
 
-    private Map<IMavenProjectFacade, List<ProfileData>> allProfiles;
+    private final Map<IMavenProjectFacade, List<ProfileData>> allProfiles;
 
-    private List<ProfileSelection> sharedProfiles;
+    private final List<ProfileSelection> sharedProfiles;
 
-    private IProfileManager profileManager;
+    private final IProfileManager profileManager;
 
-    private SelectProfilesDialog dialog;
+    private final SelectProfilesDialog dialog;
 
     private UpdateProfilesJob(Map<IMavenProjectFacade, List<ProfileData>> allProfiles,
         List<ProfileSelection> sharedProfiles, IProfileManager profileManager, SelectProfilesDialog dialog) {

--- a/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/dialog/SelectProfilesDialog.java
+++ b/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/dialog/SelectProfilesDialog.java
@@ -426,9 +426,9 @@ public class SelectProfilesDialog extends TitleAreaDialog implements IMenuListen
   private class ProfileLabelProvider extends LabelProvider
       implements ITableLabelProvider, ITableFontProvider, ITableColorProvider {
 
-    private Font implicitActivationFont;
+    private final Font implicitActivationFont;
 
-    private Color inactiveColor;
+    private final Color inactiveColor;
 
     public ProfileLabelProvider(Font defaultFont) {
       FontData[] fds = defaultFont.getFontData();

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/ChangeCreator.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/ChangeCreator.java
@@ -43,13 +43,13 @@ import org.eclipse.text.edits.TextEditGroup;
 public class ChangeCreator {
   private static final Logger log = LoggerFactory.getLogger(ChangeCreator.class);
 
-  private String label;
+  private final String label;
 
-  private IDocument oldDocument;
+  private final IDocument oldDocument;
 
-  private IDocument newDocument;
+  private final IDocument newDocument;
 
-  private IFile oldFile;
+  private final IFile oldFile;
 
   public ChangeCreator(IFile oldFile, IDocument oldDocument, IDocument newDocument, String label) {
     this.newDocument = newDocument;


### PR DESCRIPTION
…- Private fields

EclipseJdt cleanup 'MakePrivateFieldFinal' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>