### PR TITLE
[cleanup] erefactor/EclipseJdt - Use primitive parse methods instead …

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
@@ -97,7 +97,7 @@ public class MavenProperties {
       msg += " (";
       msg += (rev != null ? rev : "");
       if(StringUtils.isNotBlank(timestamp)) {
-        String ts = formatTimestamp(Long.valueOf(timestamp));
+        String ts = formatTimestamp(Long.parseLong(timestamp));
         msg += (rev != null ? "; " : "") + ts;
       }
       msg += ")";

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/IndexesExtensionReader.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/IndexesExtensionReader.java
@@ -73,7 +73,7 @@ public class IndexesExtensionReader implements IRepositoryDiscoverer {
       throws CoreException {
     String indexId = element.getAttribute(ATTR_INDEX_ID);
     String repositoryUrl = element.getAttribute(ATTR_REPOSITORY_URL);
-    boolean isShort = Boolean.valueOf(element.getAttribute(ATTR_IS_SHORT)).booleanValue();
+    boolean isShort = Boolean.parseBoolean(element.getAttribute(ATTR_IS_SHORT));
 
 //    String indexUpdateUrl = element.getAttribute(ATTR_UPDATE_URL);
 //    String archive = element.getAttribute(ATTR_INDEX_ARCHIVE);

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -231,7 +231,7 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
       IJavaProject javaProject) throws CoreException {
     IMavenProjectFacade facade = projectManager.create(javaProject.getProject(), monitor);
     MavenProject mavenProject = facade.getMavenProject(monitor);
-    if(Boolean.valueOf(mavenProject.getProperties()
+    if(Boolean.parseBoolean(mavenProject.getProperties()
         .getProperty(PROPERTY_M2E_DISABLE_ADD_MISSING_J_UNIT5_EXECUTION_DEPENDENCIES, "false"))) { //$NON-NLS-1$
       return;
     }


### PR DESCRIPTION
…of wrapper.

EclipseJdt cleanup 'ParsePrimitive' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>