### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant comparison statement

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
@@ -176,12 +176,8 @@ public class SourceLocationHelper {
             // let's see if it comes from a directly imported pom
             DependencyManagement origMgmt = mavenProject.getOriginalModel().getDependencyManagement();
             org.apache.maven.model.Dependency importDep = findDependencyImport(origMgmt, depId);
-            if(importDep != null) {
-              // use it to show marker on
-              found = importDep;
-            } else {
-              found = null;
-            }
+            // use it to show marker on
+            found = importDep;
           }
         }
       }

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MarkerResolutionWrapper.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MarkerResolutionWrapper.java
@@ -49,10 +49,7 @@ public class MarkerResolutionWrapper implements ICompletionProposal {
       return ((IMarkerResolution2) resolution).getDescription();
     }
     String problemDesc = marker.getAttribute(IMarker.MESSAGE, null);
-    if(problemDesc != null) {
-      return problemDesc;
-    }
-    return null;
+    return problemDesc;
   }
 
   public IContextInformation getContextInformation() {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/MojoParameter.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/MojoParameter.java
@@ -151,10 +151,6 @@ public class MojoParameter {
       i++ ;
     }
 
-    if(param == null) {
-      return null;
-    }
-
     return param;
   }
 }


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveRedundantComparison' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>