### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant modifier

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/IMavenDiscovery.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/IMavenDiscovery.java
@@ -18,5 +18,5 @@ import org.eclipse.swt.widgets.Shell;
 
 public interface IMavenDiscovery {
 
-  public void launch(Shell shell);
+  void launch(Shell shell);
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
@@ -650,7 +650,7 @@ public class PomEdits {
    *
    * @author mkleint
    */
-  public static interface Operation {
+  public interface Operation {
     void process(Document document);
   }
 
@@ -679,7 +679,7 @@ public class PomEdits {
    *
    * @author mkleint
    */
-  public static interface Matcher {
+  public interface Matcher {
     /**
      * returns true if the given element matches the condition.
      *

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/ILifecycleMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/ILifecycleMappingLabelProvider.java
@@ -31,11 +31,11 @@ public interface ILifecycleMappingLabelProvider {
   /**
    * Returns label of Maven Project element, i.e. project itself, packaging type, plugin execution, etc.
    */
-  public String getMavenText();
+  String getMavenText();
 
-  public boolean isError(LifecycleMappingDiscoveryRequest mappingConfiguration);
+  boolean isError(LifecycleMappingDiscoveryRequest mappingConfiguration);
 
-  public ILifecycleMappingRequirement getKey();
+  ILifecycleMappingRequirement getKey();
 
-  public Collection<MavenProject> getProjects();
+  Collection<MavenProject> getProjects();
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/MenuDetectListener.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/MenuDetectListener.java
@@ -35,5 +35,5 @@ public interface MenuDetectListener extends EventListener {
    *
    * @param e an event containing information about the menu detect
    */
-  public void menuDetected(MenuDetectEvent e);
+  void menuDetected(MenuDetectEvent e);
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/Packaging.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/Packaging.java
@@ -28,7 +28,7 @@ public enum Packaging {
 
   private final String text;
 
-  private Packaging(String text) {
+  Packaging(String text) {
     this.text = text;
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/SearchEngine.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/SearchEngine.java
@@ -31,7 +31,7 @@ public interface SearchEngine {
    * @param containingArtifact When looking for exclusion, contains information about artifact we are excluding from.
    * @return
    */
-  public Collection<String> findGroupIds(String searchExpression, Packaging packaging, ArtifactInfo containingArtifact);
+  Collection<String> findGroupIds(String searchExpression, Packaging packaging, ArtifactInfo containingArtifact);
 
   /**
    * Finds artifactIds for given expression
@@ -42,15 +42,15 @@ public interface SearchEngine {
    * @param containingArtifact When looking for exclusion, contains information about artifact we are excluding from.
    * @return
    */
-  public Collection<String> findArtifactIds(String groupId, String searchExpression, Packaging packaging,
+  Collection<String> findArtifactIds(String groupId, String searchExpression, Packaging packaging,
       ArtifactInfo containingArtifact);
 
-  public Collection<String> findVersions(String groupId, String artifactId, String searchExpression, Packaging packaging);
+  Collection<String> findVersions(String groupId, String artifactId, String searchExpression, Packaging packaging);
 
-  public Collection<String> findClassifiers(String groupId, String artifactId, String version, String prefix,
+  Collection<String> findClassifiers(String groupId, String artifactId, String version, String prefix,
       Packaging packaging);
 
-  public Collection<String> findTypes(String groupId, String artifactId, String version, String prefix,
+  Collection<String> findTypes(String groupId, String artifactId, String version, String prefix,
       Packaging packaging);
 
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/Util.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/Util.java
@@ -47,8 +47,8 @@ public class Util {
    *
    * @see Util#proxy(Object, Class)
    */
-  public static interface FileStoreEditorInputStub {
-    public java.net.URI getURI();
+  public interface FileStoreEditorInputStub {
+    java.net.URI getURI();
   }
 
   public static String nvl(String s) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/build/Node.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/build/Node.java
@@ -15,7 +15,7 @@ package org.eclipse.m2e.core.ui.internal.views.build;
 
 interface Node {
 
-  public String getName();
+  String getName();
 
-  public int getBuildCount();
+  int getBuildCount();
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IArtifactNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IArtifactNode.java
@@ -19,5 +19,5 @@ package org.eclipse.m2e.core.ui.internal.views.nodes;
  * @author dyocum
  */
 public interface IArtifactNode {
-  public String getDocumentKey();
+  String getDocumentKey();
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IMavenRepositoryNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/IMavenRepositoryNode.java
@@ -23,13 +23,13 @@ import org.eclipse.swt.graphics.Image;
  */
 public interface IMavenRepositoryNode {
 
-  public Object[] getChildren();
+  Object[] getChildren();
 
-  public String getName();
+  String getName();
 
-  public Image getImage();
+  Image getImage();
 
-  public boolean hasChildren();
+  boolean hasChildren();
 
-  public boolean isUpdating();
+  boolean isUpdating();
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/IMavenDiscoveryUI.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/IMavenDiscoveryUI.java
@@ -25,6 +25,6 @@ public interface IMavenDiscoveryUI {
   /**
    * Returns true if postInstallHook has been scheduled for execution and false otherwise
    */
-  public boolean implement(List<IMavenDiscoveryProposal> proposals, IRunnableWithProgress postInstallHook,
+  boolean implement(List<IMavenDiscoveryProposal> proposals, IRunnableWithProgress postInstallHook,
       IRunnableContext context, Collection<String> projectsToConfigure);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ILocalRepositoryListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ILocalRepositoryListener.java
@@ -27,6 +27,6 @@ public interface ILocalRepositoryListener {
   /**
    * New artifact has been downloaded or installed to maven local repository
    */
-  public void artifactInstalled(File repositoryBasedir, ArtifactKey baseArtifact, ArtifactKey artifact,
+  void artifactInstalled(File repositoryBasedir, ArtifactKey baseArtifact, ArtifactKey artifact,
       File artifactFile);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -63,12 +63,11 @@ public interface IMaven {
    *
    * @deprecated see {@link IMavenExecutionContext}.
    */
-  @Deprecated
-  public MavenExecutionRequest createExecutionRequest(IProgressMonitor monitor) throws CoreException;
+  @Deprecated MavenExecutionRequest createExecutionRequest(IProgressMonitor monitor) throws CoreException;
 
   // POM Model read/write operations
 
-  public Model readModel(InputStream in) throws CoreException;
+  Model readModel(InputStream in) throws CoreException;
 
   /**
    * Using {@link File} representations in Eclipse workspaces is prone to errors, since remote filesystems must be
@@ -77,10 +76,9 @@ public interface IMaven {
    *
    * @deprecated use {@link #readModel(InputStream)} instead.
    */
-  @Deprecated
-  public Model readModel(File pomFile) throws CoreException;
+  @Deprecated Model readModel(File pomFile) throws CoreException;
 
-  public void writeModel(Model model, OutputStream out) throws CoreException;
+  void writeModel(Model model, OutputStream out) throws CoreException;
 
   // artifact resolution
 
@@ -90,45 +88,44 @@ public interface IMaven {
    * @return Artifact resolved artifact
    * @throws CoreException if the artifact cannot be resolved.
    */
-  public Artifact resolve(String groupId, String artifactId, String version, String type, String classifier,
+  Artifact resolve(String groupId, String artifactId, String version, String type, String classifier,
       List<ArtifactRepository> artifactRepositories, IProgressMonitor monitor) throws CoreException;
 
   /**
    * Returns path of the specified artifact relative to repository baseDir. Can use used to access local repository
    * files bypassing maven resolution logic.
    */
-  public String getArtifactPath(ArtifactRepository repository, String groupId, String artifactId, String version,
+  String getArtifactPath(ArtifactRepository repository, String groupId, String artifactId, String version,
       String type, String classifier) throws CoreException;
 
   /**
    * Returns true if the artifact does NOT exist in the local repository and known to be UNavailable from all specified
    * repositories.
    */
-  public boolean isUnavailable(String groupId, String artifactId, String version, String type, String classifier,
+  boolean isUnavailable(String groupId, String artifactId, String version, String type, String classifier,
       List<ArtifactRepository> repositories) throws CoreException;
 
   // read MavenProject
 
-  public MavenProject readProject(File pomFile, IProgressMonitor monitor) throws CoreException;
+  MavenProject readProject(File pomFile, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #readMavenProject(File, IProgressMonitor)} instead.
    */
-  @Deprecated
-  public MavenExecutionResult readProject(MavenExecutionRequest request, IProgressMonitor monitor) throws CoreException;
+  @Deprecated MavenExecutionResult readProject(MavenExecutionRequest request, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @since 1.4
    * @see {@link #readMavenProjects(File, ProjectBuildingRequest)} to group requests and improve performance (RAM and
    *      CPU)
    */
-  public MavenExecutionResult readMavenProject(File pomFile, ProjectBuildingRequest configuration) throws CoreException;
+  MavenExecutionResult readMavenProject(File pomFile, ProjectBuildingRequest configuration) throws CoreException;
 
   /**
    * @since 1.10
    */
-  public Map<File, MavenExecutionResult> readMavenProjects(Collection<File> pomFiles,
+  Map<File, MavenExecutionResult> readMavenProjects(Collection<File> pomFiles,
       ProjectBuildingRequest configuration)
       throws CoreException;
 
@@ -138,7 +135,7 @@ public interface IMaven {
    * Do note that MavenProject.getParentProject() cannot be used for detached MavenProject instances,
    * #resolveParentProject to read parent project instance.
    */
-  public void detachFromSession(MavenProject project) throws CoreException;
+  void detachFromSession(MavenProject project) throws CoreException;
 
   /**
    * Returns MavenProject parent project or null if no such project.
@@ -147,92 +144,84 @@ public interface IMaven {
    *             {@link #resolveParentProject(MavenProject, IProgressMonitor)} instead.
    * @TODO Currently returns null in case of resolution error, consider if it should throw CoreException instead
    */
-  @Deprecated
-  public MavenProject resolveParentProject(MavenExecutionRequest request, MavenProject project, IProgressMonitor monitor)
+  @Deprecated MavenProject resolveParentProject(MavenExecutionRequest request, MavenProject project, IProgressMonitor monitor)
       throws CoreException;
 
-  public MavenProject resolveParentProject(MavenProject project, IProgressMonitor monitor) throws CoreException;
+  MavenProject resolveParentProject(MavenProject project, IProgressMonitor monitor) throws CoreException;
 
   // execution
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}
    */
-  @Deprecated
-  public MavenExecutionResult execute(MavenExecutionRequest request, IProgressMonitor monitor);
+  @Deprecated MavenExecutionResult execute(MavenExecutionRequest request, IProgressMonitor monitor);
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}
    */
-  @Deprecated
-  public MavenSession createSession(MavenExecutionRequest request, MavenProject project);
+  @Deprecated MavenSession createSession(MavenExecutionRequest request, MavenProject project);
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #execute(MojoExecution, IProgressMonitor)} instead.
    */
-  @Deprecated
-  public void execute(MavenSession session, MojoExecution execution, IProgressMonitor monitor);
+  @Deprecated void execute(MavenSession session, MojoExecution execution, IProgressMonitor monitor);
 
   /**
    * @since 1.4
    */
-  public void execute(MavenProject project, MojoExecution execution, IProgressMonitor monitor) throws CoreException;
+  void execute(MavenProject project, MojoExecution execution, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #calculateExecutionPlan(MavenProject, List, boolean, IProgressMonitor)} instead.
    */
-  @Deprecated
-  public MavenExecutionPlan calculateExecutionPlan(MavenSession session, MavenProject project, List<String> goals,
+  @Deprecated MavenExecutionPlan calculateExecutionPlan(MavenSession session, MavenProject project, List<String> goals,
       boolean setup, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @since 1.4
    */
-  public MavenExecutionPlan calculateExecutionPlan(MavenProject project, List<String> goals, boolean setup,
+  MavenExecutionPlan calculateExecutionPlan(MavenProject project, List<String> goals, boolean setup,
       IProgressMonitor monitor) throws CoreException;
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #setupMojoExecution(MavenProject, MojoExecution)} instead.
    */
-  @Deprecated
-  public MojoExecution setupMojoExecution(MavenSession session, MavenProject project, MojoExecution execution)
+  @Deprecated MojoExecution setupMojoExecution(MavenSession session, MavenProject project, MojoExecution execution)
       throws CoreException;
 
   /**
    * @since 1.4
    */
-  public MojoExecution setupMojoExecution(MavenProject project, MojoExecution execution, IProgressMonitor monitor)
+  MojoExecution setupMojoExecution(MavenProject project, MojoExecution execution, IProgressMonitor monitor)
       throws CoreException;
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #getMojoParameterValue(MojoExecution, String, Class)} instead.
    */
-  @Deprecated
-  public <T> T getMojoParameterValue(MavenSession session, MojoExecution mojoExecution, String parameter,
+  @Deprecated <T> T getMojoParameterValue(MavenSession session, MojoExecution mojoExecution, String parameter,
       Class<T> asType) throws CoreException;
 
   /**
    * @since 1.4
    */
-  public <T> T getMojoParameterValue(MavenProject project, MojoExecution mojoExecution, String parameter,
+  <T> T getMojoParameterValue(MavenProject project, MojoExecution mojoExecution, String parameter,
       Class<T> asType, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String)} instead.
    */
-  @Deprecated
-  public <T> T getMojoParameterValue(String parameter, Class<T> type, MavenSession session, Plugin plugin,
+  @Deprecated <T> T getMojoParameterValue(String parameter, Class<T> type, MavenSession session, Plugin plugin,
       ConfigurationContainer configuration, String goal) throws CoreException;
 
   /**
    * @since 1.4
    */
-  public <T> T getMojoParameterValue(MavenProject project, String parameter, Class<T> type, Plugin plugin,
+  <T> T getMojoParameterValue(MavenProject project, String parameter, Class<T> type, Plugin plugin,
       ConfigurationContainer configuration, String goal, IProgressMonitor monitor) throws CoreException;
 
   // configuration
@@ -240,55 +229,55 @@ public interface IMaven {
   /**
    * TODO should we expose Settings or provide access to servers and proxies instead?
    */
-  public Settings getSettings() throws CoreException;
+  Settings getSettings() throws CoreException;
 
-  public String getLocalRepositoryPath();
+  String getLocalRepositoryPath();
 
-  public ArtifactRepository getLocalRepository() throws CoreException;
+  ArtifactRepository getLocalRepository() throws CoreException;
 
-  public void populateDefaults(MavenExecutionRequest request) throws CoreException;
+  void populateDefaults(MavenExecutionRequest request) throws CoreException;
 
-  public ArtifactRepository createArtifactRepository(String id, String url) throws CoreException;
+  ArtifactRepository createArtifactRepository(String id, String url) throws CoreException;
 
   /**
    * Convenience method, fully equivalent to getArtifactRepositories(true)
    */
-  public List<ArtifactRepository> getArtifactRepositories() throws CoreException;
+  List<ArtifactRepository> getArtifactRepositories() throws CoreException;
 
   /**
    * Returns list of remote artifact repositories configured in settings.xml. Only profiles active by default are
    * considered when calculating the list. If injectSettings=true, mirrors, authentication and proxy info will be
    * injected. If injectSettings=false, raw repository definition will be used.
    */
-  public List<ArtifactRepository> getArtifactRepositories(boolean injectSettings) throws CoreException;
+  List<ArtifactRepository> getArtifactRepositories(boolean injectSettings) throws CoreException;
 
-  public List<ArtifactRepository> getPluginArtifactRepositories() throws CoreException;
+  List<ArtifactRepository> getPluginArtifactRepositories() throws CoreException;
 
-  public List<ArtifactRepository> getPluginArtifactRepositories(boolean injectSettings) throws CoreException;
+  List<ArtifactRepository> getPluginArtifactRepositories(boolean injectSettings) throws CoreException;
 
-  public Settings buildSettings(String globalSettings, String userSettings) throws CoreException;
+  Settings buildSettings(String globalSettings, String userSettings) throws CoreException;
 
-  public void writeSettings(Settings settings, OutputStream out) throws CoreException;
+  void writeSettings(Settings settings, OutputStream out) throws CoreException;
 
-  public List<SettingsProblem> validateSettings(String settings);
+  List<SettingsProblem> validateSettings(String settings);
 
-  public List<Mirror> getMirrors() throws CoreException;
+  List<Mirror> getMirrors() throws CoreException;
 
-  public Mirror getMirror(ArtifactRepository repo) throws CoreException;
+  Mirror getMirror(ArtifactRepository repo) throws CoreException;
 
-  public void addSettingsChangeListener(ISettingsChangeListener listener);
+  void addSettingsChangeListener(ISettingsChangeListener listener);
 
-  public void removeSettingsChangeListener(ISettingsChangeListener listener);
+  void removeSettingsChangeListener(ISettingsChangeListener listener);
 
-  public void reloadSettings() throws CoreException;
+  void reloadSettings() throws CoreException;
 
-  public Server decryptPassword(Server server) throws CoreException;
-
-  /** @provisional */
-  public void addLocalRepositoryListener(ILocalRepositoryListener listener);
+  Server decryptPassword(Server server) throws CoreException;
 
   /** @provisional */
-  public void removeLocalRepositoryListener(ILocalRepositoryListener listener);
+  void addLocalRepositoryListener(ILocalRepositoryListener listener);
+
+  /** @provisional */
+  void removeLocalRepositoryListener(ILocalRepositoryListener listener);
 
   /**
    * Creates wagon TransferListener that can be used with Archetype, NexusIndexer and other components that use wagon
@@ -297,24 +286,23 @@ public interface IMaven {
    *
    * @deprecated IMaven API should not expose maven.repository.ArtifactTransferListener
    */
-  @Deprecated
-  public TransferListener createTransferListener(IProgressMonitor monitor);
+  @Deprecated TransferListener createTransferListener(IProgressMonitor monitor);
 
-  public ProxyInfo getProxyInfo(String protocol) throws CoreException;
+  ProxyInfo getProxyInfo(String protocol) throws CoreException;
 
   /**
    * Sort projects by build order
    */
-  public List<MavenProject> getSortedProjects(List<MavenProject> projects) throws CoreException;
+  List<MavenProject> getSortedProjects(List<MavenProject> projects) throws CoreException;
 
-  public String resolvePluginVersion(String groupId, String artifactId, MavenSession session) throws CoreException;
+  String resolvePluginVersion(String groupId, String artifactId, MavenSession session) throws CoreException;
 
   /**
    * Returns new mojo instances configured according to provided mojoExecution. Caller must release returned mojo with
    * {@link #releaseMojo(Object, MojoExecution)}. This method is intended to allow introspection of mojo configuration
    * parameters, use {@link #execute(MavenSession, MojoExecution, IProgressMonitor)} to execute mojo.
    */
-  public <T> T getConfiguredMojo(MavenSession session, MojoExecution mojoExecution, Class<T> clazz)
+  <T> T getConfiguredMojo(MavenSession session, MojoExecution mojoExecution, Class<T> clazz)
       throws CoreException;
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
@@ -29,52 +29,52 @@ public interface IMavenConfiguration {
 
   // listeners
 
-  public void addConfigurationChangeListener(IMavenConfigurationChangeListener listener);
+  void addConfigurationChangeListener(IMavenConfigurationChangeListener listener);
 
   // remote dependency resolution
 
-  public boolean isOffline();
+  boolean isOffline();
 
   /**
    * One of org.eclipse.aether.repository.RepositoryPolicy.UPDATE constants or null. If not null, the specified update
    * policy overrides the update policies of the remote repositories being used for resolution.
    */
-  public String getGlobalUpdatePolicy();
+  String getGlobalUpdatePolicy();
 
   // maven settings.xml
 
-  public String getGlobalSettingsFile();
+  String getGlobalSettingsFile();
 
   //settable for embedded maven
-  public void setGlobalSettingsFile(String absolutePath) throws CoreException;
+  void setGlobalSettingsFile(String absolutePath) throws CoreException;
 
-  public String getUserSettingsFile();
+  String getUserSettingsFile();
 
-  public void setUserSettingsFile(String absolutePath) throws CoreException;
+  void setUserSettingsFile(String absolutePath) throws CoreException;
 
   // resolution
 
-  public boolean isDownloadSources();
+  boolean isDownloadSources();
 
-  public boolean isDownloadJavaDoc();
+  boolean isDownloadJavaDoc();
 
   // maven execution
 
-  public boolean isDebugOutput();
+  boolean isDebugOutput();
 
   // startup update behaviour
 
-  public boolean isUpdateProjectsOnStartup();
+  boolean isUpdateProjectsOnStartup();
 
-  public boolean isUpdateIndexesOnStartup();
+  boolean isUpdateIndexesOnStartup();
 
   // new experimental preferences
 
-  public boolean isHideFoldersOfNestedProjects();
+  boolean isHideFoldersOfNestedProjects();
 
-  public String getWorkspaceLifecycleMappingMetadataFile();
+  String getWorkspaceLifecycleMappingMetadataFile();
 
-  public void setWorkspaceLifecycleMappingMetadataFile(String location) throws CoreException;
+  void setWorkspaceLifecycleMappingMetadataFile(String location) throws CoreException;
 
   /**
    * Returns {@link IMarker} severity of "out-of-date" project problem
@@ -82,7 +82,7 @@ public interface IMavenConfiguration {
    * @return One of <code>ignore</code>, <code>warning</code> or <code>error</code>.
    * @since 1.5
    */
-  public String getOutOfDateProjectSeverity();
+  String getOutOfDateProjectSeverity();
 
   /**
    * Returns the global checksum policy applied on {@link MavenExecutionRequest}s.
@@ -94,7 +94,7 @@ public interface IMavenConfiguration {
    * @see {@link ArtifactRepositoryPolicy#CHECKSUM_POLICY_IGNORE}
    * @since 1.5
    */
-  public String getGlobalChecksumPolicy();
+  String getGlobalChecksumPolicy();
 
   /**
    * Returns {@link IMarker} severity of "Not Covered Mojo Execution" problem.
@@ -102,7 +102,7 @@ public interface IMavenConfiguration {
    * @return One of <code>ignore</code>, <code>warning</code> or <code>error</code>.
    * @since 1.5
    */
-  public String getNotCoveredMojoExecutionSeverity();
+  String getNotCoveredMojoExecutionSeverity();
 
   /**
    * Returns <code>true</code> if project configuration should be automatically updated when out-of-date.
@@ -110,7 +110,7 @@ public interface IMavenConfiguration {
    * @return <code>true</code> if project configuration should be automatically updated when out-of-date.
    * @since 1.6
    */
-  public boolean isAutomaticallyUpdateConfiguration();
+  boolean isAutomaticallyUpdateConfiguration();
 
   /**
    * Returns {@link IMarker} severity of "Overriding Managed version" problem.
@@ -118,13 +118,13 @@ public interface IMavenConfiguration {
    * @return One of <code>ignore</code>, <code>warning</code> or <code>error</code>.
    * @since 1.7
    */
-  public String getOverridingManagedVersionExecutionSeverity();
+  String getOverridingManagedVersionExecutionSeverity();
 
   /**
    * @experimental This can cause builds to run in parallel, and m2e is not yet protected against parallel execution of
    *               Maven and its plugins (which is usually not supported).
    * @return whether to use null as scheduling rule for builder.
    */
-  public boolean buildWithNullSchedulingRule();
+  boolean buildWithNullSchedulingRule();
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfigurationChangeListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfigurationChangeListener.java
@@ -23,6 +23,6 @@ import org.eclipse.core.runtime.CoreException;
  */
 public interface IMavenConfigurationChangeListener {
 
-  public void mavenConfigurationChange(MavenConfigurationChangeEvent event) throws CoreException;
+  void mavenConfigurationChange(MavenConfigurationChangeEvent event) throws CoreException;
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenLauncherConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenLauncherConfiguration.java
@@ -31,13 +31,13 @@ public interface IMavenLauncherConfiguration {
   /**
    * Special realm name used for launcher classpath entries.
    */
-  public static final String LAUNCHER_REALM = "]launcher"; //$NON-NLS-1$
+  String LAUNCHER_REALM = "]launcher"; //$NON-NLS-1$
 
-  public void setMainType(String type, String realm);
+  void setMainType(String type, String realm);
 
-  public void addRealm(String realm);
+  void addRealm(String realm);
 
-  public void addProjectEntry(IMavenProjectFacade facade);
+  void addProjectEntry(IMavenProjectFacade facade);
 
-  public void addArchiveEntry(String entry) throws CoreException;
+  void addArchiveEntry(String entry) throws CoreException;
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ISettingsChangeListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ISettingsChangeListener.java
@@ -25,5 +25,5 @@ import org.apache.maven.settings.Settings;
  */
 public interface ISettingsChangeListener {
 
-  public void settingsChanged(Settings settings) throws CoreException;
+  void settingsChanged(Settings settings) throws CoreException;
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntime.java
@@ -29,20 +29,20 @@ import org.eclipse.core.runtime.IProgressMonitor;
 @SuppressWarnings("deprecation")
 public interface MavenRuntime {
 
-  public abstract boolean isEditable();
+  boolean isEditable();
 
   /**
    * Reads m2.conf file and notifies configuration collector of the logical content of plexus configuration. Collector
    * callback methods are invoked in the order corresponding configuration elements are present in m2.conf file.
    */
-  public abstract void createLauncherConfiguration(IMavenLauncherConfiguration collector, IProgressMonitor monitor)
+  void createLauncherConfiguration(IMavenLauncherConfiguration collector, IProgressMonitor monitor)
       throws CoreException;
 
-  public abstract String getLocation();
+  String getLocation();
 
-  public abstract String getSettings();
+  String getSettings();
 
-  public abstract boolean isAvailable();
+  boolean isAvailable();
 
-  public String getVersion();
+  String getVersion();
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
@@ -20,111 +20,111 @@ package org.eclipse.m2e.core.internal;
  */
 public interface IMavenConstants {
 
-  public static final String PLUGIN_ID = "org.eclipse.m2e.core"; //$NON-NLS-1$
+  String PLUGIN_ID = "org.eclipse.m2e.core"; //$NON-NLS-1$
 
-  public static final String NATURE_ID = PLUGIN_ID + ".maven2Nature"; //$NON-NLS-1$
+  String NATURE_ID = PLUGIN_ID + ".maven2Nature"; //$NON-NLS-1$
 
-  public static final String BUILDER_ID = PLUGIN_ID + ".maven2Builder"; //$NON-NLS-1$
+  String BUILDER_ID = PLUGIN_ID + ".maven2Builder"; //$NON-NLS-1$
 
-  public static final String MARKER_ID = PLUGIN_ID + ".maven2Problem"; //$NON-NLS-1$
+  String MARKER_ID = PLUGIN_ID + ".maven2Problem"; //$NON-NLS-1$
 
-  public static final String MARKER_POM_LOADING_ID = MARKER_ID + ".pomloading"; //$NON-NLS-1$
+  String MARKER_POM_LOADING_ID = MARKER_ID + ".pomloading"; //$NON-NLS-1$
 
-  public static final String MARKER_CONFIGURATION_ID = MARKER_ID + ".configuration"; //$NON-NLS-1$
+  String MARKER_CONFIGURATION_ID = MARKER_ID + ".configuration"; //$NON-NLS-1$
 
-  public static final String MARKER_LIFECYCLEMAPPING_ID = MARKER_ID + ".lifecycleMapping"; //$NON-NLS-1$
+  String MARKER_LIFECYCLEMAPPING_ID = MARKER_ID + ".lifecycleMapping"; //$NON-NLS-1$
 
-  public static final String MARKER_DEPENDENCY_ID = MARKER_ID + ".dependency"; //$NON-NLS-1$
+  String MARKER_DEPENDENCY_ID = MARKER_ID + ".dependency"; //$NON-NLS-1$
 
-  public static final String MARKER_BUILD_ID = MARKER_ID + ".build"; //$NON-NLS-1$
+  String MARKER_BUILD_ID = MARKER_ID + ".build"; //$NON-NLS-1$
 
-  public static final String MARKER_BUILD_PARTICIPANT_ID = MARKER_BUILD_ID + ".participant"; //$NON-NLS-1$
+  String MARKER_BUILD_PARTICIPANT_ID = MARKER_BUILD_ID + ".participant"; //$NON-NLS-1$
 
   /**
    * string that gets included in pom.xml file comments and makes the marker manager to ignore the managed version
    * override marker
    */
-  public static final String MARKER_IGNORE_MANAGED = "$NO-MVN-MAN-VER$";//$NON-NLS-1$
+  String MARKER_IGNORE_MANAGED = "$NO-MVN-MAN-VER$";//$NON-NLS-1$
 
-  public static final String MAVEN_COMPONENT_CONTRIBUTORS_XPT = PLUGIN_ID + ".mavenComponentContributors"; //$NON-NLS-1$
+  String MAVEN_COMPONENT_CONTRIBUTORS_XPT = PLUGIN_ID + ".mavenComponentContributors"; //$NON-NLS-1$
 
-  public static final String POM_FILE_NAME = "pom.xml"; //$NON-NLS-1$
+  String POM_FILE_NAME = "pom.xml"; //$NON-NLS-1$
 
-  public static final String PREFERENCE_PAGE_ID = PLUGIN_ID + ".MavenProjectPreferencePage"; //$NON-NLS-1$
+  String PREFERENCE_PAGE_ID = PLUGIN_ID + ".MavenProjectPreferencePage"; //$NON-NLS-1$
 
-  public static final String NO_WORKSPACE_PROJECTS = "noworkspace"; //$NON-NLS-1$
+  String NO_WORKSPACE_PROJECTS = "noworkspace"; //$NON-NLS-1$
 
-  public static final String ACTIVE_PROFILES = "profiles"; //$NON-NLS-1$
+  String ACTIVE_PROFILES = "profiles"; //$NON-NLS-1$
 
-  public static final String FILTER_RESOURCES = "filterresources"; //$NON-NLS-1$
+  String FILTER_RESOURCES = "filterresources"; //$NON-NLS-1$
 
-  public static final String JAVADOC_CLASSIFIER = "javadoc"; //$NON-NLS-1$
+  String JAVADOC_CLASSIFIER = "javadoc"; //$NON-NLS-1$
 
-  public static final String SOURCES_CLASSIFIER = "sources"; //$NON-NLS-1$
+  String SOURCES_CLASSIFIER = "sources"; //$NON-NLS-1$
 
   /**
    * The name of the folder containing metadata information for the workspace.
    */
-  public static final String METADATA_FOLDER = ".metadata"; //$NON-NLS-1$
+  String METADATA_FOLDER = ".metadata"; //$NON-NLS-1$
 
-  public static final String INDEX_UPDATE_PROP = "indexUpdate"; //$NON-NLS-1$
+  String INDEX_UPDATE_PROP = "indexUpdate"; //$NON-NLS-1$
 
   /**
    * marker containing this attribute (with whatever value) will be considered to contain a quick fix and will be marker
    * appropriately in the editor.
    */
-  public static final String MARKER_ATTR_EDITOR_HINT = "editor_hint";//$NON-NLS-1$
+  String MARKER_ATTR_EDITOR_HINT = "editor_hint";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_PACKAGING = "packaging"; //$NON-NLS-1$
+  String MARKER_ATTR_PACKAGING = "packaging"; //$NON-NLS-1$
 
-  public static final String MARKER_ATTR_ARTIFACT_ID = "artifactId";//$NON-NLS-1$
+  String MARKER_ATTR_ARTIFACT_ID = "artifactId";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_CONFIGURATOR_ID = "configuratorId";//$NON-NLS-1$
+  String MARKER_ATTR_CONFIGURATOR_ID = "configuratorId";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_EXECUTION_ID = "executionId";//$NON-NLS-1$
+  String MARKER_ATTR_EXECUTION_ID = "executionId";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_GOAL = "goal";//$NON-NLS-1$
+  String MARKER_ATTR_GOAL = "goal";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_GROUP_ID = "groupId";//$NON-NLS-1$
+  String MARKER_ATTR_GROUP_ID = "groupId";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_LIFECYCLE_PHASE = "lifecyclePhase";//$NON-NLS-1$
+  String MARKER_ATTR_LIFECYCLE_PHASE = "lifecyclePhase";//$NON-NLS-1$
 
-  public static final String MARKER_ATTR_VERSION = "version";//$NON-NLS-1$
+  String MARKER_ATTR_VERSION = "version";//$NON-NLS-1$
 
   /**
    * @since 1.4.0
    */
-  public static final String MARKER_ATTR_CLASSIFIER = "classifier";//$NON-NLS-1$
+  String MARKER_ATTR_CLASSIFIER = "classifier";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_PARENT_GROUP_ID = "parent_groupid";//$NON-NLS-1$
+  String EDITOR_HINT_PARENT_GROUP_ID = "parent_groupid";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_PARENT_VERSION = "parent_version";//$NON-NLS-1$
+  String EDITOR_HINT_PARENT_VERSION = "parent_version";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_MANAGED_DEPENDENCY_OVERRIDE = "managed_dependency_override";//$NON-NLS-1$
+  String EDITOR_HINT_MANAGED_DEPENDENCY_OVERRIDE = "managed_dependency_override";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_MANAGED_PLUGIN_OVERRIDE = "managed_plugin_override";//$NON-NLS-1$
+  String EDITOR_HINT_MANAGED_PLUGIN_OVERRIDE = "managed_plugin_override";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_MISSING_SCHEMA = "missing_schema";//$NON-NLS-1$
+  String EDITOR_HINT_MISSING_SCHEMA = "missing_schema";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION = "not_covered_mojo_execution";//$NON-NLS-1$
+  String EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION = "not_covered_mojo_execution";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING = "implicit_lifecyclemaping";//$NON-NLS-1$
+  String EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING = "implicit_lifecyclemaping";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_UNKNOWN_LIFECYCLE_ID = "unknown_lifecycle_id";//$NON-NLS-1$
+  String EDITOR_HINT_UNKNOWN_LIFECYCLE_ID = "unknown_lifecycle_id";//$NON-NLS-1$
 
-  public static final String EDITOR_HINT_MISSING_CONFIGURATOR = "missing_configurator";//$NON-NLS-1$
+  String EDITOR_HINT_MISSING_CONFIGURATOR = "missing_configurator";//$NON-NLS-1$
 
-  public static final String MARKER_COLUMN_START = "columnStart"; //$NON-NLS-1$
+  String MARKER_COLUMN_START = "columnStart"; //$NON-NLS-1$
 
-  public static final String MARKER_COLUMN_END = "columnEnd"; //$NON-NLS-1$
+  String MARKER_COLUMN_END = "columnEnd"; //$NON-NLS-1$
 
-  public static final String MARKER_CAUSE_RESOURCE_PATH = "causeResourcePath"; //$NON-NLS-1$
+  String MARKER_CAUSE_RESOURCE_PATH = "causeResourcePath"; //$NON-NLS-1$
 
-  public static final String MARKER_CAUSE_RESOURCE_ID = "causeResourceId"; //$NON-NLS-1$
+  String MARKER_CAUSE_RESOURCE_ID = "causeResourceId"; //$NON-NLS-1$
 
-  public static final String MARKER_CAUSE_COLUMN_START = "causeColumnStart"; //$NON-NLS-1$
+  String MARKER_CAUSE_COLUMN_START = "causeColumnStart"; //$NON-NLS-1$
 
-  public static final String MARKER_CAUSE_COLUMN_END = "causeColumnEnd"; //$NON-NLS-1$
+  String MARKER_CAUSE_COLUMN_END = "causeColumnEnd"; //$NON-NLS-1$
 
-  public static final String MARKER_CAUSE_LINE_NUMBER = "causeLineNumber"; //$NON-NLS-1$
+  String MARKER_CAUSE_LINE_NUMBER = "causeLineNumber"; //$NON-NLS-1$
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/BuildDebugHook.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/BuildDebugHook.java
@@ -32,10 +32,10 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
  */
 public interface BuildDebugHook {
 
-  public void buildStart(IMavenProjectFacade projectFacade, int kind, Map<String, String> args,
+  void buildStart(IMavenProjectFacade projectFacade, int kind, Map<String, String> args,
       Map<MojoExecutionKey, List<AbstractBuildParticipant>> participants, IResourceDelta delta, IProgressMonitor monitor);
 
-  public void buildParticipant(IMavenProjectFacade projectFacade, MojoExecutionKey mojoExecutionKey,
+  void buildParticipant(IMavenProjectFacade projectFacade, MojoExecutionKey mojoExecutionKey,
       AbstractBuildParticipant participant, Set<File> files, IProgressMonitor monitor);
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/DeltaProvider.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/DeltaProvider.java
@@ -18,5 +18,5 @@ import org.eclipse.core.resources.IResourceDelta;
 
 
 interface DeltaProvider {
-  public IResourceDelta getDelta(IProject project);
+  IResourceDelta getDelta(IProject project);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/IIncrementalBuildFramework.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/IIncrementalBuildFramework.java
@@ -31,29 +31,29 @@ public interface IIncrementalBuildFramework {
    * @experimental this interface is part of work in progress and can be changed or removed without notice.
    * @since 1.6
    */
-  public static interface BuildResultCollector {
+  public interface BuildResultCollector {
 
-    public void refresh(File file);
+    void refresh(File file);
 
-    public void addMessage(File file, int line, int column, String message, int severity, Throwable cause);
+    void addMessage(File file, int line, int column, String message, int severity, Throwable cause);
 
-    public void removeMessages(File file);
+    void removeMessages(File file);
 
     /**
      * @since 1.6.2
      */
-    public Set<File> getFiles();
+    Set<File> getFiles();
   }
 
   /**
    * @experimental this interface is part of work in progress and can be changed or removed without notice.
    * @since 1.6
    */
-  public static interface BuildContext {
-    public void release();
+  public interface BuildContext {
+    void release();
   }
 
-  public BuildContext setupProjectBuildContext(IProject project, int kind, IResourceDelta delta,
+  BuildContext setupProjectBuildContext(IProject project, int kind, IResourceDelta delta,
       BuildResultCollector results) throws CoreException;
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomHandler.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/content/PomHandler.java
@@ -78,7 +78,7 @@ public final class PomHandler extends DefaultHandler {
    * @throws ParserConfigurationException If a parser of the given configuration cannot be created.
    * @throws SAXException If something in general goes wrong when creating the parser.
    */
-  private final SAXParser createParser(SAXParserFactory parserFactory) throws ParserConfigurationException,
+  private SAXParser createParser(SAXParserFactory parserFactory) throws ParserConfigurationException,
       SAXException, SAXNotRecognizedException, SAXNotSupportedException {
     // Initialize the parser.
     final SAXParser parser = parserFactory.newSAXParser();
@@ -136,7 +136,7 @@ public final class PomHandler extends DefaultHandler {
   }
 
   @Override
-  public final void startElement(final String uri, final String elementName, final String qualifiedName,
+  public void startElement(final String uri, final String elementName, final String qualifiedName,
       final Attributes attributes) throws SAXException {
     fLevel++ ;
     if(fTopElementFound == null) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IIndex.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IIndex.java
@@ -29,22 +29,22 @@ public interface IIndex {
 
   // search keys
 
-  public static final String SEARCH_GROUP = "groupId"; //$NON-NLS-1$
+  String SEARCH_GROUP = "groupId"; //$NON-NLS-1$
 
-  public static final String SEARCH_ARTIFACT = "artifact"; //$NON-NLS-1$
+  String SEARCH_ARTIFACT = "artifact"; //$NON-NLS-1$
 
-  public static final String SEARCH_PLUGIN = "plugin"; //$NON-NLS-1$
+  String SEARCH_PLUGIN = "plugin"; //$NON-NLS-1$
 
-  public static final String SEARCH_ARCHETYPE = "archetype"; //$NON-NLS-1$
+  String SEARCH_ARCHETYPE = "archetype"; //$NON-NLS-1$
 
-  public static final String SEARCH_PACKAGING = "packaging"; //$NON-NLS-1$
+  String SEARCH_PACKAGING = "packaging"; //$NON-NLS-1$
 
-  public static final String SEARCH_SHA1 = "sha1"; //$NON-NLS-1$
+  String SEARCH_SHA1 = "sha1"; //$NON-NLS-1$
 
   /**
    * like SEARCH_ARTIFACT but will only return artifacts with packaging == pom
    */
-  public static final String SEARCH_PARENTS = "parents"; //$NON-NLS-1$
+  String SEARCH_PARENTS = "parents"; //$NON-NLS-1$
 
   // search classifiers
 
@@ -63,29 +63,29 @@ public interface IIndex {
 
   //
 
-  public static final int SEARCH_JARS = 1 << 0;
+  int SEARCH_JARS = 1 << 0;
 
-  public static final int SEARCH_JAVADOCS = 1 << 1;
+  int SEARCH_JAVADOCS = 1 << 1;
 
-  public static final int SEARCH_SOURCES = 1 << 2;
+  int SEARCH_SOURCES = 1 << 2;
 
-  public static final int SEARCH_TESTS = 1 << 3;
+  int SEARCH_TESTS = 1 << 3;
 
-  public static final int SEARCH_ALL = 15;
+  int SEARCH_ALL = 15;
 
   // availability flags
 
-  public static final int PRESENT = 1;
+  int PRESENT = 1;
 
-  public static final int NOT_PRESENT = 0;
+  int NOT_PRESENT = 0;
 
-  public static final int NOT_AVAILABLE = 2;
+  int NOT_AVAILABLE = 2;
 
   // index queries
 
-  public IndexedArtifactFile getIndexedArtifactFile(ArtifactKey artifact) throws CoreException;
+  IndexedArtifactFile getIndexedArtifactFile(ArtifactKey artifact) throws CoreException;
 
-  public IndexedArtifactFile identify(File file) throws CoreException;
+  IndexedArtifactFile identify(File file) throws CoreException;
 
   /**
    * Performs a search for artifacts with given parameters.
@@ -97,7 +97,7 @@ public interface IIndex {
    * @return
    * @throws CoreException
    */
-  public Collection<IndexedArtifact> find(SearchExpression groupId, SearchExpression artifactId,
+  Collection<IndexedArtifact> find(SearchExpression groupId, SearchExpression artifactId,
       SearchExpression version, SearchExpression packaging) throws CoreException;
 
   /**
@@ -112,7 +112,7 @@ public interface IIndex {
    * @return
    * @throws CoreException
    */
-  public Collection<IndexedArtifact> find(Collection<SearchExpression> groupId,
+  Collection<IndexedArtifact> find(Collection<SearchExpression> groupId,
       Collection<SearchExpression> artifactId, Collection<SearchExpression> version,
       Collection<SearchExpression> packaging) throws CoreException;
 
@@ -120,7 +120,7 @@ public interface IIndex {
    * Convenience method to search in all indexes enabled for repositories defined in settings.xml. This method always
    * performs "scored" search.
    */
-  public Map<String, IndexedArtifact> search(SearchExpression expression, String searchType) throws CoreException;
+  Map<String, IndexedArtifact> search(SearchExpression expression, String searchType) throws CoreException;
 
   /**
    * Convenience method to search in all indexes enabled for repositories defined in settings.xml. This method always
@@ -131,6 +131,6 @@ public interface IIndex {
    * @param classifier - the type of classifiers to search for, SEARCH_ALL, SEARCH_JAVADOCS, SEARCH_SOURCES,
    *          SEARCH_TESTS
    */
-  public Map<String, IndexedArtifact> search(SearchExpression expression, String searchType, int classifier)
+  Map<String, IndexedArtifact> search(SearchExpression expression, String searchType, int classifier)
       throws CoreException;
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IMutableIndex.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IMutableIndex.java
@@ -28,12 +28,12 @@ public interface IMutableIndex extends IIndex {
 
   // index content manipulation
 
-  public void addArtifact(File pomFile, ArtifactKey artifactKey);
+  void addArtifact(File pomFile, ArtifactKey artifactKey);
 
-  public void removeArtifact(File pomFile, ArtifactKey artifactKey);
+  void removeArtifact(File pomFile, ArtifactKey artifactKey);
 
   // reindexing
 
-  public void updateIndex(boolean force, IProgressMonitor monitor) throws CoreException;
+  void updateIndex(boolean force, IProgressMonitor monitor) throws CoreException;
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IndexListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/IndexListener.java
@@ -23,12 +23,12 @@ import org.eclipse.m2e.core.repository.IRepository;
  */
 public interface IndexListener {
 
-  public void indexAdded(IRepository repository);
+  void indexAdded(IRepository repository);
 
-  public void indexRemoved(IRepository repository);
+  void indexRemoved(IRepository repository);
 
-  public void indexChanged(IRepository repository);
+  void indexChanged(IRepository repository);
 
-  public void indexUpdating(IRepository repository);
+  void indexUpdating(IRepository repository);
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/filter/IArtifactFilter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/filter/IArtifactFilter.java
@@ -31,5 +31,5 @@ public interface IArtifactFilter {
    * @return <code>null</code> or OK status if the artifact should be allowed, INFO/WARNING status to allow with a
    *         message and ERROR status to block the artifact.
    */
-  public IStatus filter(IProject project, ArtifactKey artifact);
+  IStatus filter(IProject project, ArtifactKey artifact);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/IndexUpdaterJob.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/IndexUpdaterJob.java
@@ -45,7 +45,7 @@ class IndexUpdaterJob extends Job implements IBackgroundProcessingQueue {
   }
 
   public interface IndexCommand {
-    abstract void run(IProgressMonitor monitor) throws CoreException;
+    void run(IProgressMonitor monitor) throws CoreException;
   }
 
   private final Stack<IndexUpdaterJob.IndexCommand> updateQueue = new Stack<>();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/jobs/IBackgroundProcessingQueue.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/jobs/IBackgroundProcessingQueue.java
@@ -23,11 +23,11 @@ import org.eclipse.core.runtime.IStatus;
  * @author igor
  */
 public interface IBackgroundProcessingQueue {
-  public void join() throws InterruptedException;
+  void join() throws InterruptedException;
 
-  public boolean isEmpty();
+  boolean isEmpty();
 
-  public IStatus run(IProgressMonitor monitor);
+  IStatus run(IProgressMonitor monitor);
 
-  public boolean cancel();
+  boolean cancel();
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MappingMetadataSource.java
@@ -26,8 +26,8 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
  * @author igor
  */
 public interface MappingMetadataSource {
-  public LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType) throws DuplicateMappingException;
+  LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType) throws DuplicateMappingException;
 
-  public List<PluginExecutionMetadata> getPluginExecutionMetadata(MojoExecutionKey execution);
+  List<PluginExecutionMetadata> getPluginExecutionMetadata(MojoExecutionKey execution);
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/ILifecycleMappingElement.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/ILifecycleMappingElement.java
@@ -20,6 +20,6 @@ package org.eclipse.m2e.core.internal.lifecyclemapping.discovery;
  */
 public interface ILifecycleMappingElement {
 
-  public ILifecycleMappingRequirement getLifecycleMappingRequirement();
+  ILifecycleMappingRequirement getLifecycleMappingRequirement();
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/IMavenDiscovery.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/IMavenDiscovery.java
@@ -39,7 +39,7 @@ public interface IMavenDiscovery {
    * with already installed Eclipse bundles and preselected proposals.
    * </p>
    */
-  public Map<ILifecycleMappingRequirement, List<IMavenDiscoveryProposal>> discover(MavenProject mavenProject,
+  Map<ILifecycleMappingRequirement, List<IMavenDiscoveryProposal>> discover(MavenProject mavenProject,
       List<MojoExecution> mojoExecutions, List<IMavenDiscoveryProposal> preselected, IProgressMonitor monitor)
       throws CoreException;
 
@@ -57,7 +57,7 @@ public interface IMavenDiscovery {
    *
    * @since 1.5.0
    */
-  public Map<ILifecycleMappingRequirement, List<IMavenDiscoveryProposal>> discover(
+  Map<ILifecycleMappingRequirement, List<IMavenDiscoveryProposal>> discover(
       Collection<ILifecycleMappingRequirement> requirements, List<IMavenDiscoveryProposal> preselected,
       IProgressMonitor monitor) throws CoreException;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/IMavenDiscoveryProposal.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/discovery/IMavenDiscoveryProposal.java
@@ -17,8 +17,8 @@ package org.eclipse.m2e.core.internal.lifecyclemapping.discovery;
  */
 public interface IMavenDiscoveryProposal {
 
-  public String getDescription();
+  String getDescription();
 
-  public String getLicense();
+  String getLicense();
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/IMavenMarkerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/IMavenMarkerManager.java
@@ -37,7 +37,7 @@ public interface IMavenMarkerManager {
    * @param pomFile the pom file to attach markers to.
    * @param result containing messages to be addedd as markers
    */
-  public void addMarkers(IResource pomFile, String type, MavenExecutionResult result);
+  void addMarkers(IResource pomFile, String type, MavenExecutionResult result);
 
   /**
    * Add a Maven marker to a resource
@@ -47,35 +47,35 @@ public interface IMavenMarkerManager {
    * @param lineNumber : the resource line to attach the marker to.
    * @param severity : the severity of the marker.
    */
-  public IMarker addMarker(IResource resource, String type, String message, int lineNumber, int severity);
+  IMarker addMarker(IResource resource, String type, String message, int lineNumber, int severity);
 
   /**
    * Delete all Maven markers of the specified type (including subtypes) from an IResource
    */
-  public void deleteMarkers(IResource resource, String type) throws CoreException;
+  void deleteMarkers(IResource resource, String type) throws CoreException;
 
   /**
    * Delete all Maven markers of the specified type from an IResource
    */
-  public void deleteMarkers(IResource resource, boolean includeSubtypes, String type) throws CoreException;
+  void deleteMarkers(IResource resource, boolean includeSubtypes, String type) throws CoreException;
 
   /**
    * Delete all Maven markers that have the specified type and attribute from an IResource
    */
-  public void deleteMarkers(IResource resource, String type, String attrName, String attrValue) throws CoreException;
+  void deleteMarkers(IResource resource, String type, String attrName, String attrValue) throws CoreException;
 
   /**
    * Transform an exception into an error marker on an IResource
    *
    * @since 1.5
    */
-  public void addErrorMarkers(IResource resource, String type, Throwable ex);
+  void addErrorMarkers(IResource resource, String type, Throwable ex);
 
   /**
    * Transform an exception into an error marker on an IResource. This method is used by mavenarchiver and likely other
    * configurations. Removing it is binary incompatible change (but is source compatible).
    */
-  public void addErrorMarkers(IResource resource, String type, Exception ex);
+  void addErrorMarkers(IResource resource, String type, Exception ex);
 
   void addErrorMarkers(IResource resource, String type, List<MavenProblemInfo> problems) throws CoreException;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
@@ -22,7 +22,7 @@ import org.eclipse.m2e.core.internal.launch.MavenRuntimeManagerImpl;
  */
 public interface MavenPreferenceConstants {
 
-  static final String PREFIX = "eclipse.m2."; //$NON-NLS-1$
+  String PREFIX = "eclipse.m2."; //$NON-NLS-1$
 
   /** String */
   // public static final String P_LOCAL_REPOSITORY_DIR = PREFIX+"localRepositoryDirectory";
@@ -31,79 +31,78 @@ public interface MavenPreferenceConstants {
   // public static final String P_CHECK_LATEST_PLUGIN_VERSION = PREFIX+"checkLatestPluginVersion";
 
   /** String */
-  public static final String P_GLOBAL_CHECKSUM_POLICY = PREFIX + "globalChecksumPolicy";
+  String P_GLOBAL_CHECKSUM_POLICY = PREFIX + "globalChecksumPolicy";
 
   /** boolean */
-  public static final String P_OFFLINE = PREFIX + "offline"; //$NON-NLS-1$
+  String P_OFFLINE = PREFIX + "offline"; //$NON-NLS-1$
 
   /** boolean. if true, use org.eclipse.aether.repository.RepositoryPolicy.UPDATE_POLICY_NEVER as global update policy */
-  public static final String P_GLOBAL_UPDATE_NEVER = PREFIX + "globalUpdatePolicy"; //$NON-NLS-1$
+  String P_GLOBAL_UPDATE_NEVER = PREFIX + "globalUpdatePolicy"; //$NON-NLS-1$
 
   /** boolean */
   // public static final String P_UPDATE_SNAPSHOTS = PREFIX+"updateSnapshots";
 
   /** boolean */
-  public static final String P_DEBUG_OUTPUT = PREFIX + "debugOutput"; //$NON-NLS-1$
+  String P_DEBUG_OUTPUT = PREFIX + "debugOutput"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_DOWNLOAD_SOURCES = PREFIX + "downloadSources"; //$NON-NLS-1$
+  String P_DOWNLOAD_SOURCES = PREFIX + "downloadSources"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_DOWNLOAD_JAVADOC = PREFIX + "downloadJavadoc"; //$NON-NLS-1$
+  String P_DOWNLOAD_JAVADOC = PREFIX + "downloadJavadoc"; //$NON-NLS-1$
 
   /** String */
-  public static final String P_GLOBAL_SETTINGS_FILE = PREFIX + "globalSettingsFile"; //$NON-NLS-1$
+  String P_GLOBAL_SETTINGS_FILE = PREFIX + "globalSettingsFile"; //$NON-NLS-1$
 
   /** String */
-  public static final String P_USER_SETTINGS_FILE = PREFIX + "userSettingsFile"; //$NON-NLS-1$
+  String P_USER_SETTINGS_FILE = PREFIX + "userSettingsFile"; //$NON-NLS-1$
 
   /** String */
-  public static final String P_OUTPUT_FOLDER = PREFIX + "outputFolder"; //$NON-NLS-1$
+  String P_OUTPUT_FOLDER = PREFIX + "outputFolder"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_DISABLE_JDK_WARNING = PREFIX + "disableJdkwarning"; //$NON-NLS-1$
+  String P_DISABLE_JDK_WARNING = PREFIX + "disableJdkwarning"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_DISABLE_JDK_CHECK = PREFIX + "disableJdkCheck"; //$NON-NLS-1$
+  String P_DISABLE_JDK_CHECK = PREFIX + "disableJdkCheck"; //$NON-NLS-1$
 
   /** String, list of configured maven installations separated by '|', see {@link MavenRuntimeManagerImpl} */
-  public static final String P_RUNTIMES = PREFIX + "runtimes"; //$NON-NLS-1$
+  String P_RUNTIMES = PREFIX + "runtimes"; //$NON-NLS-1$
 
   /** Root node of extended maven installation attributes, see {@link MavenRuntimeManagerImpl} */
-  public static final String P_RUNTIMES_NODE = PREFIX + "runtimesNodes"; //$NON-NLS-1$
+  String P_RUNTIMES_NODE = PREFIX + "runtimesNodes"; //$NON-NLS-1$
 
   /** String */
-  public static final String P_DEFAULT_RUNTIME = PREFIX + "defaultRuntime"; //$NON-NLS-1$
+  String P_DEFAULT_RUNTIME = PREFIX + "defaultRuntime"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_UPDATE_INDEXES = PREFIX + "updateIndexes"; //$NON-NLS-1$
+  String P_UPDATE_INDEXES = PREFIX + "updateIndexes"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_UPDATE_PROJECTS = PREFIX + "updateProjects"; //$NON-NLS-1$
+  String P_UPDATE_PROJECTS = PREFIX + "updateProjects"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_HIDE_FOLDERS_OF_NESTED_PROJECTS = PREFIX + "hideFoldersOfNestedProjects"; //$NON-NLS-1$
+  String P_HIDE_FOLDERS_OF_NESTED_PROJECTS = PREFIX + "hideFoldersOfNestedProjects"; //$NON-NLS-1$
 
-  public static final String P_SHOW_CONSOLE_ON_ERR = PREFIX + "showConsoleOnErr"; //$NON-NLS-1$
+  String P_SHOW_CONSOLE_ON_ERR = PREFIX + "showConsoleOnErr"; //$NON-NLS-1$
 
-  public static final String P_SHOW_CONSOLE_ON_OUTPUT = PREFIX + "showConsoleOnOutput"; //$NON-NLS-1$
+  String P_SHOW_CONSOLE_ON_OUTPUT = PREFIX + "showConsoleOnOutput"; //$NON-NLS-1$
 
   /** boolean */
-  public static final String P_FULL_INDEX = PREFIX + "fullIndex"; //$NON-NLS-1$
+  String P_FULL_INDEX = PREFIX + "fullIndex"; //$NON-NLS-1$
 
   /** boolean **/
-  public static final String P_WARN_INCOMPLETE_MAPPING = PREFIX + "warn_incomplete_mapping"; //$NON-NLS-1$
+  String P_WARN_INCOMPLETE_MAPPING = PREFIX + "warn_incomplete_mapping"; //$NON-NLS-1$
 
   /** boolean **/
-  public static final String P_DEFAULT_POM_EDITOR_PAGE = "eclipse.m2.defaultPomEditorPage"; //$NON-NLS-1$
+  String P_DEFAULT_POM_EDITOR_PAGE = "eclipse.m2.defaultPomEditorPage"; //$NON-NLS-1$
 
   /**
    * boolean
    *
    * @deprecated Use {@link MavenPreferenceConstants#P_DUP_OF_PARENT_GROUPID_PB} instead
    */
-  @Deprecated
-  public static final String P_DISABLE_GROUPID_DUP_OF_PARENT_WARNING = PREFIX
+  @Deprecated String P_DISABLE_GROUPID_DUP_OF_PARENT_WARNING = PREFIX
       + ".disableGroupIdDuplicateOfParentWarning"; //$NON-NLS-1$
 
   /**
@@ -111,75 +110,74 @@ public interface MavenPreferenceConstants {
    *
    * @deprecated Use {@link MavenPreferenceConstants#P_DISABLE_VERSION_DUP_OF_PARENT_WARNING} instead
    */
-  @Deprecated
-  public static final String P_DISABLE_VERSION_DUP_OF_PARENT_WARNING = PREFIX
+  @Deprecated String P_DISABLE_VERSION_DUP_OF_PARENT_WARNING = PREFIX
       + ".disableVersionDuplicateOfParentWarning"; //$NON-NLS-1$
 
   /**
    * @since 1.5
    **/
-  static final String PROBLEM_PREFIX = PREFIX + "problem.";
+  String PROBLEM_PREFIX = PREFIX + "problem.";
 
   /**
    * Valid values : ignore, warning or error
    *
    * @since 1.5
    **/
-  public static final String P_DUP_OF_PARENT_GROUPID_PB = PROBLEM_PREFIX + "duplicateParentGroupId"; //$NON-NLS-1$
+  String P_DUP_OF_PARENT_GROUPID_PB = PROBLEM_PREFIX + "duplicateParentGroupId"; //$NON-NLS-1$
 
   /**
    * Valid values : ignore, warning or error
    *
    * @since 1.5
    **/
-  public static final String P_DUP_OF_PARENT_VERSION_PB = PROBLEM_PREFIX + "duplicateParentVersion"; //$NON-NLS-1$
+  String P_DUP_OF_PARENT_VERSION_PB = PROBLEM_PREFIX + "duplicateParentVersion"; //$NON-NLS-1$
 
   /**
    * Valid values : ignore, warning or error
    *
    * @since 1.7
    **/
-  public static final String P_OVERRIDING_MANAGED_VERSION_PB = PROBLEM_PREFIX + "overridingManagedVersion"; //$NON-NLS-1$
+  String P_OVERRIDING_MANAGED_VERSION_PB = PROBLEM_PREFIX + "overridingManagedVersion"; //$NON-NLS-1$
 
   /**
    * Valid values : ignore, warning or error
    *
    * @since 1.5
    **/
-  public static final String P_OUT_OF_DATE_PROJECT_CONFIG_PB = PROBLEM_PREFIX + "outofdateProjectConfig"; //$NON-NLS-1$
+  String P_OUT_OF_DATE_PROJECT_CONFIG_PB = PROBLEM_PREFIX + "outofdateProjectConfig"; //$NON-NLS-1$
 
   /**
    * Valid values : ignore, warning or error
    *
    * @since 1.5
    **/
-  public static final String P_NOT_COVERED_MOJO_EXECUTION_PB = PROBLEM_PREFIX + "notCoveredMojoExecution"; //$NON-NLS-1$
+  String P_NOT_COVERED_MOJO_EXECUTION_PB = PROBLEM_PREFIX + "notCoveredMojoExecution"; //$NON-NLS-1$
 
   /** string **/
-  public static final String P_LIFECYCLE_MAPPINGS = PREFIX + "lifecycleMappings"; //$NON-NLS-1$
+  String P_LIFECYCLE_MAPPINGS = PREFIX + "lifecycleMappings"; //$NON-NLS-1$
 
   /** string **/
-  public static final String P_WORKSPACE_MAPPINGS_LOCATION = PREFIX + "WorkspacelifecycleMappingsLocation"; //$NON-NLS-1$
+  String P_WORKSPACE_MAPPINGS_LOCATION = PREFIX + "WorkspacelifecycleMappingsLocation"; //$NON-NLS-1$
 
   /**
    * boolean
    *
    * @since 1.6
    **/
-  public static final String P_AUTO_UPDATE_CONFIGURATION = PREFIX + "autoUpdateProjects"; //$NON-NLS-1$
+  String P_AUTO_UPDATE_CONFIGURATION = PREFIX + "autoUpdateProjects"; //$NON-NLS-1$
 
   /**
    * boolean.
    *
    * @experimental
    */
-  static final String P_BUILDER_USE_NULL_SCHEDULING_RULE = "builderUsesNullSchedulingRule"; //$NON-NLS-1$
+  String P_BUILDER_USE_NULL_SCHEDULING_RULE = "builderUsesNullSchedulingRule"; //$NON-NLS-1$
 
   /**
    * Enable SNAPSHOT Archetypes
    *
    * @since 1.15
    */
-  static final String P_ENABLE_SNAPSHOT_ARCHETYPES = "enableSnapshotArchetypes";
+  String P_ENABLE_SNAPSHOT_ARCHETYPES = "enableSnapshotArchetypes";
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ILifecycleMapping2.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ILifecycleMapping2.java
@@ -24,5 +24,5 @@ import org.eclipse.m2e.core.project.configurator.ILifecycleMapping;
  * @author igor
  */
 public interface ILifecycleMapping2 extends ILifecycleMapping {
-  public AbstractMavenDependencyResolver getDependencyResolver(IProgressMonitor monitor);
+  AbstractMavenDependencyResolver getDependencyResolver(IProgressMonitor monitor);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/IProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/IProjectRegistry.java
@@ -28,12 +28,12 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
  */
 public interface IProjectRegistry {
 
-  public MavenProjectFacade getProjectFacade(IFile pom);
+  MavenProjectFacade getProjectFacade(IFile pom);
 
-  public MavenProjectFacade getProjectFacade(String groupId, String artifactId, String version);
+  MavenProjectFacade getProjectFacade(String groupId, String artifactId, String version);
 
-  public MavenProjectFacade[] getProjects();
+  MavenProjectFacade[] getProjects();
 
-  public Map<ArtifactKey, Collection<IFile>> getWorkspaceArtifacts(String groupId, String artifactId);
+  Map<ArtifactKey, Collection<IFile>> getWorkspaceArtifacts(String groupId, String artifactId);
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/IRepositoryDiscoverer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/IRepositoryDiscoverer.java
@@ -27,6 +27,6 @@ public interface IRepositoryDiscoverer {
   /**
    * Called during updateRegistry operation.
    */
-  public void addRepositories(RepositoryRegistry registry, IProgressMonitor monitor) throws CoreException;
+  void addRepositories(RepositoryRegistry registry, IProgressMonitor monitor) throws CoreException;
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/IRepositoryIndexer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/IRepositoryIndexer.java
@@ -26,22 +26,22 @@ import org.eclipse.m2e.core.repository.IRepository;
  */
 public interface IRepositoryIndexer {
 
-  public String getIndexerId();
+  String getIndexerId();
 
   /**
    * This method is called from a background thread which does not keep any workspace locks.
    */
-  public void initialize(IProgressMonitor monitor) throws CoreException;
+  void initialize(IProgressMonitor monitor) throws CoreException;
 
   /**
    * Called by repository registry when new repository is added. This method is called from a background thread which
    * does not keep any workspace locks.
    */
-  public void repositoryAdded(IRepository repository, IProgressMonitor monitor) throws CoreException;
+  void repositoryAdded(IRepository repository, IProgressMonitor monitor) throws CoreException;
 
   /**
    * Called by repository registry when a repository is removed. This method is called from a background thread which
    * does not keep any workspace locks.
    */
-  public void repositoryRemoved(IRepository repository, IProgressMonitor monitor) throws CoreException;
+  void repositoryRemoved(IRepository repository, IProgressMonitor monitor) throws CoreException;
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectChangedListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectChangedListener.java
@@ -20,5 +20,5 @@ public interface IMavenProjectChangedListener {
   /**
    * This method is called while holding workspace lock.
    */
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor);
+  void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -125,35 +125,35 @@ public interface IMavenProjectFacade {
    *
    * @see #getSessionProperty(String)
    */
-  public void setSessionProperty(String key, Object value);
+  void setSessionProperty(String key, Object value);
 
   /**
    * @return the value associated with the key in session context or null if the key is not associated with any value.
    * @see #setSessionProperty(String, Object)
    */
-  public Object getSessionProperty(String key);
+  Object getSessionProperty(String key);
 
-  public Set<ArtifactRepositoryRef> getArtifactRepositoryRefs();
+  Set<ArtifactRepositoryRef> getArtifactRepositoryRefs();
 
-  public Set<ArtifactRepositoryRef> getPluginArtifactRepositoryRefs();
+  Set<ArtifactRepositoryRef> getPluginArtifactRepositoryRefs();
 
   /**
    * Returns fully setup MojoExecution instance bound to project build lifecycle that matches provided mojoExecutionKey.
    * Returns null if no such mojo execution.
    */
-  public MojoExecution getMojoExecution(MojoExecutionKey mojoExecutionKey, IProgressMonitor monitor)
+  MojoExecution getMojoExecution(MojoExecutionKey mojoExecutionKey, IProgressMonitor monitor)
       throws CoreException;
 
   /**
    * Returns list of fully setup MojoExecution instances bound to project build lifecycle that matche provided groupId,
    * artifactId and (vararg) goals. Returns empty list if no such mojo executions.
    */
-  public List<MojoExecution> getMojoExecutions(String groupId, String artifactId, IProgressMonitor monitor,
+  List<MojoExecution> getMojoExecutions(String groupId, String artifactId, IProgressMonitor monitor,
       String... goals) throws CoreException;
 
   // lifecycle mapping
 
-  public String getLifecycleMappingId();
+  String getLifecycleMappingId();
 
-  public Map<MojoExecutionKey, List<IPluginExecutionMetadata>> getMojoExecutionMapping();
+  Map<MojoExecutionKey, List<IPluginExecutionMetadata>> getMojoExecutionMapping();
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectRegistry.java
@@ -39,14 +39,14 @@ public interface IMavenProjectRegistry {
    * to load the pom if the pom is not found in the cache. In the latter case, workspace resolution is assumed to be
    * enabled for the pom but the pom will not be added to the cache.
    */
-  public IMavenProjectFacade create(IFile pom, boolean load, IProgressMonitor monitor);
+  IMavenProjectFacade create(IFile pom, boolean load, IProgressMonitor monitor);
 
-  public IMavenProjectFacade create(IProject project, IProgressMonitor monitor);
+  IMavenProjectFacade create(IProject project, IProgressMonitor monitor);
 
   /**
    * Performs requested Maven project update asynchronously, using background job. This method returns immediately.
    */
-  public void refresh(MavenUpdateRequest request);
+  void refresh(MavenUpdateRequest request);
 
   /**
    * Performs requested Maven project update synchronously. In other words, this method does not return until all
@@ -56,8 +56,7 @@ public interface IMavenProjectRegistry {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
    *             {@link #refresh(Collection, IProgressMonitor)} instead.
    */
-  @Deprecated
-  public void refresh(MavenUpdateRequest request, IProgressMonitor monitor) throws CoreException;
+  @Deprecated void refresh(MavenUpdateRequest request, IProgressMonitor monitor) throws CoreException;
 
   /**
    * Performs requested Maven project update synchronously. In other words, this method does not return until all
@@ -66,47 +65,45 @@ public interface IMavenProjectRegistry {
    *
    * @since 1.4
    */
-  public void refresh(Collection<IFile> pomFiles, IProgressMonitor monitor) throws CoreException;
+  void refresh(Collection<IFile> pomFiles, IProgressMonitor monitor) throws CoreException;
 
   /**
    * Returns IMavenProjectFacade for all opened Maven workspace projects.
    */
-  public IMavenProjectFacade[] getProjects();
+  IMavenProjectFacade[] getProjects();
 
   /**
    * @return IMavenProjectFacade cached IMavenProjectFacade corresponding to the project or null if there is no cache
    *         entry for the project.
    */
-  public IMavenProjectFacade getProject(IProject project);
+  IMavenProjectFacade getProject(IProject project);
 
   /**
    * Returns IMavenProjectFacade of the Maven workspace project that has given (groupId,artifactId,version) coordinates.
    *
    * @TODO decide what to do if multiple workspace projects have the same g/a/v.
    */
-  public IMavenProjectFacade getMavenProject(String groupId, String artifactId, String version);
+  IMavenProjectFacade getMavenProject(String groupId, String artifactId, String version);
 
   /**
    * @deprecated This method does not properly join {@link IMavenExecutionContext}
    */
-  @Deprecated
-  public MavenExecutionRequest createExecutionRequest(IFile pom, ResolverConfiguration resolverConfiguration,
+  @Deprecated MavenExecutionRequest createExecutionRequest(IFile pom, ResolverConfiguration resolverConfiguration,
       IProgressMonitor monitor) throws CoreException;
 
   /**
    * @deprecated This method does not properly join {@link IMavenExecutionContext}
    */
-  @Deprecated
-  public MavenExecutionRequest createExecutionRequest(IMavenProjectFacade project, IProgressMonitor monitor)
+  @Deprecated MavenExecutionRequest createExecutionRequest(IMavenProjectFacade project, IProgressMonitor monitor)
       throws CoreException;
 
   /**
    * @since 1.4
    */
-  public <V> V execute(IMavenProjectFacade facade, ICallable<V> callable, IProgressMonitor monitor)
+  <V> V execute(IMavenProjectFacade facade, ICallable<V> callable, IProgressMonitor monitor)
       throws CoreException;
 
-  public void addMavenProjectChangedListener(IMavenProjectChangedListener listener);
+  void addMavenProjectChangedListener(IMavenProjectChangedListener listener);
 
-  public void removeMavenProjectChangedListener(IMavenProjectChangedListener listener);
+  void removeMavenProjectChangedListener(IMavenProjectChangedListener listener);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
@@ -117,11 +117,11 @@ public interface IProjectConfigurationManager {
   /**
    * PROVISIONAL
    */
-  public ResolverConfiguration getResolverConfiguration(IProject project);
+  ResolverConfiguration getResolverConfiguration(IProject project);
 
   /**
    * PROVISIONAL
    */
-  public boolean setResolverConfiguration(IProject project, ResolverConfiguration configuration);
+  boolean setResolverConfiguration(IProject project, ResolverConfiguration configuration);
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/IProjectConversionEnabler.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/IProjectConversionEnabler.java
@@ -28,7 +28,7 @@ public interface IProjectConversionEnabler {
    *
    * @return true if the analyzer wants to work on this project.
    */
-  public boolean accept(IProject project);
+  boolean accept(IProject project);
 
   /**
    * Test if project should be converted to Maven. Enablers might have reasons for
@@ -38,7 +38,7 @@ public interface IProjectConversionEnabler {
    * not be converted, the severity must be set to IStatus.ERROR. If the project should be converted,
    * the severity must be set to IStatus.OK. This method should not return null.
    */
-  public IStatus canBeConverted(IProject project);
+  IStatus canBeConverted(IProject project);
 
 
   /**
@@ -47,7 +47,7 @@ public interface IProjectConversionEnabler {
    *
    * @return array of suggested packaging types. This should not return null.
    */
-  public String[] getPackagingTypes(IProject project);
+  String[] getPackagingTypes(IProject project);
 
 
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/repository/IRepository.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/repository/IRepository.java
@@ -42,51 +42,51 @@ public interface IRepository {
   /**
    * Repository access credentials. Can be null.
    */
-  public AuthenticationInfo getAuthenticationInfo();
+  AuthenticationInfo getAuthenticationInfo();
 
   /**
    * Repository URL
    */
-  public String getUrl();
+  String getUrl();
 
   /**
    * For local repositories, returns basedir of repository contents. Returns null for remote repositories;
    */
-  public File getBasedir();
+  File getBasedir();
 
   /**
    * Repository id element as defined in settings.xml or pom.xml file. Note that repository id is a reference to server
    * element in settings.xml file, it does not uniquely identify a repository.
    */
-  public String getId();
+  String getId();
 
   /**
    * Unique repository id. Generated based on combination of repository url and userId. Can be used to store
    * repository-related information on local filesystem.
    */
-  public String getUid();
+  String getUid();
 
   /**
    * Indicates that repository id matches mirrorOf clause of a mirror. In other words, all repository requests will be
    * redirected to a mirror. If null, repository is accessed directly. TODO decide return value format.
    */
-  public String getMirrorId();
+  String getMirrorId();
 
   /**
    * For repository mirrors, returns value of mirrorOf element as defined in settings.xml. Returns null for other
    * repositories.
    */
-  public String getMirrorOf();
+  String getMirrorOf();
 
   /**
    * Protocol part of repository url, i.e. "file", "http", etc.
    */
-  public String getProtocol();
+  String getProtocol();
 
-  public boolean isScope(int scope);
+  boolean isScope(int scope);
 
   /**
    * Human readable repository identifier
    */
-  public String toString();
+  String toString();
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/repository/IRepositoryRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/repository/IRepositoryRegistry.java
@@ -35,33 +35,33 @@ public interface IRepositoryRegistry {
   /**
    *
    */
-  public static final int SCOPE_UNKNOWN = 1;
+  int SCOPE_UNKNOWN = 1;
 
   /**
    * Maven local repositories.
    */
-  public static final int SCOPE_LOCAL = 1 << 1;
+  int SCOPE_LOCAL = 1 << 1;
 
   /**
    * Eclipse workspace repository
    */
-  public static final int SCOPE_WORKSPACE = 1 << 2;
+  int SCOPE_WORKSPACE = 1 << 2;
 
   /**
    * Repositories defined in settings.xml file.
    */
-  public static final int SCOPE_SETTINGS = 1 << 3;
+  int SCOPE_SETTINGS = 1 << 3;
 
   /**
    * Repositories defined in pom.xml files of workspace Maven projects
    */
-  public static final int SCOPE_PROJECT = 1 << 4;
+  int SCOPE_PROJECT = 1 << 4;
 
-  public List<IRepository> getRepositories(int scope);
+  List<IRepository> getRepositories(int scope);
 
-  public IRepository getWorkspaceRepository();
+  IRepository getWorkspaceRepository();
 
-  public IRepository getLocalRepository();
+  IRepository getLocalRepository();
 
-  public IRepository getRepository(ArtifactRepositoryRef repositoryRef);
+  IRepository getRepository(ArtifactRepositoryRef repositoryRef);
 }

--- a/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/InsertArtifactProposal.java
+++ b/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/InsertArtifactProposal.java
@@ -291,7 +291,7 @@ public class InsertArtifactProposal implements ICompletionProposal, ICompletionP
    *
    * @author mkleint
    */
-  public static enum SearchType {
+  public enum SearchType {
 
     PARENT(IIndex.SEARCH_PARENTS, Messages.InsertArtifactProposal_searchDialog_title,
         Messages.InsertArtifactProposal_display_name, MvnImages.IMG_OPEN_POM,
@@ -312,7 +312,7 @@ public class InsertArtifactProposal implements ICompletionProposal, ICompletionP
 
     private final String additionalInfo;
 
-    private SearchType(String type, String windowTitle, String dn, Image img, String addInfo) {
+    SearchType(String type, String windowTitle, String dn, Image img, String addInfo) {
       this.type = type;
       this.windowTitle = windowTitle;
       this.displayName = dn;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/IMojoParameterMetadataProvider.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/IMojoParameterMetadataProvider.java
@@ -32,36 +32,32 @@ public interface IMojoParameterMetadataProvider {
   /**
    * Calculates available configuration of one specific mojo.
    */
-  public MojoParameter getMojoConfiguration(ArtifactKey pluginKey, String mojo) throws CoreException;
+  MojoParameter getMojoConfiguration(ArtifactKey pluginKey, String mojo) throws CoreException;
 
   /**
    * Calculates available configuration of a number of mojos.
    */
-  public MojoParameter getMojoConfiguration(ArtifactKey pluginKey, Collection<String> mojos) throws CoreException;
+  MojoParameter getMojoConfiguration(ArtifactKey pluginKey, Collection<String> mojos) throws CoreException;
 
   /**
    * Calculates available configuration of all mojos provided by specified plugin.
    */
-  public MojoParameter getMojoConfiguration(ArtifactKey pluginKey) throws CoreException;
+  MojoParameter getMojoConfiguration(ArtifactKey pluginKey) throws CoreException;
 
   /**
    * Calculates available configuration of a single plugin class.
    */
-  public MojoParameter getClassConfiguration(ArtifactKey pluginKey, String className) throws CoreException;
+  MojoParameter getClassConfiguration(ArtifactKey pluginKey, String className) throws CoreException;
 
-  @Deprecated
-  public MojoParameter getMojoConfiguration(ArtifactKey pluginKey, String mojo, IProgressMonitor monitor)
+  @Deprecated MojoParameter getMojoConfiguration(ArtifactKey pluginKey, String mojo, IProgressMonitor monitor)
       throws CoreException;
 
-  @Deprecated
-  public MojoParameter getMojoConfiguration(ArtifactKey pluginKey, Collection<String> mojos, IProgressMonitor monitor)
+  @Deprecated MojoParameter getMojoConfiguration(ArtifactKey pluginKey, Collection<String> mojos, IProgressMonitor monitor)
       throws CoreException;
 
-  @Deprecated
-  public MojoParameter getMojoConfiguration(ArtifactKey pluginKey, IProgressMonitor monitor) throws CoreException;
+  @Deprecated MojoParameter getMojoConfiguration(ArtifactKey pluginKey, IProgressMonitor monitor) throws CoreException;
 
-  @Deprecated
-  public MojoParameter getClassConfiguration(ArtifactKey pluginKey, String className, IProgressMonitor monitor)
+  @Deprecated MojoParameter getClassConfiguration(ArtifactKey pluginKey, String className, IProgressMonitor monitor)
       throws CoreException;
 
 }

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/FormUtils.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/FormUtils.java
@@ -82,7 +82,7 @@ public abstract class FormUtils {
    * Stub interface for API added to FormToolikt in Eclipse 3.3
    */
   private interface FormTooliktStub {
-    public void decorateFormHeading(Form form);
+    void decorateFormHeading(Form form);
   }
 
   /**

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/IPomFileChangedListener.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/IPomFileChangedListener.java
@@ -15,6 +15,6 @@ package org.eclipse.m2e.editor.pom;
 
 public interface IPomFileChangedListener {
 
-  public void fileChanged();
+  void fileChanged();
 
 }


### PR DESCRIPTION
Note that this breaks formatting slightly by replaing

```
@Deprecated
public void somethod()
```

with

```
@Deprecated void somethod()
```

If that's not acceptable we either need some formatter or get the cleanup changed.

EclipseJdt cleanup 'RemoveRedundantModifier' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>