### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant modifier

### DIFF
--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
@@ -594,11 +594,11 @@ public enum PomTemplateContext {
 
   private final String contextSuffix;
 
-  private PomTemplateContext(String nodeName) {
+  PomTemplateContext(String nodeName) {
     this(nodeName, nodeName);
   }
 
-  private PomTemplateContext(String nodeName, String contextSuffix) {
+  PomTemplateContext(String nodeName, String contextSuffix) {
     this.nodeName = nodeName;
     this.contextSuffix = contextSuffix;
   }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathDescriptor.java
@@ -32,56 +32,56 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
  */
 public interface IClasspathDescriptor {
 
-  public static interface EntryFilter {
-    public boolean accept(IClasspathEntryDescriptor descriptor);
+  public interface EntryFilter {
+    boolean accept(IClasspathEntryDescriptor descriptor);
   }
 
   /**
    * @return true if classpath contains entry with specified path, false otherwise.
    */
-  public boolean containsPath(IPath path);
+  boolean containsPath(IPath path);
 
   /**
    * Convenience method, equivalent to
    * <code>addSourceEntry(sourcePath, outputLocation, new IPath[0], new IPath[0], generated)</code>
    */
-  public IClasspathEntryDescriptor addSourceEntry(IPath sourcePath, IPath outputLocation, boolean generated);
+  IClasspathEntryDescriptor addSourceEntry(IPath sourcePath, IPath outputLocation, boolean generated);
 
   /**
    * Adds project source folder to the classpath. The source folder must exist in the workspace unless generated is
    * true. In the latter case, the source classpath entry will be marked as optional.
    */
-  public IClasspathEntryDescriptor addSourceEntry(IPath sourcePath, IPath outputLocation, IPath[] inclusion,
+  IClasspathEntryDescriptor addSourceEntry(IPath sourcePath, IPath outputLocation, IPath[] inclusion,
       IPath[] exclusion, boolean generated);
 
   /**
    * Adds fully populated IClasspathEntry instance to the classpath.
    */
-  public IClasspathEntryDescriptor addEntry(IClasspathEntry entry);
+  IClasspathEntryDescriptor addEntry(IClasspathEntry entry);
 
   /**
    * Removes entry from stale entries list.
    *
    * @since 1.7
    */
-  public void touchEntry(IPath entryPath);
+  void touchEntry(IPath entryPath);
 
   /**
    * Replaces a single ClasspathEntry instance matched by filter. Returns null if none were replaced.
    *
    * @since 1.6
    */
-  public IClasspathEntryDescriptor replaceEntry(EntryFilter filter, IClasspathEntry entry);
+  IClasspathEntryDescriptor replaceEntry(EntryFilter filter, IClasspathEntry entry);
 
   /**
    * Adds and returns new project classpath entry.
    */
-  public IClasspathEntryDescriptor addProjectEntry(IPath entryPath);
+  IClasspathEntryDescriptor addProjectEntry(IPath entryPath);
 
   /**
    * Adds and returns new library entry to the classpath
    */
-  public IClasspathEntryDescriptor addLibraryEntry(IPath entryPath);
+  IClasspathEntryDescriptor addLibraryEntry(IPath entryPath);
 
   /**
    * Removes entry with specified path from the classpath. That this can remove multiple entries because classpath does
@@ -89,27 +89,27 @@ public interface IClasspathDescriptor {
    *
    * @TODO should really be removeEntries (i.e. plural)
    */
-  public List<IClasspathEntryDescriptor> removeEntry(IPath path);
+  List<IClasspathEntryDescriptor> removeEntry(IPath path);
 
   /**
    * Removes entries that match EntryFilter (i.e. EntryFilter#accept(entry) returns true) from the classpath
    *
    * @TODO should really be removeEntries (i.e. plural)
    */
-  public List<IClasspathEntryDescriptor> removeEntry(EntryFilter filter);
+  List<IClasspathEntryDescriptor> removeEntry(EntryFilter filter);
 
   /**
    * Renders classpath as IClasspathEntry[] array
    *
    * @TODO should really be toEntriesArray
    */
-  public IClasspathEntry[] getEntries();
+  IClasspathEntry[] getEntries();
 
   /**
    * Returns underlying "live" list of IClasspathEntryDescriptor instances. Changes to the list will be immediately
    * reflected in the classpath.
    */
-  public List<IClasspathEntryDescriptor> getEntryDescriptors();
+  List<IClasspathEntryDescriptor> getEntryDescriptors();
 
   // deprecated, to be removed before 1.0
 
@@ -118,14 +118,12 @@ public interface IClasspathDescriptor {
    *
    * @deprecated this method exposes Maven core classes, which are not part of m2eclipse-jdt API
    */
-  @Deprecated
-  public IClasspathEntryDescriptor addLibraryEntry(Artifact artifact, IPath srcPath, IPath srcRoot, String javaDocUrl);
+  @Deprecated IClasspathEntryDescriptor addLibraryEntry(Artifact artifact, IPath srcPath, IPath srcRoot, String javaDocUrl);
 
   /**
    * Adds worksapce Maven project dependency to the classpath
    *
    * @deprecated this method exposes Maven core classes, which are not part of m2eclipse-jdt API
    */
-  @Deprecated
-  public IClasspathEntryDescriptor addProjectEntry(Artifact artifact, IMavenProjectFacade projectFacade);
+  @Deprecated IClasspathEntryDescriptor addProjectEntry(Artifact artifact, IMavenProjectFacade projectFacade);
 }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathEntryDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathEntryDescriptor.java
@@ -33,93 +33,93 @@ public interface IClasspathEntryDescriptor {
 
   // classpath entry getters and setters (open a bug if you need any of the missing getters/setters)
 
-  public IPath getPath();
+  IPath getPath();
 
-  public void setPath(IPath path);
+  void setPath(IPath path);
 
-  public int getEntryKind();
+  int getEntryKind();
 
-  public void setEntryKind(int entryKind);
+  void setEntryKind(int entryKind);
 
-  public void setSourceAttachment(IPath srcPath, IPath srcRoot);
+  void setSourceAttachment(IPath srcPath, IPath srcRoot);
 
-  public void setJavadocUrl(String javaDocUrl);
+  void setJavadocUrl(String javaDocUrl);
 
-  public IPath getSourceAttachmentPath();
+  IPath getSourceAttachmentPath();
 
-  public IPath getSourceAttachmentRootPath();
+  IPath getSourceAttachmentRootPath();
 
-  public String getJavadocUrl();
+  String getJavadocUrl();
 
-  public void setOutputLocation(IPath outputLocation);
+  void setOutputLocation(IPath outputLocation);
 
-  public void addInclusionPattern(IPath pattern);
+  void addInclusionPattern(IPath pattern);
 
-  public void removeInclusionPattern(IPath pattern);
+  void removeInclusionPattern(IPath pattern);
 
-  public void setInclusionPatterns(IPath[] inclusionPatterns);
+  void setInclusionPatterns(IPath[] inclusionPatterns);
 
-  public IPath[] getInclusionPatterns();
+  IPath[] getInclusionPatterns();
 
-  public void addExclusionPattern(IPath pattern);
+  void addExclusionPattern(IPath pattern);
 
-  public void removeExclusionPattern(IPath pattern);
+  void removeExclusionPattern(IPath pattern);
 
-  public void setExclusionPatterns(IPath[] exclusionPatterns);
+  void setExclusionPatterns(IPath[] exclusionPatterns);
 
-  public IPath[] getExclusionPatterns();
+  IPath[] getExclusionPatterns();
 
-  public void setExported(boolean exported);
+  void setExported(boolean exported);
 
-  public boolean isExported();
+  boolean isExported();
 
-  public IPath getOutputLocation();
+  IPath getOutputLocation();
 
-  public void setClasspathAttribute(String name, String value);
+  void setClasspathAttribute(String name, String value);
 
-  public Map<String, String> getClasspathAttributes();
+  Map<String, String> getClasspathAttributes();
 
-  public void addAccessRule(IAccessRule rule);
+  void addAccessRule(IAccessRule rule);
 
-  public List<IAccessRule> getAccessRules();
+  List<IAccessRule> getAccessRules();
 
-  public void setCombineAccessRules(boolean combineAccessRules);
+  void setCombineAccessRules(boolean combineAccessRules);
 
-  public boolean combineAccessRules();
+  boolean combineAccessRules();
 
   // maven-specific getters and setters
 
   /**
    * Short for getArtifactKey().getGroupId(), with appropriate null check
    */
-  public String getGroupId();
+  String getGroupId();
 
   /**
    * Short for getArtifactKey().getArtifactId(), with appropriate null check
    */
-  public String getArtifactId();
+  String getArtifactId();
 
-  public ArtifactKey getArtifactKey();
+  ArtifactKey getArtifactKey();
 
-  public void setArtifactKey(ArtifactKey artifactKey);
+  void setArtifactKey(ArtifactKey artifactKey);
 
   /**
    * @return true if this entry corresponds to an optional maven dependency, false otherwise
    */
-  public boolean isOptionalDependency();
+  boolean isOptionalDependency();
 
-  public void setOptionalDependency(boolean optional);
+  void setOptionalDependency(boolean optional);
 
-  public String getScope();
+  String getScope();
 
-  public void setScope(String scope);
+  void setScope(String scope);
 
   //
 
   /**
    * Create IClasspathEntry with information collected in this descriptor
    */
-  public IClasspathEntry toClasspathEntry();
+  IClasspathEntry toClasspathEntry();
 
   /**
    * Returns <code>true</code> if this classpath entry was derived from pom.xml and <code>false</code> otherwise. <br/>
@@ -128,7 +128,7 @@ public interface IClasspathEntryDescriptor {
    * @see #setPomDerived(boolean)
    * @since 1.1
    */
-  public boolean isPomDerived();
+  boolean isPomDerived();
 
   /**
    * Marks classpath entry as derived from pom.xml (<code>true</code>) or not (<code>false</code>).
@@ -146,5 +146,5 @@ public interface IClasspathEntryDescriptor {
    *
    * @since 1.1
    */
-  public void setPomDerived(boolean derived);
+  void setPomDerived(boolean derived);
 }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathManager.java
@@ -29,38 +29,38 @@ public interface IClasspathManager {
   /**
    * Maven Dependencies classpath container id
    */
-  public static final String CONTAINER_ID = "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"; //$NON-NLS-1$
+  String CONTAINER_ID = "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that keeps groupId of corresponding Maven artifact.
    */
-  public static final String GROUP_ID_ATTRIBUTE = "maven.groupId"; //$NON-NLS-1$
+  String GROUP_ID_ATTRIBUTE = "maven.groupId"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that keeps artifactId of corresponding Maven artifact.
    */
-  public static final String ARTIFACT_ID_ATTRIBUTE = "maven.artifactId"; //$NON-NLS-1$
+  String ARTIFACT_ID_ATTRIBUTE = "maven.artifactId"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that keeps version of corresponding Maven artifact.
    */
-  public static final String VERSION_ATTRIBUTE = "maven.version"; //$NON-NLS-1$
+  String VERSION_ATTRIBUTE = "maven.version"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that keeps classified corresponding Maven artifact.
    */
-  public static final String CLASSIFIER_ATTRIBUTE = "maven.classifier"; //$NON-NLS-1$
+  String CLASSIFIER_ATTRIBUTE = "maven.classifier"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that keeps scope corresponding Maven artifact.
    */
-  public static final String SCOPE_ATTRIBUTE = "maven.scope"; //$NON-NLS-1$
+  String SCOPE_ATTRIBUTE = "maven.scope"; //$NON-NLS-1$
 
   /**
    * @see IClasspathEntryDescriptor#setPomDerived(boolean)
    * @since 1.1
    */
-  public static final String POMDERIVED_ATTRIBUTE = "maven.pomderived"; //$NON-NLS-1$
+  String POMDERIVED_ATTRIBUTE = "maven.pomderived"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that is set to {@code true} for entries that correspond to optional Maven
@@ -68,7 +68,7 @@ public interface IClasspathManager {
    *
    * @since 1.5
    */
-  public static final String OPTIONALDEPENDENCY_ATTRIBUTE = "maven.optionaldependency"; //$NON-NLS-1$
+  String OPTIONALDEPENDENCY_ATTRIBUTE = "maven.optionaldependency"; //$NON-NLS-1$
 
   /**
    * Name of IClasspathEntry attribute that is used to mark test sources and dependencies by jdt.core. Same as
@@ -76,7 +76,7 @@ public interface IClasspathManager {
    *
    * @since 1.9
    */
-  public static final String TEST_ATTRIBUTE = "test";
+  String TEST_ATTRIBUTE = "test";
 
   /**
    * Name of IClasspathEntry attribute that is to limit the imported code of project by jdt.core. Same as
@@ -85,37 +85,37 @@ public interface IClasspathManager {
    *
    * @since 1.9
    */
-  public static final String WITHOUT_TEST_CODE = "without_test_code";
+  String WITHOUT_TEST_CODE = "without_test_code";
 
   /**
    * Maven dependency resolution scope constant indicating test scope.
    */
-  public static final int CLASSPATH_TEST = 0;
+  int CLASSPATH_TEST = 0;
 
   /**
    * Maven dependency resolution scope constant indicating runtime scope.
    */
-  public static final int CLASSPATH_RUNTIME = 1;
+  int CLASSPATH_RUNTIME = 1;
 
   /**
    * Maven dependency resolution scope constant indicating default scope. test is the widest possible scope, and this is
    * what we need by default
    */
-  public static final int CLASSPATH_DEFAULT = CLASSPATH_TEST;
+  int CLASSPATH_DEFAULT = CLASSPATH_TEST;
 
   /**
    * Request download of sources and/or javadoc from Maven repositories by a background job (asynchronous execution).
    * After download has completed, sources and/or javadoc jar file will be attached to the corresponding classpath
    * entry.
    */
-  public void scheduleDownload(IPackageFragmentRoot fragment, boolean downloadSources, boolean downloadJavadoc);
+  void scheduleDownload(IPackageFragmentRoot fragment, boolean downloadSources, boolean downloadJavadoc);
 
   /**
    * Request download of sources and/or javadoc from Maven repositories by a background job for all classpath entries of
    * the project (asynchronous execution). After download has completed, sources and/or javadoc jar file will be
    * attached to the corresponding classpath entries.
    */
-  public void scheduleDownload(IProject project, boolean downloadSources, boolean downloadJavadoc);
+  void scheduleDownload(IProject project, boolean downloadSources, boolean downloadJavadoc);
 
   /**
    * Calculates and returns Maven classpath of the project.
@@ -126,13 +126,13 @@ public interface IClasspathManager {
    * @param monitor progress monitor
    * @return Maven classpath of the project
    */
-  public IClasspathEntry[] getClasspath(IProject project, int scope, boolean uniquePaths, IProgressMonitor monitor)
+  IClasspathEntry[] getClasspath(IProject project, int scope, boolean uniquePaths, IProgressMonitor monitor)
       throws CoreException;
 
   /**
    * Calculates Maven classpath of the project using default dependency resolution scope and updates contents of Maven
    * Dependencies classpath container.
    */
-  public void updateClasspath(IProject project, IProgressMonitor monitor);
+  void updateClasspath(IProject project, IProgressMonitor monitor);
 
 }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathManagerDelegate.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IClasspathManagerDelegate.java
@@ -21,7 +21,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 public interface IClasspathManagerDelegate {
 
-  public void populateClasspath(IClasspathDescriptor classpath, IMavenProjectFacade projectFacade, int kind,
+  void populateClasspath(IClasspathDescriptor classpath, IMavenProjectFacade projectFacade, int kind,
       IProgressMonitor monitor) throws CoreException;
 
 }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/IJavaProjectConfigurator.java
@@ -30,13 +30,13 @@ public interface IJavaProjectConfigurator {
   /**
    * Configures *Maven* project classpath, i.e. content of Maven Dependencies classpath container.
    */
-  public void configureClasspath(IMavenProjectFacade facade, IClasspathDescriptor classpath, IProgressMonitor monitor)
+  void configureClasspath(IMavenProjectFacade facade, IClasspathDescriptor classpath, IProgressMonitor monitor)
       throws CoreException;
 
   /**
    * Configures *JDT* project classpath, i.e. project-level entries like source folders, JRE and Maven Dependencies
    * classpath container.
    */
-  public void configureRawClasspath(ProjectConfigurationRequest request, IClasspathDescriptor classpath,
+  void configureRawClasspath(ProjectConfigurationRequest request, IClasspathDescriptor classpath,
       IProgressMonitor monitor) throws CoreException;
 }

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/MavenLaunchConstants.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/MavenLaunchConstants.java
@@ -17,67 +17,62 @@ import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 
 
 public interface MavenLaunchConstants {
-  public final String PLUGIN_ID = "org.eclipse.m2e.launching";
+  String PLUGIN_ID = "org.eclipse.m2e.launching";
 
   // this should correspond with launchConfigurationType.id attribute in plugin.xml!
-  public final String LAUNCH_CONFIGURATION_TYPE_ID = "org.eclipse.m2e.Maven2LaunchConfigurationType"; //$NON-NLS-1$
+  String LAUNCH_CONFIGURATION_TYPE_ID = "org.eclipse.m2e.Maven2LaunchConfigurationType"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
-  @Deprecated
-  public final String BUILDER_CONFIGURATION_TYPE_ID = "org.eclipse.m2e.Maven2BuilderConfigurationType"; //$NON-NLS-1$
+  @Deprecated String BUILDER_CONFIGURATION_TYPE_ID = "org.eclipse.m2e.Maven2BuilderConfigurationType"; //$NON-NLS-1$
 
   // pom directory automatically became working directory for maven embedder launch
-  public final String ATTR_POM_DIR = IJavaLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY;
+  String ATTR_POM_DIR = IJavaLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY;
 
-  public final String ATTR_GOALS = "M2_GOALS"; //$NON-NLS-1$
-
-  /**
-   * @deprecated this constant is not used by m2e
-   */
-  @Deprecated
-  public final String ATTR_GOALS_AUTO_BUILD = "M2_GOALS_AUTO_BUILD"; //$NON-NLS-1$
+  String ATTR_GOALS = "M2_GOALS"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
-  @Deprecated
-  public final String ATTR_GOALS_MANUAL_BUILD = "M2_GOALS_MANUAL_BUILD"; //$NON-NLS-1$
+  @Deprecated String ATTR_GOALS_AUTO_BUILD = "M2_GOALS_AUTO_BUILD"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
-  @Deprecated
-  public final String ATTR_GOALS_CLEAN = "M2_GOALS_CLEAN"; //$NON-NLS-1$
+  @Deprecated String ATTR_GOALS_MANUAL_BUILD = "M2_GOALS_MANUAL_BUILD"; //$NON-NLS-1$
 
   /**
    * @deprecated this constant is not used by m2e
    */
-  @Deprecated
-  public final String ATTR_GOALS_AFTER_CLEAN = "M2_GOALS_AFTER_CLEAN"; //$NON-NLS-1$
+  @Deprecated String ATTR_GOALS_CLEAN = "M2_GOALS_CLEAN"; //$NON-NLS-1$
 
-  public final String ATTR_PROFILES = "M2_PROFILES"; //$NON-NLS-1$
+  /**
+   * @deprecated this constant is not used by m2e
+   */
+  @Deprecated String ATTR_GOALS_AFTER_CLEAN = "M2_GOALS_AFTER_CLEAN"; //$NON-NLS-1$
 
-  public final String ATTR_PROPERTIES = "M2_PROPERTIES"; //$NON-NLS-1$
+  String ATTR_PROFILES = "M2_PROFILES"; //$NON-NLS-1$
 
-  public final String ATTR_OFFLINE = "M2_OFFLINE"; //$NON-NLS-1$
+  String ATTR_PROPERTIES = "M2_PROPERTIES"; //$NON-NLS-1$
 
-  public final String ATTR_UPDATE_SNAPSHOTS = "M2_UPDATE_SNAPSHOTS"; //$NON-NLS-1$
+  String ATTR_OFFLINE = "M2_OFFLINE"; //$NON-NLS-1$
 
-  public final String ATTR_DEBUG_OUTPUT = "M2_DEBUG_OUTPUT"; //$NON-NLS-1$
+  String ATTR_UPDATE_SNAPSHOTS = "M2_UPDATE_SNAPSHOTS"; //$NON-NLS-1$
 
-  public final String ATTR_SKIP_TESTS = "M2_SKIP_TESTS"; //$NON-NLS-1$
+  String ATTR_DEBUG_OUTPUT = "M2_DEBUG_OUTPUT"; //$NON-NLS-1$
 
-  public final String ATTR_NON_RECURSIVE = "M2_NON_RECURSIVE"; //$NON-NLS-1$
+  String ATTR_SKIP_TESTS = "M2_SKIP_TESTS"; //$NON-NLS-1$
 
-  public final String ATTR_WORKSPACE_RESOLUTION = "M2_WORKSPACE_RESOLUTION"; //$NON-NLS-1$
+  String ATTR_NON_RECURSIVE = "M2_NON_RECURSIVE"; //$NON-NLS-1$
 
-  public final String ATTR_USER_SETTINGS = "M2_USER_SETTINGS"; //$NON-NLS-1$
+  String ATTR_WORKSPACE_RESOLUTION = "M2_WORKSPACE_RESOLUTION"; //$NON-NLS-1$
 
-  public final String ATTR_RUNTIME = "M2_RUNTIME"; //$NON-NLS-1$
+  String ATTR_USER_SETTINGS = "M2_USER_SETTINGS"; //$NON-NLS-1$
 
-  public final String ATTR_DISABLED_EXTENSIONS = "M2_DISABLED_EXTENSIONS";
+  String ATTR_RUNTIME = "M2_RUNTIME"; //$NON-NLS-1$
 
-  public final String ATTR_THREADS = "M2_THREADS"; //$NON-NLS-1$
+  String ATTR_DISABLED_EXTENSIONS = "M2_DISABLED_EXTENSIONS";
+
+  String ATTR_THREADS = "M2_THREADS"; //$NON-NLS-1$
 }

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/IMavenLaunchParticipant.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/IMavenLaunchParticipant.java
@@ -31,16 +31,16 @@ public interface IMavenLaunchParticipant {
   /**
    * Returns additional program arguments or <code>null</code>.
    */
-  public String getProgramArguments(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor);
+  String getProgramArguments(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor);
 
   /**
    * Returns additional vm arguments or <code>null</code>
    */
-  public String getVMArguments(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor);
+  String getVMArguments(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor);
 
   /**
    * Returns additional source lookup participants or <code>null</code>
    */
-  public List<ISourceLookupParticipant> getSourceLookupParticipants(ILaunchConfiguration configuration, ILaunch launch,
+  List<ISourceLookupParticipant> getSourceLookupParticipants(ILaunchConfiguration configuration, ILaunch launch,
       IProgressMonitor monitor);
 }

--- a/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Configuration.java
+++ b/org.eclipse.m2e.model.edit/src/main/java/org/eclipse/m2e/model/edit/pom/Configuration.java
@@ -34,11 +34,11 @@ import org.eclipse.emf.ecore.EObject;
  * @generated NOT
  */
 public interface Configuration extends EObject {
-  public Node getConfigurationNode();
+  Node getConfigurationNode();
 
-  public String getStringValue(String xpath);
+  String getStringValue(String xpath);
 
-  public void setStringValue(String xpath, String value);
+  void setStringValue(String xpath, String value);
 
   List<String> getListValue(String xpath);
 

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -189,7 +189,7 @@ public class CacheManager {
 	 *
 	 * @param <T> the return type
 	 */
-	public static interface CacheConsumer<T> {
+	public interface CacheConsumer<T> {
 		T consume(File file) throws Exception;
 	}
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/PomVisitor.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/PomVisitor.java
@@ -31,5 +31,5 @@ public interface PomVisitor {
    * @return command that executes changes (if any)
    * @throws Exception
    */
-  public CompoundCommand applyChanges(RefactoringModelResources model, IProgressMonitor pm) throws Exception;
+  CompoundCommand applyChanges(RefactoringModelResources model, IProgressMonitor pm) throws Exception;
 }

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/rename/RenameRefactoring.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/rename/RenameRefactoring.java
@@ -336,7 +336,7 @@ public class RenameRefactoring extends AbstractPomRefactoring {
   // XXX move stuff UP after implementing another refactoring
   // after moving up, use this
   interface ScanVisitor {
-    public boolean interested(EObject obj);
+    boolean interested(EObject obj);
   }
 
   @Override

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/ScmTag.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/ScmTag.java
@@ -20,7 +20,7 @@ package org.eclipse.m2e.scm;
  */
 public class ScmTag {
 
-  public static enum Type {
+  public enum Type {
     HEAD, TAG, BRANCH, DATE;
   }
 

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/JobHelpers.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/JobHelpers.java
@@ -199,7 +199,7 @@ public class JobHelpers {
     return null;
   }
 
-  public static interface IJobMatcher {
+  public interface IJobMatcher {
 
     boolean matches(Job job);
 


### PR DESCRIPTION
Note that this breaks formatting slightly by replaing

```
@Deprecated
public void somethod()
```

with

```
@Deprecated void somethod()
```

If that's not acceptable we either need some formatter or get the cleanup changed.

EclipseJdt cleanup 'RemoveRedundantModifier' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

Signed-off-by: Carsten Heyl <cal-1@web.de>