### PR TITLE
[cleanup] erefactor/EclipseJdt - Invert equals arguments if parameter is constant string

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
@@ -370,7 +370,7 @@ public class SelectionUtil {
           if(input instanceof IFileEditorInput) {
             IFileEditorInput fileInput = (IFileEditorInput) input;
             file = fileInput.getFile();
-            if(file.getName().equals(IMavenConstants.POM_FILE_NAME)) {
+            if(IMavenConstants.POM_FILE_NAME.equals(file.getName())) {
               return file;
             }
           }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
@@ -315,9 +315,9 @@ public class MavenRepositorySearchDialog extends AbstractMavenDialog {
     }
 
     Packaging pack;
-    if(queryType.equals(IIndex.SEARCH_PARENTS)) {
+    if(IIndex.SEARCH_PARENTS.equals(queryType)) {
       pack = Packaging.POM;
-    } else if(queryType.equals(IIndex.SEARCH_PLUGIN)) {
+    } else if(IIndex.SEARCH_PLUGIN.equals(queryType)) {
       pack = Packaging.PLUGIN;
     } else {
       pack = Packaging.ALL;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -174,7 +174,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
             }
             Element ourMarkerPlacement = null;
             for(Element candid : candidates) {
-              Matcher match = exec.equals("default") ? childMissingOrEqual(PomEdits.ID, "default")
+              Matcher match = "default".equals(exec) ? childMissingOrEqual(PomEdits.ID, "default")
                   : childEquals(PomEdits.ID, exec);
               Element execution = findChild(findChild(candid, PomEdits.EXECUTIONS), PomEdits.EXECUTION, match);
               if(execution != null) {
@@ -209,7 +209,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
           }
 
           private Element findPlugin(Element build, String groupId, String artifactId) {
-            Matcher grIdmatch = groupId.equals("org.apache.maven.plugins")
+            Matcher grIdmatch = "org.apache.maven.plugins".equals(groupId)
                 ? childMissingOrEqual(PomEdits.GROUP_ID, groupId)
                 : childEquals(PomEdits.GROUP_ID, groupId);
             return findChild(findChild(build, PomEdits.PLUGINS), PomEdits.PLUGIN, grIdmatch,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/ExtensionReader.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/ExtensionReader.java
@@ -119,7 +119,7 @@ public class ExtensionReader {
       for(IExtension extension : mappingsExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals(ELEMENT_LISTENER)) {
+          if(ELEMENT_LISTENER.equals(element.getName())) {
             try {
               listeners.add((IMavenProjectChangedListener) element.createExecutableExtension("class")); //$NON-NLS-1$
             } catch(CoreException ex) {
@@ -143,7 +143,7 @@ public class ExtensionReader {
       for(IExtension extension : mappingsExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals("framework")) {
+          if("framework".equals(element.getName())) {
             try {
               frameworks.add((IIncrementalBuildFramework) element.createExecutableExtension("class")); //$NON-NLS-1$
             } catch(CoreException ex) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/IndexesExtensionReader.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/IndexesExtensionReader.java
@@ -61,7 +61,7 @@ public class IndexesExtensionReader implements IRepositoryDiscoverer {
       for(IExtension extension : indexesExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals(ELEMENT_INDEX)) {
+          if(ELEMENT_INDEX.equals(element.getName())) {
             processIndexElement(registry, element, monitor);
           }
         }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingFactory.java
@@ -973,7 +973,7 @@ public class LifecycleMappingFactory {
       for(IExtension extension : configuratorExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals(ELEMENT_LIFECYCLE_MAPPING)) {
+          if(ELEMENT_LIFECYCLE_MAPPING.equals(element.getName())) {
             mappings.put(element.getAttribute(ATTR_ID), element);
           }
         }
@@ -985,7 +985,7 @@ public class LifecycleMappingFactory {
 
   private static AbstractLifecycleMapping getLifecycleMapping(String mappingId) {
     IConfigurationElement element = getLifecycleMappingExtensions().get(mappingId);
-    if(element != null && element.getName().equals(ELEMENT_LIFECYCLE_MAPPING)) {
+    if(element != null && ELEMENT_LIFECYCLE_MAPPING.equals(element.getName())) {
       if(mappingId.equals(element.getAttribute(ATTR_ID))) {
         return createLifecycleMapping(element);
       }
@@ -1025,7 +1025,7 @@ public class LifecycleMappingFactory {
       for(IExtension extension : configuratorExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals(ELEMENT_CONFIGURATOR)) {
+          if(ELEMENT_CONFIGURATOR.equals(element.getName())) {
             extensions.put(element.getAttribute(AbstractProjectConfigurator.ATTR_ID), element);
           }
         }
@@ -1040,7 +1040,7 @@ public class LifecycleMappingFactory {
       return null;
     }
     IConfigurationElement element = elements.get(configuratorId);
-    if(element != null && element.getName().equals(ELEMENT_CONFIGURATOR)) {
+    if(element != null && ELEMENT_CONFIGURATOR.equals(element.getName())) {
       if(configuratorId.equals(element.getAttribute(AbstractProjectConfigurator.ATTR_ID))) {
         return element;
       }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryInfo.java
@@ -156,7 +156,7 @@ public class RepositoryInfo implements IRepository {
   }
 
   public static File getBasedir(String repositoryUrl) {
-    if(getProtocol(repositoryUrl).equalsIgnoreCase("file")) { //$NON-NLS-1$
+    if("file".equalsIgnoreCase(getProtocol(repositoryUrl))) { //$NON-NLS-1$
       // dirty trick!
       MavenArtifactRepository trick = new MavenArtifactRepository();
       trick.setUrl(repositoryUrl);

--- a/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/PomContentAssistProcessor.java
+++ b/org.eclipse.m2e.editor.xml/src/main/java/org/eclipse/m2e/editor/xml/PomContentAssistProcessor.java
@@ -190,7 +190,7 @@ public class PomContentAssistProcessor extends DefaultXMLCompletionProposalCompu
 
     Node node = request.getParent();
 
-    if(context == PomTemplateContext.PARENT && node.getNodeName().equals("parent")) { //$NON-NLS-1$
+    if(context == PomTemplateContext.PARENT && "parent".equals(node.getNodeName())) { //$NON-NLS-1$
       Element parent = (Element) node;
       Element relPath = XmlUtils.findChild(parent, "relativePath"); //$NON-NLS-1$
       if(relPath == null) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/ListEditorComposite.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/ListEditorComposite.java
@@ -198,7 +198,7 @@ public class ListEditorComposite<T> extends Composite {
   public void setReadOnly(boolean readOnly) {
     this.readOnly = readOnly;
     for(Map.Entry<String, Button> entry : buttons.entrySet()) {
-      if(entry.getKey().equals(REMOVE)) {
+      if(REMOVE.equals(entry.getKey())) {
         //Special case, as it makes no sense to enable if it there's nothing selected.
         updateRemoveButton();
       } else {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MavenMarkerResolutionGenerator.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MavenMarkerResolutionGenerator.java
@@ -58,16 +58,16 @@ public class MavenMarkerResolutionGenerator implements IMarkerResolutionGenerato
           new IgnoreWarningResolution(marker, IMavenConstants.MARKER_IGNORE_MANAGED),
           new OpenManagedVersionDefinitionResolution(marker)};
     }
-    if(hint.equals(IMavenConstants.EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION)) {
+    if(IMavenConstants.EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION.equals(hint)) {
       return new IMarkerResolution[] {new LifecycleMappingResolution(marker, PluginExecutionAction.ignore),
           new WorkspaceLifecycleMappingResolution(marker, PluginExecutionAction.ignore),};
     }
-    if(hint.equals(IMavenConstants.EDITOR_HINT_MISSING_CONFIGURATOR)) {
+    if(IMavenConstants.EDITOR_HINT_MISSING_CONFIGURATOR.equals(hint)) {
       return new IMarkerResolution[] {new LifecycleMappingResolution(marker, PluginExecutionAction.ignore),
           new WorkspaceLifecycleMappingResolution(marker, PluginExecutionAction.ignore)};
     }
     if(marker.getAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR) == IMarker.SEVERITY_ERROR
-        && hint.equals(IMavenConstants.EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING)) {
+        && IMavenConstants.EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING.equals(hint)) {
       return new IMarkerResolution[] {new LifecycleMappingResolution(marker, PluginExecutionAction.ignore),
           new WorkspaceLifecycleMappingResolution(marker, PluginExecutionAction.ignore)};
     }
@@ -75,11 +75,11 @@ public class MavenMarkerResolutionGenerator implements IMarkerResolutionGenerato
   }
 
   static boolean isPluginVersionOverride(String hint) {
-    return hint.equals(IMavenConstants.EDITOR_HINT_MANAGED_PLUGIN_OVERRIDE);
+    return IMavenConstants.EDITOR_HINT_MANAGED_PLUGIN_OVERRIDE.equals(hint);
   }
 
   static boolean isDependencyVersionOverride(String hint) {
-    return hint.equals(IMavenConstants.EDITOR_HINT_MANAGED_DEPENDENCY_OVERRIDE);
+    return IMavenConstants.EDITOR_HINT_MANAGED_DEPENDENCY_OVERRIDE.equals(hint);
   }
 
   static boolean isUnneededParentGroupId(String hint) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/SchemaCompletionResolution.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/SchemaCompletionResolution.java
@@ -62,7 +62,7 @@ public class SchemaCompletionResolution extends AbstractPomProblemResolution {
   @Override
   protected void processFix(IStructuredDocument doc, Element root, List<IMarker> markers) {
     for(IMarker marker : markers) {
-      if(root.getNodeName().equals(PROJECT_NODE) && root instanceof IndexedRegion) {
+      if(PROJECT_NODE.equals(root.getNodeName()) && root instanceof IndexedRegion) {
         IndexedRegion off = (IndexedRegion) root;
 
         int offset = off.getStartOffset() + PROJECT_NODE.length() + 1;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/MojoParameterMetadataProvider.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/MojoParameterMetadataProvider.java
@@ -197,7 +197,7 @@ public class MojoParameterMetadataProvider implements IMojoParameterMetadataProv
 
     PlexusConfigHelper helper = new PlexusConfigHelper();
 
-    if(goal.equals("*")) { //$NON-NLS-1$
+    if("*".equals(goal)) { //$NON-NLS-1$
       List<MojoParameter> parameters = new ArrayList<>();
       Set<String> collected = new HashSet<>();
       for(MojoDescriptor mojo : desc.getMojos()) {
@@ -327,7 +327,7 @@ public class MojoParameterMetadataProvider implements IMojoParameterMetadataProv
       for(IExtension extension : mappingsExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals("mojoParameterMetadata") //$NON-NLS-1$
+          if("mojoParameterMetadata".equals(element.getName()) //$NON-NLS-1$
               && mojoConfigurator.equals(element.getAttribute("configurator"))) { //$NON-NLS-1$
             try {
               return (IMojoParameterMetadata) element.createExecutableExtension("class"); //$NON-NLS-1$

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
@@ -399,7 +399,7 @@ public class PlexusConfigHelper {
     }
     // remove common package names
     String pkg = name.substring(0, idx);
-    if(pkg.equals("java.lang") || pkg.equals("java.util") || pkg.equals("java.io")) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    if("java.lang".equals(pkg) || "java.util".equals(pkg) || "java.io".equals(pkg)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
       return clazz.getSimpleName();
     }
     return name;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
@@ -403,7 +403,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
       IExtension[] indexesExtensions = indexesExtensionPoint.getExtensions();
       for(IExtension extension : indexesExtensions) {
         for(IConfigurationElement element : extension.getConfigurationElements()) {
-          if(element.getName().equals(ELEMENT_PAGE)) {
+          if(ELEMENT_PAGE.equals(element.getName())) {
             try {
               MavenPomEditorPageFactory factory;
               factory = (MavenPomEditorPageFactory) element.createExecutableExtension("class"); //$NON-NLS-1$

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
@@ -759,7 +759,7 @@ public enum PomTemplateContext {
     Node moduleNode = node;
     if(moduleNode != null) {
       Node modulesNode;
-      if(moduleNode.getLocalName().equals("modules")) {
+      if("modules".equals(moduleNode.getLocalName())) {
         modulesNode = moduleNode;
       } else {
         modulesNode = moduleNode.getParentNode();

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -221,8 +221,8 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
     }
 
     if(scope == IClasspathManager.CLASSPATH_TEST
-        && configuration.getAttribute(ATTRIBUTE_ORG_ECLIPSE_JDT_JUNIT_TEST_KIND, "") //$NON-NLS-1$
-            .equals(TESTKIND_ORG_ECLIPSE_JDT_JUNIT_LOADER_JUNIT5)) {
+        && TESTKIND_ORG_ECLIPSE_JDT_JUNIT_LOADER_JUNIT5 //$NON-NLS-1$
+            .equals(configuration.getAttribute(ATTRIBUTE_ORG_ECLIPSE_JDT_JUNIT_TEST_KIND, ""))) {
       addMissingJUnit5ExecutionDependencies(resolved, monitor, javaProject);
     }
   }

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
@@ -181,7 +181,7 @@ public class ExecutePomAction implements ILaunchShortcut, IExecutableExtension {
             return folder;
           }
         } else if(dir.getType() == IResource.FILE) {
-          if(((IFile) dir).getName().equals(IMavenConstants.POM_FILE_NAME)) {
+          if(IMavenConstants.POM_FILE_NAME.equals(((IFile) dir).getName())) {
             return dir.getParent();
           }
         }
@@ -344,7 +344,7 @@ public class ExecutePomAction implements ILaunchShortcut, IExecutableExtension {
               });
           dialog.setElements(matchingConfigs.toArray(new ILaunchConfiguration[matchingConfigs.size()]));
           dialog.setTitle(Messages.ExecutePomAction_dialog_title);
-          if(mode.equals(ILaunchManager.DEBUG_MODE)) {
+          if(ILaunchManager.DEBUG_MODE.equals(mode)) {
             dialog.setMessage(Messages.ExecutePomAction_dialog_debug_message);
           } else {
             dialog.setMessage(Messages.ExecutePomAction_dialog_run_message);

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenSourceBundle.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenSourceBundle.java
@@ -69,7 +69,7 @@ public class MavenSourceBundle extends TargetBundle {
 								Enumeration<JarEntry> entries = jar.entries();
 								while (entries.hasMoreElements()) {
 									JarEntry jarEntry = entries.nextElement();
-									if (jarEntry.getName().equals(JarFile.MANIFEST_NAME)) {
+									if (JarFile.MANIFEST_NAME.equals(jarEntry.getName())) {
 										continue;
 									}
 									try (InputStream is = jar.getInputStream(jarEntry)) {

--- a/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/actions/ProfileSelectionHandler.java
+++ b/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/actions/ProfileSelectionHandler.java
@@ -338,7 +338,7 @@ public class ProfileSelectionHandler extends AbstractHandler {
           // was not displayed. Use existing value.
           if(st.isUserSelected()) {
             id = st.getId();
-            isDisabled = st.getActivationState().equals(ProfileState.Disabled);
+            isDisabled = ProfileState.Disabled.equals(st.getActivationState());
           }
         } else {
           if(null == selection.getSelected()) {
@@ -346,13 +346,13 @@ public class ProfileSelectionHandler extends AbstractHandler {
             // previous state
             if(st.isUserSelected()) {
               id = st.getId();
-              isDisabled = st.getActivationState().equals(ProfileState.Disabled);
+              isDisabled = ProfileState.Disabled.equals(st.getActivationState());
             }
           } else {
             // Value was displayed and is consistent
             if(Boolean.TRUE.equals(selection.getSelected())) {
               id = selection.getId();
-              isDisabled = selection.getActivationState().equals(ProfileState.Disabled);
+              isDisabled = ProfileState.Disabled.equals(selection.getActivationState());
             }
           }
         }

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/internal/ScmHandlerFactory.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/internal/ScmHandlerFactory.java
@@ -120,7 +120,7 @@ public class ScmHandlerFactory {
       for(IExtension extension : scmHandlersExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals(ELEMENT_SCM_HANDLER)) {
+          if(ELEMENT_SCM_HANDLER.equals(element.getName())) {
             try {
               scmHandlers.add((ScmHandler) element.createExecutableExtension(ScmHandler.ATTR_CLASS));
             } catch(CoreException ex) {
@@ -142,7 +142,7 @@ public class ScmHandlerFactory {
       for(IExtension extension : scmHandlersUiExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if(element.getName().equals(ELEMENT_SCM_HANDLER_UI)) {
+          if(ELEMENT_SCM_HANDLER_UI.equals(element.getName())) {
             try {
               scmHandlerUis.add((ScmHandlerUi) element.createExecutableExtension(ScmHandlerUi.ATTR_CLASS));
             } catch(CoreException ex) {

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/internal/wizards/MavenCheckoutLocationPage.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/internal/wizards/MavenCheckoutLocationPage.java
@@ -260,7 +260,7 @@ public class MavenCheckoutLocationPage extends AbstractMavenWizardPage {
             IExtension[] extension = point.getExtensions();
             if(extension.length > 0) {
               for(IConfigurationElement element : extension[0].getConfigurationElements()) {
-                if(element.getName().equals("launcher")) {
+                if("launcher".equals(element.getName())) {
                   try {
                     ((IMavenDiscovery) element.createExecutableExtension("class"))
                         .launch(Display.getCurrent().getActiveShell());

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -520,7 +520,7 @@ public abstract class AbstractMavenProjectTestCase {
     }
     if(waitForJobsToComplete) {
       // emulate behavior when autobuild was not honored by ProjectRegistryRefreshJob
-      if(!isAutoBuilding() && file.getParent().getType() == IResource.PROJECT && file.getName().equals("pom.xml")) {
+      if(!isAutoBuilding() && file.getParent().getType() == IResource.PROJECT && "pom.xml".equals(file.getName())) {
         refreshMavenProject(project);
       }
       waitForJobsToComplete();

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
@@ -125,10 +125,10 @@ public class HttpServer {
     sslContextFactory.setKeyManagerPassword(storePassword);
     sslContextFactory.setKeyStorePath(new File(keyStoreLocation).getAbsolutePath());
     sslContextFactory.setKeyStorePassword(keyStorePassword);
-    if(trustStoreLocation != null && !trustStoreLocation.equals("")) {
+    if(trustStoreLocation != null && !"".equals(trustStoreLocation)) {
       sslContextFactory.setTrustStorePath(new File(trustStoreLocation).getAbsolutePath());
     }
-    if(trustStorePassword != null && !trustStoreLocation.equals("")) {
+    if(trustStorePassword != null && !"".equals(trustStoreLocation)) {
       sslContextFactory.setTrustStorePassword(trustStorePassword);
     }
     sslContextFactory.setNeedClientAuth(needClientAuth);


### PR DESCRIPTION
I guess it's a matter of taste and policy if you want this.

EclipseJdt cleanup 'InvertEquals' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor