### PR TITLE
Include sources in development target-platform

### DIFF
--- a/target-platform/dev-workspace.target
+++ b/target-platform/dev-workspace.target
@@ -4,41 +4,41 @@
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<locations>
 		<!-- Dev: Add Maven runtime bundles to Target Platform as they are usually not necessary to have in workspace to develop m2e -->
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/technology/m2e/releases/latest/"/>
 			<unit id="org.eclipse.m2e.maven.runtime" version="0.0.0"/>
 			<unit id="org.eclipse.m2e.maven.indexer" version="0.0.0"/>
 			<unit id="org.eclipse.m2e.maven.runtime.slf4j.simple" version="0.0.0"/>
 		</location>
 		<!-- copied from m2e-build.target -->
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/eclipse/updates/4.19"/>
 			<unit id="org.eclipse.platform.ide" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://bndtools.jfrog.io/bndtools/update-latest"/>
 			<unit id="bndtools.main.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="http://download.eclipse.org/egit/updates/"/>
 			<unit id="org.eclipse.jgit" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>
 			<unit id="org.eclipse.emf.edit.ui.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.ecore.edit.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.21.0/R-3.21.0-20210304100654/repository/"/>
 			<unit id="org.eclipse.wst.common.uriresolver" version="0.0.0"/>
 			<unit id="org.eclipse.wst.common.emf" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository"/>
 			<unit id="com.google.gson" version="0.0.0"/>
 			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
@@ -47,15 +47,15 @@
 			<unit id="ch.qos.logback.classic" version="0.0.0"/>
 			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/latest/"/>
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
-		<location missingManifest="error" type="Maven">
+		<location includeSource="true" missingManifest="error" type="Maven">
 			<groupId>io.takari.m2e.workspace</groupId>
 			<artifactId>org.eclipse.m2e.workspace.cli</artifactId>
 			<version>0.3.1</version>


### PR DESCRIPTION
Having the sources of dependencies is handy during development.