### PR TITLE
Mark test source folders as such

### DIFF
--- a/org.eclipse.m2e.editor.lemminx.tests/.classpath
+++ b/org.eclipse.m2e.editor.lemminx.tests/.classpath
@@ -6,6 +6,10 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.m2e.editor.xml.sse.tests/.classpath
+++ b/org.eclipse.m2e.editor.xml.sse.tests/.classpath
@@ -6,6 +6,10 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
As test harness plugin already does it and this fixes compilation.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>