### PR TITLE
Improve Oomph-setup, adjust doc and add auto-launch Installer button

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,20 +42,26 @@ Latest builds, for testing, can usually be found at https://download.eclipse.org
 ### Prerequisites
 
 Java 11 and Maven 3.6.3 (only if you want to build from the command-line), or newer.
+Furthermore a local git installation is required and the git executable must be in the PATH environment variable.
 
 ### ⌨️ Setting up the Development Environment automatically, using the Eclipse Installer (Oomph)
 
 1. Download the [Eclipse Installer](https://wiki.eclipse.org/Eclipse_Installer).  
 	1. If you are already in the workspace of an Eclipse provisioned by Oomph, go to *File > Import... > Oomph > Projects from catalog* and continue with step 6.
 2. Start the installer using the `eclipse-inst` executable.
-3. On the first page (product selection), click the preference button in the top-right corner and select the *Advanced Mode* .
-4. If you are behind a proxy, at this point you might want to double check your network settings by clicking in the *Network Proxy Settings* at the bottom.
-5. Select *Eclipse IDE for Eclipse Committers* . Click *Next* .
-6. Under *Eclipse Projects* , double-click on *m2e-core* (single click is not enough!). Make sure that *m2e-core* is shown in the table on the bottom. Click *Next*.
-7. You can edit the *Installation Folder* , but you do not have to select the *Target Platform* here, this will be set later automatically. By choosing *Show all variables* at the bottom of the page, you are able to change other values as well but you do not have to. Click *Next* .
-8. Press *Finished* on the *Confirmation* page will start the installation process. 
-9. The installer will download the selected Eclipse version, starts Eclipse and will perform all the additional steps (cloning the git repos, etc...). When the downloaded Eclispe started, the progress bar in the status bar shows the progress of the overall setup.
-10. Once the *Executing startup task* job is finished you should have all the *m2-core*, *m2-core-tests* and *m2e-maven-runtime* projects imported into three working sets called *m2-core*, *m2-core-tests* and *m2e-maven-runtime*.
+3. On the first page (*Product*), click the preference button in the top-right corner and select the *Advanced Mode*.
+    1. If you are behind a proxy, at this point you might want to double check your network settings by clicking in the *Network proxy settings* at the bottom.
+    2. If an SSH key is required to access the git-repository, make sure that this key is known by clicking on the *SSH2 settings* at the bottom and verify that *SS2 home* has the correct value and the key is listed in *Private keys*.
+4. Select *Eclipse IDE for Eclipse Committers* (use *Product Version - latest* to use the latest builds of Eclipse). Click *Next* .
+5. On the *Projects*-page under *Eclipse Projects*, select *m2e*. Make sure that *m2e* is shown in the table on the bottom. Click *Next*.
+6. You can edit the *Installation location and folder name*, the *Workspace location and folder name* or the *Git clone location*, among others.
+    1. Only the latter is available if you came here via the Import-projects dialog.
+    2. By choosing *Show all variables* at the bottom of the page, you are able to change other values as well but you do not have to.
+    3. Click *Next* .
+7. Press *Finish* on the *Confirmation* page will start the installation process. 
+8. The installer will download the selected Eclipse version, starts Eclipse and will perform all the additional steps (cloning the git repos, etc...). When the downloaded Eclispe started, the progress bar in the status bar shows the progress of the overall setup.
+9. Once the *Executing startup task* job is finished you should have all the *m2-core*, *m2-core-tests* and *m2e-maven-runtime* projects imported into three working sets called *m2-core*, *m2-core-tests* and *m2e-maven-runtime*.
+10. Remaining errors are resolved after a restart of Eclipse.
 11. Happy coding!
 
 ### ⌨️ Setting up the Development Environment manually

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,13 @@ Furthermore a local git installation is required and the git executable must be 
 
 ### ⌨️ Setting up the Development Environment automatically, using the Eclipse Installer (Oomph)
 
+Quick-Link:
+
+ <a href="https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true"
+style="margin-left:2em;margin-top:1ex;margin-bottom:1ex;font-weight:bold;border:1px solid chocolate;background-color:darkorange;color:white;padding:0.25ex 0.25em;text-align:center;text-decoration:none" rel="nofollow">Create m2e Development Environment with Eclipse-Oomph...</a>
+
+Step by Step guide:
+
 1. Download the [Eclipse Installer](https://wiki.eclipse.org/Eclipse_Installer).  
 	1. If you are already in the workspace of an Eclipse provisioned by Oomph, go to *File > Import... > Oomph > Projects from catalog* and continue with step 6.
 2. Start the installer using the `eclipse-inst` executable.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Eclipse IDE integration for Maven (Eclipse m2e project)
 
+ <a href="https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true"
+style="margin-left:2em;margin-top:1ex;margin-bottom:1ex;font-weight:bold;border:1px solid chocolate;background-color:darkorange;color:white;padding:0.25ex 0.25em;text-align:center;text-decoration:none" rel="nofollow">Create m2e Development Environment...</a>
+ or just 
  <a href="https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/redirect.html"><img src="https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/cloneToEclipseBadge.png" alt="Clone to Eclipse IDE"/></a>
 
 M2Eclipse provides tight integration for Apache Maven into the Eclipse IDE with the following features:

--- a/setup/m2e-maven-runtime--install.launch
+++ b/setup/m2e-maven-runtime--install.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="clean install -f m2e-maven-runtime install"/>
+    <stringAttribute key="M2_GOALS" value="clean install -f m2e-maven-runtime"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>

--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -16,6 +16,22 @@
     xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/launching/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Launching.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore http://www.eclipse.org/oomph/setup/pde/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore"
     name="m2e"
     label="m2e">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/org.eclipse.m2e.core/m2eclipse.gif</value>
+    </detail>
+    <detail
+        key="siteURI">
+      <value>https://www.eclipse.org/m2e/</value>
+    </detail>
+  </annotation>
+  <annotation
+      source="ConfigurationReference">
+    <reference
+        href="m2eDevelopmentEnvironmentConfiguration.setup#/"/>
+  </annotation>
   <setupTask
       xsi:type="setup:CompoundTask"
       name="User Preferences">

--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -63,6 +63,10 @@
     </content>
   </setupTask>
   <setupTask
+      xsi:type="setup:VariableTask"
+      name="eclipse.target.platform"
+      value="None"/>
+  <setupTask
       xsi:type="setup.p2:P2Task"
       label="m2e">
     <requirement
@@ -207,13 +211,12 @@
       xsi:type="pde:TargetPlatformTask"
       name="m2e-dev-workspace"/>
   <setupTask
+      xsi:type="launching:LaunchTask"
+      launcher="m2e-maven-runtime--install"/>
+  <setupTask
       xsi:type="projects:ProjectsBuildTask"
       refresh="true"
       clean="true"/>
-  <setupTask
-      xsi:type="launching:LaunchTask"
-      predecessor="//@setupTasks.11"
-      launcher="m2e-maven-runtime--install"/>
   <stream name="master"
       label="master"/>
   <logicalProjectContainer

--- a/setup/m2eDevelopmentEnvironmentConfiguration.setup
+++ b/setup/m2eDevelopmentEnvironmentConfiguration.setup
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="m2e Development Environment">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/org.eclipse.m2e.core/m2eclipse.gif</value>
+    </detail>
+    <detail
+        key="siteURI">
+      <value>https://www.eclipse.org/m2e/</value>
+    </detail>
+  </annotation>
+  <installation
+      name="m2e.development.environment.installation"
+      label="m2e Development Environment Installation">
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.products']/@products[name='epp.package.committers']/@versions[name='latest']"/>
+    <description>The m2e development environment installation provides the full development environment for working with m2e.</description>
+  </installation>
+  <workspace
+      name="m2e.development.environment.workspace"
+      label="m2e Development Environment Workspace">
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='m2e']/@streams[name='master']"/>
+    <description>The m2e development environment workspace includes m2e-core, m2e-maven-runtime and m2e-core-tests</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The &lt;a href=&quot;https://www.eclipse.org/m2e/&quot;/>m2e&lt;/a> Development Environment configuration provisions a dedicated development environment 
+    for the complete set of source projects used by &lt;a href=&quot;https://ci.eclipse.org/m2e/&quot;>m2e's build server&lt;/a> 
+    to produce &lt;a href=&quot;https://download.eclipse.org/technology/m2e/&quot;>m2e's update site&lt;/a>.
+    &lt;/p>
+    &lt;p>
+    The installation is based on the latest successful integration build of the Eclipse-for-commiters.
+    The workspace consists of all the projects from &lt;a href=&quot;https://github.com/eclipse-m2e/m2e-core.git&quot;>m2e's Git Repository&lt;/a>
+    , organized into working sets, and ready for contribution.
+    &lt;/p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the analgous tutorial instructions&lt;/a> for the Eclispe Platform SDK's configuration for more details.
+    &lt;/p>
+  </description>
+</setup:Configuration>


### PR DESCRIPTION
This PR improves the m2e-Oomph-setup in the following way:
- add the variable eclipse.target.platform=None so it is not prompted by the installer (it is unused).
- Swap order of Launch of m2e-maven-runtime-installion and refresh/clean/build all. This way the maven-runtime installation is done before all projects are build, which can avoid a manual refresh/rebuild or restart.

In the CONTRIBUTING.md some names are corrected, settings of SSH keys are mentioned and the text is improved in general.