### PR TITLE
Fix signing of m2e-maven-runtime

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -213,29 +213,9 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200a-plugin</artifactId>
-						<version>${tycho.version}</version>
-						<executions>
-							<execution>
-								<id>pack200-normalize</id>
-								<goals>
-									<goal>normalize</goal>
-								</goals>
-								<phase>verify</phase>
-							</execution>
-						</executions>
-						<configuration>
-							<supportedProjectTypes>
-								<supportedProjectType>bundle</supportedProjectType>
-							</supportedProjectTypes>
-						</configuration>
-					</plugin>
-
-					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.1.7</version>
+						<version>1.3.1</version>
 						<executions>
 							<execution>
 								<id>sign</id>
@@ -251,26 +231,6 @@
 							</supportedProjectTypes>
 							<excludeInnerJars>true</excludeInnerJars>
 							<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
-						</configuration>
-					</plugin>
-
-					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200b-plugin</artifactId>
-						<version>${tycho.version}</version>
-						<executions>
-							<execution>
-								<id>pack200-pack</id>
-								<goals>
-									<goal>pack</goal>
-								</goals>
-								<phase>verify</phase>
-							</execution>
-						</executions>
-						<configuration>
-							<supportedProjectTypes>
-								<supportedProjectType>bundle</supportedProjectType>
-							</supportedProjectTypes>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -37,7 +37,7 @@
 		<archetype-common.version>2.4</archetype-common.version>
 		<maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
 		<m2e.version>1.16.2</m2e.version>
-		<tycho.version>2.2.0</tycho.version>
+		<tycho.version>2.3.0</tycho.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Update to latest eclipse-jarsigner-plugin which uses the correct url.
Drop the pack200 from runtime bundles as this is already not used with
the main site not using pack200.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>