### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unused imports

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core.ui.tests
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core.ui.tests/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.core.ui.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.1-SNAPSHOT</version>
 
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
+++ b/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
@@ -27,13 +27,11 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.m2e.actions.MavenLaunchConstants;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
-import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.TextConsole;
 import org.junit.Test;
 


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnusedImport' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
