### PR TITLE
[cleanup] erefactor/EclipseJdt - Add elements in collections without loop

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core.ui.tests
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core.ui.tests/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.core.ui.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.1-SNAPSHOT</version>
 
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -17,7 +17,7 @@
 
   <artifactId>org.eclipse.m2e.core</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.1-SNAPSHOT</version>
 
   <name>Maven Integration for Eclipse Core Plug-in</name>
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntimeManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenRuntimeManager.java
@@ -78,9 +78,7 @@ public class MavenRuntimeManager {
 
   public List<MavenRuntime> getMavenRuntimes() {
     List<MavenRuntime> result = new ArrayList<>();
-    for(AbstractMavenRuntime runtime : impl.getMavenRuntimes()) {
-      result.add(runtime);
-    }
+    result.addAll(impl.getMavenRuntimes());
     return result;
   }
 

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="1.18.0.qualifier"
+      version="1.18.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-internal:=true,

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ClasspathEntryDescriptor.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/ClasspathEntryDescriptor.java
@@ -15,6 +15,7 @@ package org.eclipse.m2e.jdt.internal;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -183,9 +184,7 @@ public class ClasspathEntryDescriptor implements IClasspathEntryDescriptor {
     this.outputLocation = entry.getOutputLocation();
 
     this.accessRules = new ArrayList<>();
-    for(IAccessRule rule : entry.getAccessRules()) {
-      this.accessRules.add(rule);
-    }
+    Collections.addAll(this.accessRules, entry.getAccessRules());
 
     this.attributes = new LinkedHashMap<>();
     for(IClasspathAttribute attribute : entry.getExtraAttributes()) {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -16,6 +16,7 @@ package org.eclipse.m2e.jdt.internal.launch;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -191,9 +192,7 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
   private void addStandardClasspathEntries(Set<IRuntimeClasspathEntry> all, IRuntimeClasspathEntry entry,
       ILaunchConfiguration configuration) throws CoreException {
     IRuntimeClasspathEntry[] resolved = JavaRuntime.resolveRuntimeClasspathEntry(entry, configuration);
-    for(IRuntimeClasspathEntry element : resolved) {
-      all.add(element);
-    }
+    Collections.addAll(all, resolved);
   }
 
   private void addMavenClasspathEntries(Set<IRuntimeClasspathEntry> resolved,

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.18.0.qualifier"
+      version="1.18.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 1.17.2.qualifier
+Bundle-Version: 1.17.3.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -568,9 +568,7 @@ public abstract class AbstractMavenProjectTestCase {
   @SafeVarargs
   protected static <T> void assertContainsOnly(Set<? extends T> actual, T... expected) {
     Set<T> expectedSet = new HashSet<>();
-    for(T item : expected) {
-      expectedSet.add(item);
-    }
+    Collections.addAll(expectedSet, expected);
     assertEquals(expectedSet, actual);
   }
 

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/HttpServer.java
@@ -428,9 +428,7 @@ public class HttpServer {
    * @return This server, never {@code null}.
    */
   public HttpServer enableRecording(String... patterns) {
-    for(String pattern : patterns) {
-      recordedPatterns.add(pattern);
-    }
+    Collections.addAll(recordedPatterns, patterns);
 
     return this;
   }


### PR DESCRIPTION
EclipseJdt cleanup 'UseAddAll' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
