### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant super() call

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.m2e.core.ui;bundle-version="[1.16.0,2.0.0)"
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core.ui.tests
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core.ui.tests/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.core.ui.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.1-SNAPSHOT</version>
 
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizard.java
@@ -65,7 +65,6 @@ public class MavenPomWizard extends Wizard implements INewWizard {
    * Constructor for MavenPomWizard.
    */
   public MavenPomWizard() {
-    super();
     setNeedsProgressMonitor(true);
     setWindowTitle(Messages.MavenPomWizard_title);
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizard.java
@@ -90,7 +90,6 @@ public class MavenProjectWizard extends AbstractMavenProjectWizard implements IN
    * Default constructor. Sets the title and image of the wizard.
    */
   public MavenProjectWizard() {
-    super();
     setWindowTitle(Messages.wizardProjectTitle);
     setDefaultPageImageDescriptor(MavenImages.WIZ_NEW_PROJECT);
     setNeedsProgressMonitor(true);

--- a/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor.xml;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.xml.MvnIndexPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.m2e.editor.xml/src/org/eclipse/m2e/editor/xml/internal/POMMarkerAnnotationModelFactory.java
+++ b/org.eclipse.m2e.editor.xml/src/org/eclipse/m2e/editor/xml/internal/POMMarkerAnnotationModelFactory.java
@@ -28,7 +28,6 @@ import org.eclipse.ui.texteditor.ResourceMarkerAnnotationModelFactory;
  */
 public class POMMarkerAnnotationModelFactory extends ResourceMarkerAnnotationModelFactory {
   public POMMarkerAnnotationModelFactory() {
-    super();
   }
 
   /*

--- a/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.MavenEditorPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/DependencyLabelProvider.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/composites/DependencyLabelProvider.java
@@ -64,7 +64,6 @@ public class DependencyLabelProvider extends LabelProvider implements IColorProv
   }
 
   public DependencyLabelProvider(boolean showManagedOverlay) {
-    super();
     this.showManagedOverlay = showManagedOverlay;
   }
 

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="1.18.0.qualifier"
+      version="1.18.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.model.edit;singleton:=true
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/PomModelHandler.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/PomModelHandler.java
@@ -47,7 +47,6 @@ public class PomModelHandler extends ModelHandlerForXML {
   private static final String POM_XSD = "http://maven.apache.org/xsd/maven-4.0.0.xsd"; //$NON-NLS-1$
 
   public PomModelHandler() {
-    super();
     setAssociatedContentTypeId(ASSOCIATED_CONTENT_TYPE_ID);
   }
 

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationFileImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationFileImpl.java
@@ -82,7 +82,6 @@ public class ActivationFileImpl extends EObjectImpl implements ActivationFile {
    * @generated
    */
   protected ActivationFileImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationImpl.java
@@ -150,7 +150,6 @@ public class ActivationImpl extends EObjectImpl implements Activation {
    * @generated
    */
   protected ActivationImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationOSImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationOSImpl.java
@@ -121,7 +121,6 @@ public class ActivationOSImpl extends EObjectImpl implements ActivationOS {
    * @generated
    */
   protected ActivationOSImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationPropertyImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ActivationPropertyImpl.java
@@ -81,7 +81,6 @@ public class ActivationPropertyImpl extends EObjectImpl implements ActivationPro
    * @generated
    */
   protected ActivationPropertyImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/BuildBaseImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/BuildBaseImpl.java
@@ -178,7 +178,6 @@ public class BuildBaseImpl extends EObjectImpl implements BuildBase {
    * @generated
    */
   protected BuildBaseImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/BuildImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/BuildImpl.java
@@ -165,7 +165,6 @@ public class BuildImpl extends BuildBaseImpl implements Build {
    * @generated
    */
   protected BuildImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/CiManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/CiManagementImpl.java
@@ -98,7 +98,6 @@ public class CiManagementImpl extends EObjectImpl implements CiManagement {
    * @generated
    */
   protected CiManagementImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ConfigurationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ConfigurationImpl.java
@@ -50,7 +50,6 @@ public class ConfigurationImpl extends EObjectImpl implements Configuration {
    * @generated
    */
   protected ConfigurationImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ContributorImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ContributorImpl.java
@@ -194,7 +194,6 @@ public class ContributorImpl extends EObjectImpl implements Contributor {
    * @generated
    */
   protected ContributorImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DependencyImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DependencyImpl.java
@@ -241,7 +241,6 @@ public class DependencyImpl extends EObjectImpl implements Dependency {
    * @generated
    */
   protected DependencyImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DependencyManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DependencyManagementImpl.java
@@ -58,7 +58,6 @@ public class DependencyManagementImpl extends EObjectImpl implements DependencyM
    * @generated
    */
   protected DependencyManagementImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DeploymentRepositoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DeploymentRepositoryImpl.java
@@ -159,7 +159,6 @@ public class DeploymentRepositoryImpl extends EObjectImpl implements DeploymentR
    * @generated
    */
   protected DeploymentRepositoryImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DeveloperImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DeveloperImpl.java
@@ -213,7 +213,6 @@ public class DeveloperImpl extends EObjectImpl implements Developer {
    * @generated
    */
   protected DeveloperImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DistributionManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DistributionManagementImpl.java
@@ -171,7 +171,6 @@ public class DistributionManagementImpl extends EObjectImpl implements Distribut
    * @generated
    */
   protected DistributionManagementImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DocumentRootImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/DocumentRootImpl.java
@@ -83,7 +83,6 @@ public class DocumentRootImpl extends EObjectImpl implements DocumentRoot {
    * @generated
    */
   protected DocumentRootImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ExclusionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ExclusionImpl.java
@@ -81,7 +81,6 @@ public class ExclusionImpl extends EObjectImpl implements Exclusion {
    * @generated
    */
   protected ExclusionImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ExtensionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ExtensionImpl.java
@@ -102,7 +102,6 @@ public class ExtensionImpl extends EObjectImpl implements Extension {
    * @generated
    */
   protected ExtensionImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/IssueManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/IssueManagementImpl.java
@@ -80,7 +80,6 @@ public class IssueManagementImpl extends EObjectImpl implements IssueManagement 
    * @generated
    */
   protected IssueManagementImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/LicenseImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/LicenseImpl.java
@@ -120,7 +120,6 @@ public class LicenseImpl extends EObjectImpl implements License {
    * @generated
    */
   protected LicenseImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/MailingListImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/MailingListImpl.java
@@ -159,7 +159,6 @@ public class MailingListImpl extends EObjectImpl implements MailingList {
    * @generated
    */
   protected MailingListImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ModelImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ModelImpl.java
@@ -564,7 +564,6 @@ public class ModelImpl extends EObjectImpl implements Model {
    * @generated
    */
   protected ModelImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/NotifierImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/NotifierImpl.java
@@ -223,7 +223,6 @@ public class NotifierImpl extends EObjectImpl implements Notifier {
    * @generated
    */
   protected NotifierImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/OrganizationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/OrganizationImpl.java
@@ -78,7 +78,6 @@ public class OrganizationImpl extends EObjectImpl implements Organization {
    * @generated
    */
   protected OrganizationImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ParentImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ParentImpl.java
@@ -123,7 +123,6 @@ public class ParentImpl extends EObjectImpl implements Parent {
    * @generated
    */
   protected ParentImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PluginExecutionImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PluginExecutionImpl.java
@@ -139,7 +139,6 @@ public class PluginExecutionImpl extends EObjectImpl implements PluginExecution 
    * @generated
    */
   protected PluginExecutionImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PluginImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PluginImpl.java
@@ -203,7 +203,6 @@ public class PluginImpl extends EObjectImpl implements Plugin {
    * @generated
    */
   protected PluginImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PluginManagementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PluginManagementImpl.java
@@ -57,7 +57,6 @@ public class PluginManagementImpl extends EObjectImpl implements PluginManagemen
    * @generated
    */
   protected PluginManagementImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PomFactoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PomFactoryImpl.java
@@ -92,7 +92,6 @@ public class PomFactoryImpl extends EFactoryImpl implements PomFactory {
    * @generated
    */
   public PomFactoryImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PrerequisitesImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PrerequisitesImpl.java
@@ -68,7 +68,6 @@ public class PrerequisitesImpl extends EObjectImpl implements Prerequisites {
    * @generated
    */
   protected PrerequisitesImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ProfileImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ProfileImpl.java
@@ -234,7 +234,6 @@ public class ProfileImpl extends EObjectImpl implements Profile {
    * @generated
    */
   protected ProfileImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PropertyElementImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/PropertyElementImpl.java
@@ -81,7 +81,6 @@ public class PropertyElementImpl extends EObjectImpl implements PropertyElement 
    * @generated
    */
   protected PropertyElementImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/RelocationImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/RelocationImpl.java
@@ -123,7 +123,6 @@ public class RelocationImpl extends EObjectImpl implements Relocation {
    * @generated
    */
   protected RelocationImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ReportPluginImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ReportPluginImpl.java
@@ -163,7 +163,6 @@ public class ReportPluginImpl extends EObjectImpl implements ReportPlugin {
    * @generated
    */
   protected ReportPluginImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ReportSetImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ReportSetImpl.java
@@ -115,7 +115,6 @@ public class ReportSetImpl extends EObjectImpl implements ReportSet {
    * @generated
    */
   protected ReportSetImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ReportingImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ReportingImpl.java
@@ -110,7 +110,6 @@ public class ReportingImpl extends EObjectImpl implements Reporting {
    * @generated
    */
   protected ReportingImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/RepositoryImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/RepositoryImpl.java
@@ -167,7 +167,6 @@ public class RepositoryImpl extends EObjectImpl implements Repository {
    * @generated
    */
   protected RepositoryImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/RepositoryPolicyImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/RepositoryPolicyImpl.java
@@ -113,7 +113,6 @@ public class RepositoryPolicyImpl extends EObjectImpl implements RepositoryPolic
    * @generated
    */
   protected RepositoryPolicyImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ResourceImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ResourceImpl.java
@@ -136,7 +136,6 @@ public class ResourceImpl extends EObjectImpl implements Resource {
    * @generated
    */
   protected ResourceImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ScmImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/ScmImpl.java
@@ -127,7 +127,6 @@ public class ScmImpl extends EObjectImpl implements Scm {
    * @generated
    */
   protected ScmImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/SiteImpl.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/impl/SiteImpl.java
@@ -97,7 +97,6 @@ public class SiteImpl extends EObjectImpl implements Site {
    * @generated
    */
   protected SiteImpl() {
-    super();
   }
 
   /**

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/provider/PomEditPlugin.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/provider/PomEditPlugin.java
@@ -79,8 +79,6 @@ public final class PomEditPlugin extends EMFPlugin {
      * @generated
      */
     public Implementation() {
-      super();
-
       // Remember the static instance.
       //
       plugin = this;

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/translators/PropertiesAdapter.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/translators/PropertiesAdapter.java
@@ -172,7 +172,6 @@ public class PropertiesAdapter extends ListAdapter {
      * @param container
      */
     public PropertyChildAdapter(PropertyElement propertyElement, Element element) {
-      super();
       this.property = propertyElement;
       this.element = element;
     }

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/translators/SSESyncResource.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/translators/SSESyncResource.java
@@ -56,7 +56,6 @@ public class SSESyncResource extends ResourceImpl {
   private Document doc;
 
   public SSESyncResource() {
-    super();
   }
 
   public SSESyncResource(URI uri) {

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.18.0.qualifier"
+      version="1.18.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.sse.ui.feature/feature.xml
+++ b/org.eclipse.m2e.sse.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sse.ui.feature"
       label="%featureName"
-      version="1.18.0.qualifier"
+      version="1.18.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnnecessarySuperCall' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
