### PR TITLE
[cleanup] erefactor/EclipseJdt - Add/Remove '$NON-NLS$' tags

### DIFF
--- a/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject.ui;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-Activator: org.eclipse.m2e.binaryproject.ui.internal.BinaryprojectUIActivator
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.binaryproject.ui/src/org/eclipse/m2e/binaryproject/ui/internal/BinaryProjectImportWizard.java
+++ b/org.eclipse.m2e.binaryproject.ui/src/org/eclipse/m2e/binaryproject/ui/internal/BinaryProjectImportWizard.java
@@ -57,7 +57,7 @@ public class BinaryProjectImportWizard extends Wizard implements IImportWizard {
       }
     }
     artifactsPage =
-        new MavenDependenciesWizardPage(new ProjectImportConfiguration(), "Artifacts", "Select artifacts to import") {
+        new MavenDependenciesWizardPage(new ProjectImportConfiguration(), "Artifacts", "Select artifacts to import") { //$NON-NLS-1$ //$NON-NLS-2$
           @Override
           protected void createAdvancedSettings(Composite composite, GridData gridData) {
             // TODO profile can theoretically be usedful

--- a/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/AbstractBinaryProjectsImportJob.java
+++ b/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/AbstractBinaryProjectsImportJob.java
@@ -26,7 +26,7 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
 public abstract class AbstractBinaryProjectsImportJob extends Job {
 
   public AbstractBinaryProjectsImportJob() {
-    super("Import binary projects");
+    super("Import binary projects"); //$NON-NLS-1$
   }
 
   @Override

--- a/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/BinaryProjectPlugin.java
+++ b/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/BinaryProjectPlugin.java
@@ -45,25 +45,25 @@ import org.osgi.service.prefs.BackingStoreException;
 
 public class BinaryProjectPlugin implements BundleActivator {
 
-  public static final String PLUGIN_ID = "org.eclipse.m2e.binaryproject";
+  public static final String PLUGIN_ID = "org.eclipse.m2e.binaryproject"; //$NON-NLS-1$
 
-  public static final String LIFECYCLE_MAPPING_ID = "org.eclipse.m2e.binaryproject";
+  public static final String LIFECYCLE_MAPPING_ID = "org.eclipse.m2e.binaryproject"; //$NON-NLS-1$
 
-  public static final String P_GROUPID = "groupId";
+  public static final String P_GROUPID = "groupId"; //$NON-NLS-1$
 
-  public static final String P_ARTIFACTID = "artifactId";
+  public static final String P_ARTIFACTID = "artifactId"; //$NON-NLS-1$
 
-  public static final String P_VERSION = "version";
+  public static final String P_VERSION = "version"; //$NON-NLS-1$
 
-  public static final String P_TYPE = "type";
+  public static final String P_TYPE = "type"; //$NON-NLS-1$
 
-  public static final String P_CLASSIFIER = "classifier";
+  public static final String P_CLASSIFIER = "classifier"; //$NON-NLS-1$
 
   /**
    * Name of IProject persistent property that identifies absolute filesystem path of the target jar artifact of the
    * workspace binary project.
    */
-  public static final QualifiedName QNAME_JAR = new QualifiedName(PLUGIN_ID, "jar");
+  public static final QualifiedName QNAME_JAR = new QualifiedName(PLUGIN_ID, "jar"); //$NON-NLS-1$
 
   private static BinaryProjectPlugin SELF;
 
@@ -78,24 +78,24 @@ public class BinaryProjectPlugin implements BundleActivator {
     IMaven maven = MavenPlugin.getMaven();
 
     Artifact pomArtifact =
-        maven.resolve(groupId, artifactId, version, "pom" /* type */, null /* classifier */, repositories, monitor);
+        maven.resolve(groupId, artifactId, version, "pom" /* type */, null /* classifier */, repositories, monitor); //$NON-NLS-1$
 
     ResolverConfiguration resolverConfig = new ResolverConfiguration();
     resolverConfig.setLifecycleMappingId(LIFECYCLE_MAPPING_ID);
 
-    String projectName = groupId + "_" + artifactId + "_" + version;
+    String projectName = groupId + "_" + artifactId + "_" + version; //$NON-NLS-1$ //$NON-NLS-2$
 
     IPath stateLocation = Platform.getStateLocation(bundle);
 
     IPath projectLocation = stateLocation.append(projectName);
     projectLocation.toFile().mkdirs();
 
-    File pomFile = new File(projectLocation.toFile(), "pom.xml");
+    File pomFile = new File(projectLocation.toFile(), "pom.xml"); //$NON-NLS-1$
 
     try {
       FileUtils.copyFile(pomArtifact.getFile(), pomFile);
     } catch (IOException e) {
-      throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, "Could not create binary project", e));
+      throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, "Could not create binary project", e)); //$NON-NLS-1$
     }
 
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
@@ -120,7 +120,7 @@ public class BinaryProjectPlugin implements BundleActivator {
     try {
       projectNode.flush();
     } catch (BackingStoreException e) {
-      throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, "Could not create binary project", e));
+      throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, "Could not create binary project", e)); //$NON-NLS-1$
     }
 
     IProjectConfigurationManager configManager = MavenPlugin.getProjectConfigurationManager();

--- a/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/ClasspathConfigurator.java
+++ b/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/ClasspathConfigurator.java
@@ -62,7 +62,7 @@ public class ClasspathConfigurator extends AbstractJavaProjectConfigurator {
     String groupId = projectNode.get(BinaryProjectPlugin.P_GROUPID, (String) null);
     String artifactId = projectNode.get(BinaryProjectPlugin.P_ARTIFACTID, (String) null);
     String version = projectNode.get(BinaryProjectPlugin.P_VERSION, (String) null);
-    String type = projectNode.get(BinaryProjectPlugin.P_TYPE, "jar");
+    String type = projectNode.get(BinaryProjectPlugin.P_TYPE, "jar"); //$NON-NLS-1$
     String classifier = projectNode.get(BinaryProjectPlugin.P_CLASSIFIER, (String) null);
 
     List<ArtifactRepository> repositories = null; // TODO store in project preferences

--- a/org.eclipse.m2e.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)"
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core.tests
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.16.2.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core.tests/pom.xml
+++ b/org.eclipse.m2e.core.tests/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.core.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.16.2-SNAPSHOT</version>
 
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/MavenBugsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/MavenBugsTest.java
@@ -46,31 +46,31 @@ public class MavenBugsTest extends AbstractMavenProjectTestCase {
   @Test
   public void testMNG6530() throws Exception {
     File sourceDirectory = new File(
-        FileLocator.toFileURL(getClass().getResource("/resources/projects/testMNG6530")).toURI());
+        FileLocator.toFileURL(getClass().getResource("/resources/projects/testMNG6530")).toURI()); //$NON-NLS-1$
     File tempDirectory = Files.createTempDirectory(getClass().getSimpleName()).toFile();
     try {
       FileUtils.copyDirectoryStructure(sourceDirectory, tempDirectory);
       List<MavenProjectInfo> toImport = new ArrayList<>(2);
-      toImport.add(new MavenProjectInfo("", new File(tempDirectory, "pom.xml"), null, null));
-      toImport.add(new MavenProjectInfo("", new File(tempDirectory, "child/pom.xml"), null, null));
+      toImport.add(new MavenProjectInfo("", new File(tempDirectory, "pom.xml"), null, null)); //$NON-NLS-1$ //$NON-NLS-2$
+      toImport.add(new MavenProjectInfo("", new File(tempDirectory, "child/pom.xml"), null, null)); //$NON-NLS-1$ //$NON-NLS-2$
       MavenPlugin.getProjectConfigurationManager().importProjects(toImport, new ProjectImportConfiguration(), null,
           new NullProgressMonitor());
 
-      IProject parent = ResourcesPlugin.getWorkspace().getRoot().getProject("testMNG6530");
-      IProject child = ResourcesPlugin.getWorkspace().getRoot().getProject("child");
+      IProject parent = ResourcesPlugin.getWorkspace().getRoot().getProject("testMNG6530"); //$NON-NLS-1$
+      IProject child = ResourcesPlugin.getWorkspace().getRoot().getProject("child"); //$NON-NLS-1$
       try {
         IMavenProjectFacade childFacade = MavenPlugin.getMavenProjectRegistry().getProject(child);
         MavenProject mavenProject = childFacade.getMavenProject(new NullProgressMonitor());
-        assertEquals("bar", mavenProject.getProperties().get("foo"));
+        assertEquals("bar", mavenProject.getProperties().get("foo")); //$NON-NLS-1$ //$NON-NLS-2$
         
-		IFile pomXml = parent.getFile("pom.xml");
-		String content = Files.readString(Path.of(pomXml.getLocationURI())).replace("bar", "lol");
+		IFile pomXml = parent.getFile("pom.xml"); //$NON-NLS-1$
+		String content = Files.readString(Path.of(pomXml.getLocationURI())).replace("bar", "lol"); //$NON-NLS-1$ //$NON-NLS-2$
 		pomXml.setContents(new ByteArrayInputStream(content.getBytes()), true, false, null);
 		
         MavenPlugin.getProjectConfigurationManager().updateProjectConfiguration(child, monitor);
         waitForJobsToComplete();
         mavenProject = childFacade.getMavenProject(monitor);
-        assertEquals("lol", mavenProject.getProperties().get("foo"));
+        assertEquals("lol", mavenProject.getProperties().get("foo")); //$NON-NLS-1$ //$NON-NLS-2$
       } finally {
         parent.delete(true, null);
         child.delete(true, null);

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/MemoryConsumptionTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/MemoryConsumptionTest.java
@@ -62,17 +62,17 @@ public class MemoryConsumptionTest extends AbstractMavenProjectTestCase {
     int nbProjects = 50;
     Set<File> poms = buildLinearHierarchy(nbProjects, tempDirectory);
     try {
-      List<MavenProjectInfo> toImport = poms.stream().map(pom -> new MavenProjectInfo("", pom, null, null))
+      List<MavenProjectInfo> toImport = poms.stream().map(pom -> new MavenProjectInfo("", pom, null, null)) //$NON-NLS-1$
           .collect(Collectors.toList());
       MavenPlugin.getProjectConfigurationManager().importProjects(toImport, new ProjectImportConfiguration(), null,
           new NullProgressMonitor());
       waitForJobsToComplete(monitor);
       for(IProject p : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
         if(p.hasNature(IMavenConstants.NATURE_ID)) {
-          poms.remove(p.getFile("pom.xml").getLocation().toFile());
+          poms.remove(p.getFile("pom.xml").getLocation().toFile()); //$NON-NLS-1$
         }
       }
-      Assert.assertEquals("Some poms were not imported as project", Collections.emptySet(), poms);
+      Assert.assertEquals("Some poms were not imported as project", Collections.emptySet(), poms); //$NON-NLS-1$
       Assert.assertEquals(nbProjects, maxMavenProjectInstancesInContext[0]);
     } finally {
       MavenPluginActivator.getDefault().getMavenProjectManagerImpl().addContextProjectListener = null;
@@ -83,26 +83,26 @@ public class MemoryConsumptionTest extends AbstractMavenProjectTestCase {
   private Set<File> buildLinearHierarchy(int depth, File tempDirectory) throws FileNotFoundException {
     Set<File> poms = new HashSet<>(depth, 1.f);
     for(int i = 0; i < depth; i++ ) {
-      File projectDir = new File(tempDirectory, "p" + i);
+      File projectDir = new File(tempDirectory, "p" + i); //$NON-NLS-1$
       projectDir.mkdirs();
-      File pom = new File(projectDir, "pom.xml");
+      File pom = new File(projectDir, "pom.xml"); //$NON-NLS-1$
       poms.add(pom);
       try (PrintStream content = new PrintStream(pom);) {
-        content.println("<project>");
-        content.println("  <modelVersion>4.0.0</modelVersion>");
-        content.println("  <groupId>org.eclipse.m2e.core.tests.hierarchy</groupId>");
-        content.println("  <artifactId>pNUMBER</artifactId>".replace("NUMBER", Integer.toString(i)));
-        content.println("  <version>1</version>");
-        content.println("  <packaging>pom</packaging>");
+        content.println("<project>"); //$NON-NLS-1$
+        content.println("  <modelVersion>4.0.0</modelVersion>"); //$NON-NLS-1$
+        content.println("  <groupId>org.eclipse.m2e.core.tests.hierarchy</groupId>"); //$NON-NLS-1$
+        content.println("  <artifactId>pNUMBER</artifactId>".replace("NUMBER", Integer.toString(i))); //$NON-NLS-1$ //$NON-NLS-2$
+        content.println("  <version>1</version>"); //$NON-NLS-1$
+        content.println("  <packaging>pom</packaging>"); //$NON-NLS-1$
         if(i > 1) {
-          content.println("  <parent>");
-          content.println("    <groupId>org.eclipse.m2e.core.tests.hierarchy</groupId>");
-          content.println("    <artifactId>pNUMBER</artifactId>".replace("NUMBER", Integer.toString(i - 1)));
-          content.println("    <version>1</version>");
-          content.println("    <relativePath>../pNUMBER</relativePath>".replace("NUMBER", Integer.toString(i - 1)));
-          content.println("  </parent>");
+          content.println("  <parent>"); //$NON-NLS-1$
+          content.println("    <groupId>org.eclipse.m2e.core.tests.hierarchy</groupId>"); //$NON-NLS-1$
+          content.println("    <artifactId>pNUMBER</artifactId>".replace("NUMBER", Integer.toString(i - 1))); //$NON-NLS-1$ //$NON-NLS-2$
+          content.println("    <version>1</version>"); //$NON-NLS-1$
+          content.println("    <relativePath>../pNUMBER</relativePath>".replace("NUMBER", Integer.toString(i - 1))); //$NON-NLS-1$ //$NON-NLS-2$
+          content.println("  </parent>"); //$NON-NLS-1$
         }
-        content.println("</project>");
+        content.println("</project>"); //$NON-NLS-1$
       }
     }
     return poms;

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/RegistryTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/RegistryTest.java
@@ -45,7 +45,7 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
 
   @Test
   public void testDeletedFacadeIsRemoved() throws IOException, CoreException, InterruptedException {
-    IProject project = createExisting(getClass().getSimpleName(), "resources/projects/simplePomOK", true);
+    IProject project = createExisting(getClass().getSimpleName(), "resources/projects/simplePomOK", true); //$NON-NLS-1$
     waitForJobsToComplete(monitor);
     IMavenProjectFacade facade = MavenPluginActivator.getDefault().getMavenProjectManagerImpl().create(project,
         monitor);
@@ -53,7 +53,7 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
     project.delete(true, monitor);
     waitForJobsToComplete(new NullProgressMonitor());
     Assert.assertTrue(facade.isStale());
-    project = createExisting(getClass().getSimpleName(), "resources/projects/emptyPom", true);
+    project = createExisting(getClass().getSimpleName(), "resources/projects/emptyPom", true); //$NON-NLS-1$
     waitForJobsToComplete(monitor);
     facade = MavenPluginActivator.getDefault().getMavenProjectManagerImpl().create(project, monitor);
     Assert.assertNull(facade);
@@ -61,24 +61,24 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
 
   @Test
   public void testMissingParentCapabilityStored() throws IOException, CoreException, InterruptedException {
-    IProject project = createExisting(getClass().getSimpleName(), "resources/projects/missingParent", true);
+    IProject project = createExisting(getClass().getSimpleName(), "resources/projects/missingParent", true); //$NON-NLS-1$
     waitForJobsToComplete(monitor);
     MutableProjectRegistry registry = MavenPluginActivator.getDefault().getMavenProjectManagerImpl()
         .newMutableProjectRegistry();
     MavenCapability parentCapability = MavenCapability
-        .createMavenParent(new ArtifactKey("missingGroup", "missingArtifactId", "1", null));
-    assertEquals(Collections.singleton(project.getFile("pom.xml")), registry.getDependents(parentCapability, false));
+        .createMavenParent(new ArtifactKey("missingGroup", "missingArtifactId", "1", null)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    assertEquals(Collections.singleton(project.getFile("pom.xml")), registry.getDependents(parentCapability, false)); //$NON-NLS-1$
   }
 
   @Test
   public void testMultiRefreshKeepsCapabilities() throws IOException, CoreException, InterruptedException {
-    IProject dependentProject = createExisting("dependent", "resources/projects/dependency/dependent", true);
-    IProject dependencyProject = createExisting("dependency", "resources/projects/dependency/dependency", true);
+    IProject dependentProject = createExisting("dependent", "resources/projects/dependency/dependent", true); //$NON-NLS-1$ //$NON-NLS-2$
+    IProject dependencyProject = createExisting("dependency", "resources/projects/dependency/dependency", true); //$NON-NLS-1$ //$NON-NLS-2$
     waitForJobsToComplete(monitor);
     ProjectRegistryManager registryManager = MavenPluginActivator.getDefault().getMavenProjectManagerImpl();
     Collection<IFile> pomFiles = new ArrayList<>(2);
-    pomFiles.add(dependentProject.getFile("pom.xml"));
-    pomFiles.add(dependencyProject.getFile("pom.xml"));
+    pomFiles.add(dependentProject.getFile("pom.xml")); //$NON-NLS-1$
+    pomFiles.add(dependencyProject.getFile("pom.xml")); //$NON-NLS-1$
     MutableProjectRegistry state = MavenPluginActivator.getDefault().getMavenProjectManagerImpl().newMutableProjectRegistry();
     state.clear();
     registryManager.getMaven().execute(false, false, (context, aMonitor) -> {
@@ -91,7 +91,7 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
   @Ignore(value = "This test doesn't manage to reproduce Bug 547172 while similar manual steps do lead to an error")
   @Test
   public void testInvalidParent() throws IOException, CoreException, InterruptedException {
-    IProject childProject = importProject("invalidParent", "resources/projects/invalidParent/child/", new ProjectImportConfiguration());
+    IProject childProject = importProject("invalidParent", "resources/projects/invalidParent/child/", new ProjectImportConfiguration()); //$NON-NLS-1$ //$NON-NLS-2$
     waitForJobsToComplete(monitor);
     Optional<IMarker> maybeErrorMarker = Arrays.stream(childProject.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE))
       .filter(marker -> marker.getAttribute(IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR)
@@ -107,14 +107,14 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
     boolean autoBuilding = isAutoBuilding();
     setAutoBuilding(false);
     try {
-        IProject parent = createExisting("parent", "resources/projects/bug548652/", false);
-        IProjectDescription childProjectDescription = parent.getWorkspace().loadProjectDescription(parent.getFolder("child").getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocation());
+        IProject parent = createExisting("parent", "resources/projects/bug548652/", false); //$NON-NLS-1$ //$NON-NLS-2$
+        IProjectDescription childProjectDescription = parent.getWorkspace().loadProjectDescription(parent.getFolder("child").getFile(IProjectDescription.DESCRIPTION_FILE_NAME).getLocation()); //$NON-NLS-1$
         IProject child = parent.getWorkspace().getRoot().getProject(childProjectDescription.getName());
         child.create(childProjectDescription, new NullProgressMonitor());
         child.open(new NullProgressMonitor());
         MavenUpdateRequest request = new MavenUpdateRequest(false, false);
-        request.addPomFile(parent.getFile("pom.xml"));
-        IFile childPom = child.getFile("pom.xml");
+        request.addPomFile(parent.getFile("pom.xml")); //$NON-NLS-1$
+        IFile childPom = child.getFile("pom.xml"); //$NON-NLS-1$
         request.addPomFile(childPom);
         MavenPluginActivator.getDefault().getProjectManagerRefreshJob().refresh(request);
         waitForJobsToComplete();

--- a/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
+++ b/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
@@ -40,11 +40,11 @@ public class ConsoleTest extends AbstractMavenProjectTestCase {
   @Test
   public void testConsoleHasOutput() throws Exception {
 	  var launchManager = DebugPlugin.getDefault().getLaunchManager();
-	  var configName = launchManager.generateLaunchConfigurationName("testConsole");
+	  var configName = launchManager.generateLaunchConfigurationName("testConsole"); //$NON-NLS-1$
 	  var wc = launchManager.getLaunchConfigurationType(MavenLaunchConstants.LAUNCH_CONFIGURATION_TYPE_ID).newInstance(null, configName);
-	  var pomFile = new File(FileLocator.toFileURL(getClass().getResource("/resources/projects/simplePomOK/pom.xml")).getPath());
+	  var pomFile = new File(FileLocator.toFileURL(getClass().getResource("/resources/projects/simplePomOK/pom.xml")).getPath()); //$NON-NLS-1$
 	  wc.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, pomFile.getParent());
-	  wc.setAttribute(MavenLaunchConstants.ATTR_GOALS, "verify");
+	  wc.setAttribute(MavenLaunchConstants.ATTR_GOALS, "verify"); //$NON-NLS-1$
 	  wc.setAttribute(MavenLaunchConstants.ATTR_POM_DIR, pomFile.getParent());
 	  var consoleManager = ConsolePlugin.getDefault().getConsoleManager();
 	  var consolesBefore = Arrays.stream(consoleManager.getConsoles()).collect(Collectors.toSet());
@@ -55,9 +55,9 @@ public class ConsoleTest extends AbstractMavenProjectTestCase {
 	  Set<IConsole> consolesAfter = new HashSet<>();
 	  consolesAfter.addAll(List.of(consoleManager.getConsoles()));
 	  consolesAfter.removeAll(consolesBefore);
-	  assertEquals("console not found", 1, consolesAfter.size());
+	  assertEquals("console not found", 1, consolesAfter.size()); //$NON-NLS-1$
 	  var mavenConsole = consolesAfter.iterator().next();
-	  assertTrue("missing output in console", ((TextConsole)mavenConsole).getDocument().get().contains("BUILD SUCCESS"));
+	  assertTrue("missing output in console", ((TextConsole)mavenConsole).getDocument().get().contains("BUILD SUCCESS")); //$NON-NLS-1$ //$NON-NLS-2$
   }
 
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/M2EUIPluginActivator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/M2EUIPluginActivator.java
@@ -73,7 +73,7 @@ public class M2EUIPluginActivator extends AbstractUIPlugin {
 
   private MavenUpdateConfigurationChangeListener mavenUpdateConfigurationChangeListener;
 
-  public static final String PROP_SHOW_EXPERIMENTAL_FEATURES = "m2e.showExperimentalFeatures";
+  public static final String PROP_SHOW_EXPERIMENTAL_FEATURES = "m2e.showExperimentalFeatures"; //$NON-NLS-1$
 
   @Override
   public void start(BundleContext context) throws Exception {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/WorkingSets.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/WorkingSets.java
@@ -63,7 +63,7 @@ public class WorkingSets {
     if(workingSet == null) {
       workingSet = wsm.createWorkingSet(workingSetName, new IAdaptable[0]);
       // TODO is there a constant we should be setting here?
-      workingSet.setId("org.eclipse.ui.resourceWorkingSetPage");
+      workingSet.setId("org.eclipse.ui.resourceWorkingSetPage"); //$NON-NLS-1$
       wsm.addWorkingSet(workingSet);
     }
     return workingSet;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
@@ -88,13 +88,13 @@ public class MavenPropertyTester extends PropertyTester {
     if(IS_TRANSITIVE_DEPENDENCY_TREE_NODE.equals(property)) {
       if(receiver instanceof DependencyNode) {
         DependencyNode nd = (DependencyNode) receiver;
-        return nd.getData().get("LEVEL") == null;
+        return nd.getData().get("LEVEL") == null; //$NON-NLS-1$
       }
     }
     if(IS_DIRECT_DEPENDENCY_TREE_NODE.equals(property)) {
       if(receiver instanceof DependencyNode) {
         DependencyNode nd = (DependencyNode) receiver;
-        return "DIRECT".equals(nd.getData().get("LEVEL"));
+        return "DIRECT".equals(nd.getData().get("LEVEL")); //$NON-NLS-1$ //$NON-NLS-2$
       }
     }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
@@ -118,7 +118,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       StringBuilder buffer = new StringBuilder();
       Model model = project.getProject().getModel();
       buffer.append(model.getGroupId()).append(" : ") //$NON-NLS-1$
-          .append(model.getArtifactId()).append(" : ") //$NON-NLS-2$
+          .append(model.getArtifactId()).append(" : ") //$NON-NLS-1$
           .append(model.getVersion());
       return buffer.toString();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
@@ -256,7 +256,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
     if(showConsoleOnOutput()) {
       bringConsoleToFront();
     }
-    appendLine(ConsoleDocument.MESSAGE, getDateFormat().format(new Date()) + ": " + message);
+    appendLine(ConsoleDocument.MESSAGE, getDateFormat().format(new Date()) + ": " + message); //$NON-NLS-1$
 
     for(IMavenConsoleListener listener : listeners) {
       try {
@@ -271,7 +271,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
     if(showConsoleOnOutput()) {
       bringConsoleToFront();
     }
-    appendLine(ConsoleDocument.MESSAGE, getDateFormat().format(new Date()) + ": " + message);
+    appendLine(ConsoleDocument.MESSAGE, getDateFormat().format(new Date()) + ": " + message); //$NON-NLS-1$
 
     for(IMavenConsoleListener listener : listeners) {
       try {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/InputHistory.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/InputHistory.java
@@ -117,7 +117,7 @@ public class InputHistory {
   public void add(String id, final Control combo) {
     if(combo != null) {
       if(id == null) {
-        id = String.valueOf(combo.getData("name"));
+        id = String.valueOf(combo.getData("name")); //$NON-NLS-1$
       }
       List<ControlWrapper> combos = comboMap.get(id);
       if(combos == null) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
@@ -119,7 +119,7 @@ public class ChangeCreator {
       try {
         return getHash(thisIndex).equals(((LineComparator) other).getHash(otherIndex));
       } catch(BadLocationException e) {
-        log.error("Problem comparing", e);
+        log.error("Problem comparing", e); //$NON-NLS-1$
         return false;
       }
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
@@ -285,7 +285,7 @@ public class PomEdits {
     Element toFormat = null;
     Element toRet = null;
     if(names.length == 0) {
-      throw new IllegalArgumentException("At least one child name has to be specified");
+      throw new IllegalArgumentException("At least one child name has to be specified"); //$NON-NLS-1$
     }
     for(String name : names) {
       toRet = findChild(parent, name);
@@ -502,7 +502,7 @@ public class PomEdits {
             doc.appendChild(project);
 
             Element modelVersion = doc.createElement(MODEL_VERSION);
-            modelVersion.appendChild(doc.createTextNode(MODEL_VERSION_VALUE)); //$NON-NLS-1$
+            modelVersion.appendChild(doc.createTextNode(MODEL_VERSION_VALUE));
             project.appendChild(modelVersion);
             format(project);
           }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/AggregateMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/AggregateMappingLabelProvider.java
@@ -51,16 +51,16 @@ public class AggregateMappingLabelProvider implements ILifecycleMappingLabelProv
 
   public String getMavenText() {
     if(element instanceof LifecycleStrategyMappingRequirement) {
-      return NLS.bind("Connector {0}", ((LifecycleStrategyMappingRequirement) element).getLifecycleMappingId());
+      return NLS.bind("Connector {0}", ((LifecycleStrategyMappingRequirement) element).getLifecycleMappingId()); //$NON-NLS-1$
     } else if(element instanceof MojoExecutionMappingRequirement) {
       MojoExecutionKey exec = ((MojoExecutionMappingRequirement) element).getExecution();
-      return NLS.bind("{0}:{1}:{2}",
+      return NLS.bind("{0}:{1}:{2}", //$NON-NLS-1$
           new String[] {exec.getArtifactId(), exec.getVersion(), exec.getGoal(), String.valueOf(content.size())});
     } else if(element instanceof PackagingTypeMappingRequirement) {
-      return NLS.bind("Packaging {0}", ((PackagingTypeMappingRequirement) element).getPackaging());
+      return NLS.bind("Packaging {0}", ((PackagingTypeMappingRequirement) element).getPackaging()); //$NON-NLS-1$
     } else if(element instanceof ProjectConfiguratorMappingRequirement) {
       MojoExecutionKey exec = ((ProjectConfiguratorMappingRequirement) element).getExecution();
-      return NLS.bind("{0}:{1}:{2}",
+      return NLS.bind("{0}:{1}:{2}", //$NON-NLS-1$
           new String[] {exec.getArtifactId(), exec.getVersion(), exec.getGoal(), String.valueOf(content.size())});
     }
     throw new IllegalStateException();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/MojoExecutionMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/MojoExecutionMappingLabelProvider.java
@@ -48,11 +48,11 @@ public class MojoExecutionMappingLabelProvider implements ILifecycleMappingLabel
 
   public String getMavenText() {
     MojoExecutionKey execution = element.getExecution();
-    if("default".equals(execution.getExecutionId())) {
-      return NLS.bind("{0}", prjconf.getRelpath());
+    if("default".equals(execution.getExecutionId())) { //$NON-NLS-1$
+      return NLS.bind("{0}", prjconf.getRelpath()); //$NON-NLS-1$
     }
     //TODO is execution id actually important or just takes up space
-    return NLS.bind("Execution {0}, in {1}", execution.getExecutionId(), prjconf.getRelpath());
+    return NLS.bind("Execution {0}, in {1}", execution.getExecutionId(), prjconf.getRelpath()); //$NON-NLS-1$
   }
 
   /* (non-Javadoc)

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -109,7 +109,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
       IFile resource = (IFile) marker.getResource();
       domModel = (IDOMModel) StructuredModelManager.getModelManager().getModelForRead(resource);
       if(domModel == null) {
-        throw new IllegalArgumentException("Document is not structured: " + resource);
+        throw new IllegalArgumentException("Document is not structured: " + resource); //$NON-NLS-1$
       }
       IStructuredDocument document = domModel.getStructuredDocument();
       int charStart = document.getLineOffset(lineNumber - 1) + columnStart - 1;
@@ -138,10 +138,10 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
     if(IMavenConstants.EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION.equals(hint)) {
       try {
         final boolean lookInPM = false;
-        final String groupId = marker.getAttribute(IMavenConstants.MARKER_ATTR_GROUP_ID, "");
-        final String artifactId = marker.getAttribute(IMavenConstants.MARKER_ATTR_ARTIFACT_ID, "");
-        final String exec = marker.getAttribute(IMavenConstants.MARKER_ATTR_EXECUTION_ID, "");
-        final String goal = marker.getAttribute(IMavenConstants.MARKER_ATTR_GOAL, "");
+        final String groupId = marker.getAttribute(IMavenConstants.MARKER_ATTR_GROUP_ID, ""); //$NON-NLS-1$
+        final String artifactId = marker.getAttribute(IMavenConstants.MARKER_ATTR_ARTIFACT_ID, ""); //$NON-NLS-1$
+        final String exec = marker.getAttribute(IMavenConstants.MARKER_ATTR_EXECUTION_ID, ""); //$NON-NLS-1$
+        final String goal = marker.getAttribute(IMavenConstants.MARKER_ATTR_GOAL, ""); //$NON-NLS-1$
         XmlUtils.performOnRootElement((IFile) marker.getResource(), new NodeOperation<Element>() {
           public void process(Element root, IStructuredDocument structuredDocument) {
             Element build = findChild(root, PomEdits.BUILD);
@@ -174,7 +174,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
             }
             Element ourMarkerPlacement = null;
             for(Element candid : candidates) {
-              Matcher match = "default".equals(exec) ? childMissingOrEqual(PomEdits.ID, "default")
+              Matcher match = "default".equals(exec) ? childMissingOrEqual(PomEdits.ID, "default") //$NON-NLS-1$ //$NON-NLS-2$
                   : childEquals(PomEdits.ID, exec);
               Element execution = findChild(findChild(candid, PomEdits.EXECUTIONS), PomEdits.EXECUTION, match);
               if(execution != null) {
@@ -209,7 +209,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
           }
 
           private Element findPlugin(Element build, String groupId, String artifactId) {
-            Matcher grIdmatch = "org.apache.maven.plugins".equals(groupId)
+            Matcher grIdmatch = "org.apache.maven.plugins".equals(groupId) //$NON-NLS-1$
                 ? childMissingOrEqual(PomEdits.GROUP_ID, groupId)
                 : childEquals(PomEdits.GROUP_ID, groupId);
             return findChild(findChild(build, PomEdits.PLUGINS), PomEdits.PLUGIN, grIdmatch,
@@ -217,9 +217,9 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
           }
         });
       } catch(IOException e) {
-        log.error("Error locating marker", e);
+        log.error("Error locating marker", e); //$NON-NLS-1$
       } catch(CoreException e) {
-        log.error("Error locating marker", e);
+        log.error("Error locating marker", e); //$NON-NLS-1$
       }
     }
   }
@@ -411,18 +411,18 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
 
   private static void setManagedVersionAttributes(IMarker mark, MavenProject mavenproject,
       InputLocationTracker dependencyOrPlugin) throws CoreException {
-    InputLocation loc = dependencyOrPlugin == null ? null : dependencyOrPlugin.getLocation("version");
+    InputLocation loc = dependencyOrPlugin == null ? null : dependencyOrPlugin.getLocation("version"); //$NON-NLS-1$
     File file = loc == null ? null : XmlUtils.fileForInputLocation(loc, mavenproject);
 
     if(file != null) {
       mark.setAttribute(ATTR_MANAGED_VERSION_LOCATION, file.toURI().toString());
       int lineNumber = loc != null ? loc.getLineNumber() : -1;
       if(lineNumber > 0) {
-        mark.setAttribute("managedVersionLine", lineNumber);
+        mark.setAttribute("managedVersionLine", lineNumber); //$NON-NLS-1$
       }
       int columnNumber = loc != null ? loc.getColumnNumber() : -1;
       if(columnNumber > 0) {
-        mark.setAttribute("managedVersionColumn", columnNumber);
+        mark.setAttribute("managedVersionColumn", columnNumber); //$NON-NLS-1$
       }
     }
   }
@@ -493,11 +493,11 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
       List<Plugin> plgs = pm.getPlugins();
       if(plgs != null) {
         for(Plugin plg : plgs) {
-          InputLocation loc = plg.getLocation("version");
+          InputLocation loc = plg.getLocation("version"); //$NON-NLS-1$
           //#350203 skip plugins defined in the superpom
           String modelID = loc == null ? null : (loc.getSource() == null ? null : loc.getSource().getModelId());
           if(loc != null && (modelID == null
-              || !(modelID.startsWith("org.apache.maven:maven-model-builder:") && modelID.endsWith(":super-pom")))) {
+              || !(modelID.startsWith("org.apache.maven:maven-model-builder:") && modelID.endsWith(":super-pom")))) { //$NON-NLS-1$ //$NON-NLS-2$
             managed.put(plg.getKey(), plg);
           }
         }
@@ -506,12 +506,12 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
 
     //now we have all the candidates, match them against the effective managed set
     for(Element dep : candidates) {
-      String grpString = getTextValue(findChild(dep, PomEdits.GROUP_ID)); //$NON-NLS-1$
+      String grpString = getTextValue(findChild(dep, PomEdits.GROUP_ID));
       if(grpString == null) {
         grpString = "org.apache.maven.plugins"; //$NON-NLS-1$
       }
-      String artString = getTextValue(findChild(dep, PomEdits.ARTIFACT_ID)); //$NON-NLS-1$
-      Element version = findChild(dep, PomEdits.VERSION); //$NON-NLS-1$
+      String artString = getTextValue(findChild(dep, PomEdits.ARTIFACT_ID));
+      Element version = findChild(dep, PomEdits.VERSION);
       String versionString = getTextValue(version);
       if(artString != null && versionString != null) {
         String id = Plugin.constructKey(grpString, artString);
@@ -571,11 +571,11 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
         }
       }
     }
-    Element version = findChild(root, PomEdits.VERSION); //$NON-NLS-1$
+    Element version = findChild(root, PomEdits.VERSION);
     ProblemSeverity matchingParentVersionSeverity = getMatchingParentVersionSeverity();
     if(parent != null && version != null && !ProblemSeverity.ignore.equals(matchingParentVersionSeverity)) {
       //now compare the values of parent and project version..
-      String parentString = getTextValue(findChild(parent, PomEdits.VERSION)); //$NON-NLS-1$
+      String parentString = getTextValue(findChild(parent, PomEdits.VERSION));
       String childString = getTextValue(version);
       if(parentString != null && parentString.equals(childString)) {
         //now figure out the offset

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenSettingsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenSettingsPreferencePage.java
@@ -181,8 +181,8 @@ public class MavenSettingsPreferencePage extends PreferencePage implements IWork
 
   @Override
   protected void performDefaults() {
-    globalSettingsText.setText("");
-    userSettingsText.setText("");
+    globalSettingsText.setText(""); //$NON-NLS-1$
+    userSettingsText.setText(""); //$NON-NLS-1$
     checkSettings();
     updateLocalRepository();
     super.performDefaults();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenUpdateConfigurationChangeListener.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenUpdateConfigurationChangeListener.java
@@ -50,7 +50,7 @@ public class MavenUpdateConfigurationChangeListener implements IResourceChangeLi
       event.getDelta().accept(visitor);
       outOfDateProjects = visitor.outOfDateProjects;
     } catch(CoreException e) {
-      LOG.error("An error occurred while checking for out-of-date configuration markers", e);
+      LOG.error("An error occurred while checking for out-of-date configuration markers", e); //$NON-NLS-1$
       return;
     }
     updateProjectConfiguration(outOfDateProjects);
@@ -62,7 +62,7 @@ public class MavenUpdateConfigurationChangeListener implements IResourceChangeLi
 
   protected void updateProjectConfiguration(List<IProject> outOfDateProjects) {
     if(outOfDateProjects != null && !outOfDateProjects.isEmpty()) {
-      LOG.debug("Automatic update of {}", outOfDateProjects);
+      LOG.debug("Automatic update of {}", outOfDateProjects); //$NON-NLS-1$
       Job updateJob = new UpdateMavenProjectJob(outOfDateProjects.toArray(new IProject[outOfDateProjects.size()]));
       updateJob.schedule();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/IndexSearchEngine.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/search/util/IndexSearchEngine.java
@@ -64,8 +64,8 @@ public class IndexSearchEngine implements SearchEngine {
       // we are wiring in the defaults only, but user changes are lost!
       // org.apache.maven.plugins
       // org.codehaus.mojo
-      groupIdSearchExpressions.add(new MatchTypedStringSearchExpression("org.apache.maven.plugins", MatchType.EXACT));
-      groupIdSearchExpressions.add(new MatchTypedStringSearchExpression("org.codehaus.mojo", MatchType.EXACT));
+      groupIdSearchExpressions.add(new MatchTypedStringSearchExpression("org.apache.maven.plugins", MatchType.EXACT)); //$NON-NLS-1$
+      groupIdSearchExpressions.add(new MatchTypedStringSearchExpression("org.codehaus.mojo", MatchType.EXACT)); //$NON-NLS-1$
     } else {
       groupIdSearchExpressions.add(new MatchTypedStringSearchExpression(groupId, MatchType.EXACT));
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/ProposalUtil.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/ProposalUtil.java
@@ -129,7 +129,7 @@ public class ProposalUtil {
         return getSearchEngine(project).findClassifiers(
             escapeQuerySpecialCharacters(groupIdText.getText()), //
             escapeQuerySpecialCharacters(artifactIdText.getText()),
-            escapeQuerySpecialCharacters(versionText.getText()), "", packaging);
+            escapeQuerySpecialCharacters(versionText.getText()), "", packaging); //$NON-NLS-1$
       }
     });
   }
@@ -140,7 +140,7 @@ public class ProposalUtil {
       public Collection<String> search() throws CoreException {
         Collection<String> toRet = new ArrayList<>();
         toRet.addAll(getSearchEngine(project).findVersions(escapeQuerySpecialCharacters(groupIdText.getText()), //
-            escapeQuerySpecialCharacters(artifactIdText.getText()), "", packaging));
+            escapeQuerySpecialCharacters(artifactIdText.getText()), "", packaging)); //$NON-NLS-1$
         if(mp != null) {
           //add version props now..
           Properties props = mp.getProperties();
@@ -166,7 +166,7 @@ public class ProposalUtil {
     addCompletionProposal(artifactIdText, new Searcher() {
       public Collection<String> search() throws CoreException {
         // TODO handle artifact info
-        return getSearchEngine(project).findArtifactIds(escapeQuerySpecialCharacters(groupIdText.getText()), "",
+        return getSearchEngine(project).findArtifactIds(escapeQuerySpecialCharacters(groupIdText.getText()), "", //$NON-NLS-1$
             packaging, null);
       }
     });

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/XmlUtils.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/XmlUtils.java
@@ -164,7 +164,7 @@ public class XmlUtils {
         if(origin.getModel().getId().equals(modelId) && origin.getFile() != null) {
           return origin.getFile();
         }
-        String[] splitStrings = modelId.split(":");
+        String[] splitStrings = modelId.split(":"); //$NON-NLS-1$
         assert splitStrings.length == 3;
         IMavenProjectFacade facade = MavenPlugin.getMavenProjectRegistry().getMavenProject(splitStrings[0],
             splitStrings[1], splitStrings[2]);
@@ -175,12 +175,12 @@ public class XmlUtils {
           IMaven maven = MavenPlugin.getMaven();
           try {
             String path = maven.getArtifactPath(maven.getLocalRepository(), splitStrings[0], splitStrings[1],
-                splitStrings[2], "pom", null);
+                splitStrings[2], "pom", null); //$NON-NLS-1$
             if(path != null) {
               file = new File(maven.getLocalRepositoryPath(), path);
             }
           } catch(CoreException e) {
-            log.error("Failed to calculate local repository path of artifact", e);
+            log.error("Failed to calculate local repository path of artifact", e); //$NON-NLS-1$
           }
         }
       }
@@ -234,7 +234,7 @@ public class XmlUtils {
     try {
       domModel = (IDOMModel) StructuredModelManager.getModelManager().getExistingModelForRead(doc);
       if(domModel == null) {
-        throw new IllegalArgumentException("Document is not structured: " + doc);
+        throw new IllegalArgumentException("Document is not structured: " + doc); //$NON-NLS-1$
       }
       IStructuredDocument document = domModel.getStructuredDocument();
       Element root = domModel.getDocument().getDocumentElement();
@@ -259,7 +259,7 @@ public class XmlUtils {
     try {
       domModel = (IDOMModel) StructuredModelManager.getModelManager().getModelForRead(resource);
       if(domModel == null) {
-        throw new IllegalArgumentException("Document is not structured: " + resource);
+        throw new IllegalArgumentException("Document is not structured: " + resource); //$NON-NLS-1$
       }
       IStructuredDocument document = domModel.getStructuredDocument();
       Element root = domModel.getDocument().getDocumentElement();
@@ -287,7 +287,7 @@ public class XmlUtils {
     while(node != null && current > 0) {
       if(node instanceof Element) {
         if(buf.length() > 0) {
-          buf.insert(0, "/");
+          buf.insert(0, "/"); //$NON-NLS-1$
         }
         buf.insert(0, node.getNodeName());
         current = current - 1;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenRepositoryView.java
@@ -86,12 +86,12 @@ public class MavenRepositoryView extends ViewPart {
   /**
    *
    */
-  private static final String MENU_OPEN_GRP = "open";
+  private static final String MENU_OPEN_GRP = "open"; //$NON-NLS-1$
 
   /**
    *
    */
-  private static final String MENU_UPDATE_GRP = "update";
+  private static final String MENU_UPDATE_GRP = "update"; //$NON-NLS-1$
 
   private static final Logger log = LoggerFactory.getLogger(MavenRepositoryView.class);
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/build/BuildDebugView.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/build/BuildDebugView.java
@@ -79,7 +79,7 @@ public class BuildDebugView extends ViewPart implements BuildDebugHook {
 
   /*package*/final Map<String, ProjectNode> projects = new ConcurrentHashMap<>();
 
-  /*package*/final Job refreshJob = new Job("") {
+  /*package*/final Job refreshJob = new Job("") { //$NON-NLS-1$
     protected IStatus run(IProgressMonitor monitor) {
       getSite().getShell().getDisplay().asyncExec(() -> viewer.refresh());
       return Status.OK_STATUS;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/RepositoryNode.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/nodes/RepositoryNode.java
@@ -37,10 +37,10 @@ public class RepositoryNode extends AbstractIndexedRepositoryNode {
     sb.append(repository.getId());
     sb.append(" (").append(repository.getUrl()).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
     if(repository.getMirrorOf() != null) {
-      sb.append(" [mirrorOf=").append(repository.getMirrorOf()).append("]"); //$NON-NLS-2$
+      sb.append(" [mirrorOf=").append(repository.getMirrorOf()).append("]");  //$NON-NLS-1$//$NON-NLS-2$
     }
     if(repository.getMirrorId() != null) {
-      sb.append(" [mirrored by ").append(repository.getMirrorId()).append("]"); //$NON-NLS-2$
+      sb.append(" [mirrored by ").append(repository.getMirrorId()).append("]");  //$NON-NLS-1$//$NON-NLS-2$
     }
     if(isUpdating()) {
       sb.append(Messages.RepositoryNode_updating);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/AbstractMavenWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/AbstractMavenWizardPage.java
@@ -132,7 +132,7 @@ public abstract class AbstractMavenWizardPage extends WizardPage {
 
     // This is strictly to get SWT Designer working locally without blowing up.
     if(MavenPluginActivator.getDefault() == null) {
-      pluginSettings = new DialogSettings("Workbench");
+      pluginSettings = new DialogSettings("Workbench"); //$NON-NLS-1$
     } else {
       pluginSettings = M2EUIPluginActivator.getDefault().getDialogSettings();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
@@ -314,10 +314,10 @@ public class LifecycleMappingPage extends WizardPage {
                     }
 
                     if(executionId != null) {
-                      if("default".equals(executionId)) {
-                        return NLS.bind("{0}", relPath);
+                      if("default".equals(executionId)) { //$NON-NLS-1$
+                        return NLS.bind("{0}", relPath); //$NON-NLS-1$
                       }
-                      return NLS.bind("Execution {0}, in {1}", executionId, relPath);
+                      return NLS.bind("Execution {0}, in {1}", executionId, relPath); //$NON-NLS-1$
                     }
 
                     return null;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MappingDiscoveryJob.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MappingDiscoveryJob.java
@@ -41,7 +41,7 @@ public class MappingDiscoveryJob extends WorkspaceJob {
   private final Collection<IProject> projects;
 
   public MappingDiscoveryJob(Collection<IProject> projects) {
-    super("Discover lifecycle mappings");
+    super("Discover lifecycle mappings"); //$NON-NLS-1$
     this.projects = projects;
 
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
@@ -202,7 +202,7 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
         }
       };
 
-      Job job = new WorkspaceJob("Apply Lifecycle Mapping Changes") {
+      Job job = new WorkspaceJob("Apply Lifecycle Mapping Changes") { //$NON-NLS-1$
         @Override
         public IStatus runInWorkspace(IProgressMonitor monitor) {
           try {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenImportWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenImportWizard.java
@@ -97,7 +97,7 @@ public class MavenImportWizard extends AbstractMavenProjectWizard implements IIm
 
       // https://bugs.eclipse.org/bugs/show_bug.cgi?id=427205
       // ideally, this should be contributed by m2e jdt.ui, but this looks like overkill
-      String JDT_OTHER_PROJECTS = "org.eclipse.jdt.internal.ui.OthersWorkingSet";
+      String JDT_OTHER_PROJECTS = "org.eclipse.jdt.internal.ui.OthersWorkingSet"; //$NON-NLS-1$
       if(workingSet != null && !JDT_OTHER_PROJECTS.equals(workingSet.getId())) {
         page.setWorkingSetName(workingSet.getName());
       }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenInstallFileArtifactWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenInstallFileArtifactWizardPage.java
@@ -75,7 +75,7 @@ public class MavenInstallFileArtifactWizardPage extends WizardPage {
   private final IFile file;
 
   public MavenInstallFileArtifactWizardPage(IFile file) {
-    super("mavenInstallFileWizardPage");
+    super("mavenInstallFileWizardPage"); //$NON-NLS-1$
     this.file = file;
     this.setTitle(Messages.MavenInstallFileArtifactWizardPage_title);
     this.setDescription(Messages.MavenInstallFileArtifactWizardPage_desc);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenInstallFileWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenInstallFileWizard.java
@@ -120,7 +120,7 @@ public class MavenInstallFileWizard extends Wizard implements IImportWizard {
 
           // TODO update index for local maven repository
         } catch(CoreException ex) {
-          log.error("Failed to install artifact:" + ex.getMessage(), ex);
+          log.error("Failed to install artifact:" + ex.getMessage(), ex); //$NON-NLS-1$
         }
         return Status.OK_STATUS;
       }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizardParentPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizardParentPage.java
@@ -88,7 +88,7 @@ public class MavenModuleWizardParentPage extends AbstractMavenWizardPage {
   /** Creates a new page. */
   public MavenModuleWizardParentPage(ProjectImportConfiguration projectImportConfiguration,
       List<IWorkingSet> workingSets) {
-    super("MavenModuleWizardParentPage", projectImportConfiguration);
+    super("MavenModuleWizardParentPage", projectImportConfiguration); //$NON-NLS-1$
     this.workingSets = workingSets;
     setTitle(Messages.wizardModulePageParentTitle);
     setDescription(Messages.wizardModulePageParentDescription);
@@ -249,7 +249,7 @@ public class MavenModuleWizardParentPage extends AbstractMavenWizardPage {
   /** Skips the archetype selection page if the user chooses a simple project. */
   public IWizardPage getNextPage() {
     return getWizard()
-        .getPage(isSimpleProject() ? "MavenProjectWizardArtifactPage" : "MavenProjectWizardArchetypePage");
+        .getPage(isSimpleProject() ? "MavenProjectWizardArtifactPage" : "MavenProjectWizardArchetypePage"); //$NON-NLS-1$ //$NON-NLS-2$
   }
 
   /** Returns the module name. */

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenParentComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenParentComponent.java
@@ -120,7 +120,7 @@ public class MavenParentComponent extends Composite {
       parentClearButton = new Button(buttonPanel, SWT.NONE);
       parentClearButton.setText(Messages.wizardProjectPageArtifactParentClear);
       parentClearButton.setData("name", "parentClearButton"); //$NON-NLS-1$ //$NON-NLS-2$
-      parentClearButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> setValues("", "", "")));
+      parentClearButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> setValues("", "", ""))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizard.java
@@ -152,7 +152,7 @@ public class MavenPomWizard extends Wizard implements INewWizard {
       });
 
     } catch(Exception ex) {
-      log.error("Unable to create POM " + pom + "; " + ex.getMessage(), ex);
+      log.error("Unable to create POM " + pom + "; " + ex.getMessage(), ex); //$NON-NLS-1$ //$NON-NLS-2$
 
     }
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectSelectionDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectSelectionDialog.java
@@ -137,7 +137,7 @@ public class MavenProjectSelectionDialog extends AbstractMavenDialog {
               children.add(project);
             }
           } catch(CoreException e) {
-            log.error("Error checking project: " + e.getMessage(), e);
+            log.error("Error checking project: " + e.getMessage(), e); //$NON-NLS-1$
           }
         }
         return children.toArray();
@@ -155,7 +155,7 @@ public class MavenProjectSelectionDialog extends AbstractMavenDialog {
             }
             return children.toArray();
           } catch(CoreException e) {
-            log.error("Error checking container: " + e.getMessage(), e);
+            log.error("Error checking container: " + e.getMessage(), e); //$NON-NLS-1$
           }
         }
       }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypePage.java
@@ -869,7 +869,7 @@ public class MavenProjectWizardArchetypePage extends AbstractMavenWizardPage imp
           final String msg = NLS.bind(
               org.eclipse.m2e.core.ui.internal.Messages.MavenProjectWizardArchetypePage_error_resolve2, archetypeName);
           log.error(msg, ex2);
-          getShell().getDisplay().asyncExec(() -> setErrorMessage(msg + "\n" + ex2.toString()));
+          getShell().getDisplay().asyncExec(() -> setErrorMessage(msg + "\n" + ex2.toString())); //$NON-NLS-1$
 
         } finally {
           monitor.done();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ArtifactKey.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/ArtifactKey.java
@@ -124,7 +124,7 @@ public class ArtifactKey implements Serializable {
   private static int nextColonIndex(String str, int pos) {
     int idx = str.indexOf(':', pos);
     if(idx < 0)
-      throw new IllegalArgumentException(NLS.bind("Invalid portable string: {0}", str));
+      throw new IllegalArgumentException(NLS.bind("Invalid portable string: {0}", str)); //$NON-NLS-1$
     return idx;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Bundles.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Bundles.java
@@ -84,7 +84,7 @@ public class Bundles {
   }
 
   public static List<String> getClasspathEntries(Bundle bundle) {
-    log.debug("getClasspathEntries(Bundle={})", bundle.toString());
+    log.debug("getClasspathEntries(Bundle={})", bundle.toString()); //$NON-NLS-1$
     Set<String> cp = new LinkedHashSet<>();
     if(DevClassPathHelper.inDevelopmentMode()) {
       cp.addAll(Arrays.asList(DevClassPathHelper.getDevClassPath(bundle.getSymbolicName())));
@@ -93,15 +93,15 @@ public class Bundles {
     List<String> entries = new ArrayList<>();
     for(String cpe : cp) {
       String entry;
-      if(".".equals(cpe)) {
-        entry = getNestedJarOrDir(bundle, "/");
+      if(".".equals(cpe)) { //$NON-NLS-1$
+        entry = getNestedJarOrDir(bundle, "/"); //$NON-NLS-1$
       } else {
         entry = getNestedJarOrDir(bundle, cpe);
       }
 
       if(entry != null) {
         entry = new Path(entry).toOSString();
-        log.debug("\tEntry:{}", entry);
+        log.debug("\tEntry:{}", entry); //$NON-NLS-1$
         entries.add(entry);
       }
     }
@@ -109,13 +109,13 @@ public class Bundles {
   }
 
   private static String[] parseBundleClasspath(Bundle bundle) {
-    String[] result = new String[] {"."};
+    String[] result = new String[] {"."}; //$NON-NLS-1$
     String header = bundle.getHeaders().get(Constants.BUNDLE_CLASSPATH);
     ManifestElement[] classpathEntries = null;
     try {
       classpathEntries = ManifestElement.parseHeader(Constants.BUNDLE_CLASSPATH, header);
     } catch(BundleException ex) {
-      log.warn("Could not parse bundle classpath of {}", bundle.toString(), ex);
+      log.warn("Could not parse bundle classpath of {}", bundle.toString(), ex); //$NON-NLS-1$
     }
     if(classpathEntries != null) {
       result = new String[classpathEntries.length];
@@ -133,7 +133,7 @@ public class Bundles {
       try {
         return FileLocator.toFileURL(url).getFile();
       } catch(IOException ex) {
-        log.warn("Could not get entry {} for bundle {}", cp, bundle.toString(), ex);
+        log.warn("Could not get entry {} for bundle {}", cp, bundle.toString(), ex); //$NON-NLS-1$
       }
     }
 
@@ -145,7 +145,7 @@ public class Bundles {
       }
     }
 
-    log.debug("Bundle {} does not have entry {}", bundle.toString(), cp);
+    log.debug("Bundle {} does not have entry {}", bundle.toString(), cp); //$NON-NLS-1$
     return null;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/ExtensionReader.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/ExtensionReader.java
@@ -97,7 +97,7 @@ public class ExtensionReader {
             return new ArchetypeCatalogFactory.LocalCatalogFactory(url, description, false);
           }
         }
-        log.error("Unable to find Archetype catalog " + name + " in " + contributor.getName());
+        log.error("Unable to find Archetype catalog " + name + " in " + contributor.getName()); //$NON-NLS-1$ //$NON-NLS-2$
       }
     } else if(ELEMENT_REMOTE_ARCHETYPE.equals(element.getName())) {
       String url = element.getAttribute(ATTR_URL);
@@ -143,7 +143,7 @@ public class ExtensionReader {
       for(IExtension extension : mappingsExtensions) {
         IConfigurationElement[] elements = extension.getConfigurationElements();
         for(IConfigurationElement element : elements) {
-          if("framework".equals(element.getName())) {
+          if("framework".equals(element.getName())) { //$NON-NLS-1$
             try {
               frameworks.add((IIncrementalBuildFramework) element.createExecutableExtension("class")); //$NON-NLS-1$
             } catch(CoreException ex) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
@@ -259,7 +259,7 @@ public class MavenPluginActivator extends Plugin {
     ResourcesPlugin.getWorkspace().addSaveParticipant(IMavenConstants.PLUGIN_ID, saveParticipant);
     //register URL handler, we can't use DS here because this triggers loading of m2e too early
     Hashtable<String, Object>               properties = new Hashtable<>();
-    properties.put(URLConstants.URL_HANDLER_PROTOCOL, new String[] {"mvn"});
+    properties.put(URLConstants.URL_HANDLER_PROTOCOL, new String[] {"mvn"}); //$NON-NLS-1$
     this.protocolHandlerService = context.registerService(URLStreamHandlerService.class,
         new MvnProtocolHandlerService(), properties);
   }
@@ -378,7 +378,7 @@ public class MavenPluginActivator extends Plugin {
           ((RepositoryRegistry) getRepositoryRegistry())
               .addRepositoryDiscoverer(new IndexesExtensionReader(indexManager));
         } catch(PlexusContainerException ex1) {
-          log.error("Failed to initialize the NexusIndexManager", ex1);
+          log.error("Failed to initialize the NexusIndexManager", ex1); //$NON-NLS-1$
         }
       }
     }
@@ -399,11 +399,11 @@ public class MavenPluginActivator extends Plugin {
           try {
             this.archetypeManager.readCatalogs();
           } catch(Exception ex) {
-            String msg = "Can't read archetype catalog configuration";
+            String msg = "Can't read archetype catalog configuration"; //$NON-NLS-1$
             log.error(msg, ex);
           }
         } catch(PlexusContainerException ex1) {
-          log.error("Failed to initialize the ArchetypeManager", ex1);
+          log.error("Failed to initialize the ArchetypeManager", ex1); //$NON-NLS-1$
         }
       }
     }
@@ -444,8 +444,8 @@ public class MavenPluginActivator extends Plugin {
     String osgiVersion = Platform
         .getBundle("org.eclipse.osgi").getHeaders().get(org.osgi.framework.Constants.BUNDLE_VERSION); //$NON-NLS-1$
     String m2eVersion = plugin.qualifiedVersion;
-    String javaVersion = System.getProperty("java.version", "unknown"); //$NON-NLS-1$ $NON-NLS-1$
-    return "m2e/" + osgiVersion + "/" + m2eVersion + "/" + javaVersion; //$NON-NLS-1$ $NON-NLS-1$
+    String javaVersion = System.getProperty("java.version", "unknown"); //$NON-NLS-1$ //$NON-NLS-2$ $NON-NLS-1$
+    return "m2e/" + osgiVersion + "/" + m2eVersion + "/" + javaVersion; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ $NON-NLS-1$
   }
 
   public IRepositoryRegistry getRepositoryRegistry() {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MvnProtocolHandlerService.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MvnProtocolHandlerService.java
@@ -74,21 +74,21 @@ public class MvnProtocolHandlerService extends AbstractURLStreamHandlerService {
       }
       String path = url.getPath();
       if(path == null) {
-        throw new IOException("maven coordinates are missing");
+        throw new IOException("maven coordinates are missing"); //$NON-NLS-1$
       }
       int subPathIndex = path.indexOf('/');
 
       String[] coordinates;
       if(subPathIndex > -1) {
         subPath = path.substring(subPathIndex);
-        coordinates = path.substring(0, subPathIndex).split(":");
+        coordinates = path.substring(0, subPathIndex).split(":"); //$NON-NLS-1$
       } else {
-        coordinates = path.split(":");
+        coordinates = path.split(":"); //$NON-NLS-1$
       }
       if(coordinates.length < 3) {
-        throw new IOException("required format is groupId:artifactId:version[:packaging[:classifier]]");
+        throw new IOException("required format is groupId:artifactId:version[:packaging[:classifier]]"); //$NON-NLS-1$
       }
-      String type = coordinates.length > 3 ? coordinates[3] : "jar";
+      String type = coordinates.length > 3 ? coordinates[3] : "jar"; //$NON-NLS-1$
       String classifier = coordinates.length > 4 ? coordinates[4] : null;
       Artifact artifact = new DefaultArtifact(coordinates[0], coordinates[1], classifier, type, coordinates[2]);
       try {
@@ -108,12 +108,12 @@ public class MvnProtocolHandlerService extends AbstractURLStreamHandlerService {
               return repoSystem.resolveArtifact(session, artifactRequest);
             } catch(ArtifactResolutionException e) {
               throw new CoreException(new Status(IStatus.ERROR, MvnProtocolHandlerService.class.getPackage().getName(),
-                  "Resolving artifact failed", e));
+                  "Resolving artifact failed", e)); //$NON-NLS-1$
             }
           }
         }, new NullProgressMonitor());
       } catch(CoreException e) {
-        throw new IOException("resolving artifact " + artifact + " failed", e);
+        throw new IOException("resolving artifact " + artifact + " failed", e); //$NON-NLS-1$ //$NON-NLS-2$
       }
     }
 
@@ -127,7 +127,7 @@ public class MvnProtocolHandlerService extends AbstractURLStreamHandlerService {
       if(subPath == null) {
         return new FileInputStream(location);
       }
-      String urlSpec = "jar:" + location.toURI() + "!" + subPath;
+      String urlSpec = "jar:" + location.toURI() + "!" + subPath; //$NON-NLS-1$ //$NON-NLS-2$
       return new URL(urlSpec).openStream();
     }
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/URLConnectionCaches.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/URLConnectionCaches.java
@@ -58,7 +58,7 @@ public final class URLConnectionCaches {
 
   public static void assertDisabled() {
     if(conn.getDefaultUseCaches()) {
-      log.error("Unexpected URLConnection defaultUseCaches enabled");
+      log.error("Unexpected URLConnection defaultUseCaches enabled"); //$NON-NLS-1$
     }
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogFactory.java
@@ -189,7 +189,7 @@ public abstract class ArchetypeCatalogFactory {
 
     private URL getEmbeddedUrl() {
       String path = getId();
-      if(path != null && path.startsWith("bundleentry://")) {
+      if(path != null && path.startsWith("bundleentry://")) { //$NON-NLS-1$
         try {
           return new URL(path);
         } catch(Exception ex) {
@@ -242,7 +242,7 @@ public abstract class ArchetypeCatalogFactory {
 
     public ArchetypeCatalog getArchetypeCatalog() {
       String url = getId();
-      int idx = url.lastIndexOf("/archetype-catalog.xml");
+      int idx = url.lastIndexOf("/archetype-catalog.xml"); //$NON-NLS-1$
       if(idx > -1) {
         url = url.substring(0, idx);
       }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogsWriter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeCatalogsWriter.java
@@ -73,9 +73,9 @@ public class ArchetypeCatalogsWriter {
 
   private static final String TYPE_SYSTEM = "system"; //$NON-NLS-1$
 
-  public static final String ATT_CATALOG_ID = "id";
+  public static final String ATT_CATALOG_ID = "id"; //$NON-NLS-1$
 
-  public static final String ATT_CATALOG_ENABLED = "enabled";
+  public static final String ATT_CATALOG_ENABLED = "enabled"; //$NON-NLS-1$
 
   public Collection<ArchetypeCatalogFactory> readArchetypeCatalogs(InputStream is,
       Map<String, ArchetypeCatalogFactory> existingCatalogs) throws IOException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/archetype/ArchetypeManager.java
@@ -153,7 +153,7 @@ public class ArchetypeManager {
    */
   public List<?> getRequiredProperties(Archetype archetype, ArtifactRepository remoteArchetypeRepository,
       IProgressMonitor monitor) throws UnknownArchetype, CoreException {
-    Assert.isNotNull(archetype, "Archetype can not be null");
+    Assert.isNotNull(archetype, "Archetype can not be null"); //$NON-NLS-1$
 
     if(monitor == null) {
       monitor = new NullProgressMonitor();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/BuildResultCollector.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/BuildResultCollector.java
@@ -77,7 +77,7 @@ class BuildResultCollector implements IIncrementalBuildFramework.BuildResultColl
   @Override
   public void addMessage(File file, int line, int column, String message, int severity, Throwable cause) {
     if(currentParticipantId == null) {
-      throw new IllegalStateException("currentBuildParticipantId cannot be null or empty");
+      throw new IllegalStateException("currentBuildParticipantId cannot be null or empty"); //$NON-NLS-1$
     }
     List<Message> messageList = messages.get(currentParticipantId);
     if(messageList == null) {
@@ -90,7 +90,7 @@ class BuildResultCollector implements IIncrementalBuildFramework.BuildResultColl
   @Override
   public void removeMessages(File file) {
     if(currentParticipantId == null) {
-      throw new IllegalStateException("currentBuildParticipantId cannot be null or empty");
+      throw new IllegalStateException("currentBuildParticipantId cannot be null or empty"); //$NON-NLS-1$
     }
     List<File> files = removeMessages.get(currentParticipantId);
     if(files == null) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilderImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilderImpl.java
@@ -67,7 +67,7 @@ public class MavenBuilderImpl {
 
   public static final QualifiedName BUILD_CONTEXT_KEY = new QualifiedName(IMavenConstants.PLUGIN_ID, "BuildContext"); //$NON-NLS-1$
 
-  private static final String BUILD_PARTICIPANT_ID_ATTR_NAME = "buildParticipantId";
+  private static final String BUILD_PARTICIPANT_ID_ATTR_NAME = "buildParticipantId"; //$NON-NLS-1$
 
   private final DeltaProvider deltaProvider;
 
@@ -119,9 +119,9 @@ public class MavenBuilderImpl {
           Set<File> debugRefreshFiles = !debugHooks.isEmpty() ? new LinkedHashSet<>(participantResults.getFiles())
               : null;
 
-          log.debug("Executing build participant {} for plugin execution {}", participant.getClass().getName(),
+          log.debug("Executing build participant {} for plugin execution {}", participant.getClass().getName(), //$NON-NLS-1$
               mojoExecutionKey.toString());
-          participantResults.setParticipantId(mojoExecutionKey.getKeyString() + "-" + participant.getClass().getName());
+          participantResults.setParticipantId(mojoExecutionKey.getKeyString() + "-" + participant.getClass().getName()); //$NON-NLS-1$
           participant.setMavenProjectFacade(projectFacade);
           participant.setGetDeltaCallback(getDeltaProvider());
           participant.setSession(session);
@@ -138,10 +138,10 @@ public class MavenBuilderImpl {
               }
             }
           } catch(Exception e) {
-            log.debug("Exception in build participant {}", participant.getClass().getName(), e);
+            log.debug("Exception in build participant {}", participant.getClass().getName(), e); //$NON-NLS-1$
             buildErrors.put(e, mojoExecutionKey);
           } finally {
-            log.debug("Finished executing build participant {} for plugin execution {} in {} ms", participant.getClass().getName(), mojoExecutionKey.toString(), System.currentTimeMillis() - executionStartTime);
+            log.debug("Finished executing build participant {} for plugin execution {} in {} ms", participant.getClass().getName(), mojoExecutionKey.toString(), System.currentTimeMillis() - executionStartTime); //$NON-NLS-1$
             participant.setMavenProjectFacade(null);
             participant.setGetDeltaCallback(null);
             participant.setSession(null);
@@ -158,7 +158,7 @@ public class MavenBuilderImpl {
         }
       }
     } catch(Exception e) {
-      log.debug("Unexpected build exception", e);
+      log.debug("Unexpected build exception", e); //$NON-NLS-1$
       buildErrors.put(e, null);
     } finally {
       snapshot.restore(mavenProject);
@@ -219,7 +219,7 @@ public class MavenBuilderImpl {
     MavenExecutionResult result = session.getResult();
     if(result.hasExceptions()) {
       for(Throwable e : result.getExceptions()) {
-        log.debug("Exception during execution {}", mojoExecutionKey, e);
+        log.debug("Exception during execution {}", mojoExecutionKey, e); //$NON-NLS-1$
         buildErrors.put(e, mojoExecutionKey);
       }
       result.getExceptions().clear();
@@ -231,7 +231,7 @@ public class MavenBuilderImpl {
     for(File file : resources) {
       IPath path = getProjectRelativePath(project, file);
       if(path == null) {
-        log.debug("Could not get relative path for file: ", file.getAbsoluteFile());
+        log.debug("Could not get relative path for file: ", file.getAbsoluteFile()); //$NON-NLS-1$
         continue; // odd
       }
 
@@ -380,7 +380,7 @@ public class MavenBuilderImpl {
       for(Entry<MojoExecutionKey, List<AbstractBuildParticipant>> entry : participants.entrySet()) {
         MojoExecutionKey mojoExecutionKey = entry.getKey();
         for(InternalBuildParticipant participant : entry.getValue()) {
-          participantResults.setParticipantId(mojoExecutionKey.getKeyString() + "-" + participant.getClass().getName());
+          participantResults.setParticipantId(mojoExecutionKey.getKeyString() + "-" + participant.getClass().getName()); //$NON-NLS-1$
           participant.setMavenProjectFacade(projectFacade);
           participant.setGetDeltaCallback(getDeltaProvider());
           participant.setSession(session);
@@ -388,7 +388,7 @@ public class MavenBuilderImpl {
           try {
             participant.clean(monitor);
           } catch(Exception e) {
-            log.debug("Exception in build participant", e);
+            log.debug("Exception in build participant", e); //$NON-NLS-1$
             buildErrors.put(e, mojoExecutionKey);
           } finally {
             participant.setMavenProjectFacade(null);


### PR DESCRIPTION
Do you care for NLS-Tags and is it useful to clean up this way? It's a lot of changes.

EclipseJdt cleanup 'CleanupNlsTag' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor