### PR TITLE
[cleanup] erefactor/EclipseJdt - Add missing @override annotation

### DIFF
--- a/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject.ui;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-Activator: org.eclipse.m2e.binaryproject.ui.internal.BinaryprojectUIActivator
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.binaryproject.ui/src/org/eclipse/m2e/binaryproject/ui/internal/BinaryprojectUIActivator.java
+++ b/org.eclipse.m2e.binaryproject.ui/src/org/eclipse/m2e/binaryproject/ui/internal/BinaryprojectUIActivator.java
@@ -36,6 +36,7 @@ public class BinaryprojectUIActivator extends AbstractUIPlugin {
    *
    * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
    */
+  @Override
   public void start(BundleContext context) throws Exception {
     super.start(context);
     plugin = this;
@@ -46,6 +47,7 @@ public class BinaryprojectUIActivator extends AbstractUIPlugin {
    *
    * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
    */
+  @Override
   public void stop(BundleContext context) throws Exception {
     plugin = null;
     super.stop(context);

--- a/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/BinaryProjectLifecycleMapping.java
+++ b/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/BinaryProjectLifecycleMapping.java
@@ -59,9 +59,11 @@ public class BinaryProjectLifecycleMapping extends AbstractLifecycleMapping {
     return false;
   }
 
+  @Override
   public void configure(ProjectConfigurationRequest request, IProgressMonitor monitor) throws CoreException {
     configurator.configure(request, monitor);
   }
 
+  @Override
   public void unconfigure(ProjectConfigurationRequest request, IProgressMonitor monitor) {}
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/MavenVersionDecorator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/MavenVersionDecorator.java
@@ -41,10 +41,12 @@ public class MavenVersionDecorator implements ILabelDecorator {
 
   private final Map<ILabelProviderListener, IMavenProjectChangedListener> listeners = new HashMap<>();
 
+  @Override
   public Image decorateImage(Image image, Object element) {
     return null;
   }
 
+  @Override
   public String decorateText(String text, Object element) {
     if(element instanceof IResource) {
       IResource resource = (IResource) element;
@@ -71,10 +73,12 @@ public class MavenVersionDecorator implements ILabelDecorator {
     return null;
   }
 
+  @Override
   public boolean isLabelProperty(Object element, String property) {
     return false;
   }
 
+  @Override
   public void addListener(final ILabelProviderListener listener) {
     IMavenProjectChangedListener projectChangeListener = (events, monitor) -> {
       ArrayList<IResource> pomList = new ArrayList<>();
@@ -97,6 +101,7 @@ public class MavenVersionDecorator implements ILabelDecorator {
     projectManager.addMavenProjectChangedListener(projectChangeListener);
   }
 
+  @Override
   public void removeListener(ILabelProviderListener listener) {
     IMavenProjectChangedListener projectChangeListener = listeners.get(listener);
     if(projectChangeListener != null) {
@@ -105,6 +110,7 @@ public class MavenVersionDecorator implements ILabelDecorator {
     }
   }
 
+  @Override
   public void dispose() {
     // TODO remove all listeners
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/UpdateMavenProjectJob.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/UpdateMavenProjectJob.java
@@ -69,6 +69,7 @@ public class UpdateMavenProjectJob extends WorkspaceJob {
     setRule(MavenPlugin.getProjectConfigurationManager().getRule());
   }
 
+  @Override
   public IStatus runInWorkspace(IProgressMonitor monitor) {
     ProjectConfigurationManager configurationManager = (ProjectConfigurationManager) MavenPlugin
         .getProjectConfigurationManager();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/AddDependencyAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/AddDependencyAction.java
@@ -61,6 +61,7 @@ public class AddDependencyAction extends MavenActionSupport implements IWorkbenc
 
   public static final String ID = "org.eclipse.m2e.addDependencyAction"; //$NON-NLS-1$
 
+  @Override
   public void run(IAction action) {
     IFile file = getPomFileFromPomEditorOrViewSelection();
 
@@ -128,9 +129,11 @@ public class AddDependencyAction extends MavenActionSupport implements IWorkbenc
     }
   }
 
+  @Override
   public void dispose() {
   }
 
+  @Override
   public void init(IWorkbenchWindow window) {
   }
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/AddPluginAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/AddPluginAction.java
@@ -48,6 +48,7 @@ public class AddPluginAction extends MavenActionSupport implements IWorkbenchWin
 
   public static final String ID = "org.eclipse.m2e.addPluginAction"; //$NON-NLS-1$
 
+  @Override
   public void run(IAction action) {
     IFile file = getPomFileFromPomEditorOrViewSelection();
 
@@ -81,9 +82,11 @@ public class AddPluginAction extends MavenActionSupport implements IWorkbenchWin
     }
   }
 
+  @Override
   public void dispose() {
   }
 
+  @Override
   public void init(IWorkbenchWindow window) {
   }
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/AssignWorkingSetAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/AssignWorkingSetAction.java
@@ -25,7 +25,8 @@ import org.eclipse.m2e.core.ui.internal.dialogs.AssignWorkingSetDialog;
  */
 public class AssignWorkingSetAction extends MavenProjectActionSupport {
 
-  public void run(IAction action) {
+    @Override
+    public void run(IAction action) {
     IProject[] initialSelection = getProjects();
 
     AssignWorkingSetDialog dialog = new AssignWorkingSetDialog(getShell(), initialSelection);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/ChangeNatureAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/ChangeNatureAction.java
@@ -68,6 +68,7 @@ public class ChangeNatureAction implements IObjectActionDelegate, IExecutableExt
   /* (non-Javadoc)
    * @see org.eclipse.core.runtime.IExecutableExtension#setInitializationData(org.eclipse.core.runtime.IConfigurationElement, java.lang.String, java.lang.Object)
    */
+  @Override
   public void setInitializationData(IConfigurationElement config, String propertyName, Object data) {
     if(data != null) {
       if("enableWorkspaceResolution".equals(data)) {//$NON-NLS-1$
@@ -79,13 +80,16 @@ public class ChangeNatureAction implements IObjectActionDelegate, IExecutableExt
     }
   }
 
+  @Override
   public void selectionChanged(IAction action, ISelection selection) {
     this.selection = selection;
   }
 
+  @Override
   public void setActivePart(IAction action, IWorkbenchPart targetPart) {
   }
 
+  @Override
   public void run(IAction action) {
     if(selection instanceof IStructuredSelection) {
       IStructuredSelection structuredSelection = (IStructuredSelection) selection;
@@ -128,6 +132,7 @@ public class ChangeNatureAction implements IObjectActionDelegate, IExecutableExt
       this.mavenConfiguration = MavenPlugin.getMavenConfiguration();
     }
 
+    @Override
     public IStatus runInWorkspace(IProgressMonitor monitor) {
       MultiStatus status = null;
       for(IProject project : projects) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/DisableNatureAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/DisableNatureAction.java
@@ -40,6 +40,7 @@ public class DisableNatureAction implements IObjectActionDelegate {
    * (non-Javadoc)
    * @see org.eclipse.ui.IActionDelegate#run(org.eclipse.jface.action.IAction)
    */
+  @Override
   public void run(IAction action) {
     if(selection instanceof IStructuredSelection) {
       IStructuredSelection structuredSelection = (IStructuredSelection) selection;
@@ -67,6 +68,7 @@ public class DisableNatureAction implements IObjectActionDelegate {
    * @see org.eclipse.ui.IActionDelegate#selectionChanged(org.eclipse.jface.action.IAction,
    *      org.eclipse.jface.viewers.ISelection)
    */
+  @Override
   public void selectionChanged(IAction action, ISelection selection) {
     this.selection = selection;
   }
@@ -76,6 +78,7 @@ public class DisableNatureAction implements IObjectActionDelegate {
    * @see org.eclipse.ui.IObjectActionDelegate#setActivePart(org.eclipse.jface.action.IAction,
    *      org.eclipse.ui.IWorkbenchPart)
    */
+  @Override
   public void setActivePart(IAction action, IWorkbenchPart targetPart) {
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/EnableNatureAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/EnableNatureAction.java
@@ -67,19 +67,23 @@ public class EnableNatureAction implements IObjectActionDelegate, IExecutableExt
     setInitializationData(null, null, option);
   }
 
+  @Override
   public void setInitializationData(IConfigurationElement config, String propertyName, Object data) {
     if(IMavenConstants.NO_WORKSPACE_PROJECTS.equals(data)) {
       this.workspaceProjects = false;
     }
   }
 
+  @Override
   public void selectionChanged(IAction action, ISelection selection) {
     this.selection = selection;
   }
 
+  @Override
   public void setActivePart(IAction action, IWorkbenchPart targetPart) {
   }
 
+  @Override
   public void run(IAction action) {
     if(selection instanceof IStructuredSelection) {
       IStructuredSelection structuredSelection = (IStructuredSelection) selection;
@@ -125,7 +129,8 @@ public class EnableNatureAction implements IObjectActionDelegate, IExecutableExt
     }
     Job job = new Job(Messages.EnableNatureAction_job_enable) {
 
-      protected IStatus run(IProgressMonitor monitor) {
+        @Override
+        protected IStatus run(IProgressMonitor monitor) {
         try {
           ResolverConfiguration configuration = new ResolverConfiguration();
           configuration.setResolveWorkspaceProjects(workspaceProjects);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenActionSupport.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenActionSupport.java
@@ -64,10 +64,12 @@ public abstract class MavenActionSupport implements IObjectActionDelegate {
     return Collections.emptySet();
   }
 
+  @Override
   public void setActivePart(IAction action, IWorkbenchPart targetPart) {
     this.targetPart = targetPart;
   }
 
+  @Override
   public void selectionChanged(IAction action, ISelection selection) {
     if(selection instanceof IStructuredSelection) {
       this.selection = (IStructuredSelection) selection;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenConsoleRemoveAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenConsoleRemoveAction.java
@@ -28,6 +28,7 @@ public class MavenConsoleRemoveAction extends Action {
     setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_ELCL_REMOVE));
   }
 
+  @Override
   public void run() {
     M2EUIPluginActivator.getDefault().getMavenConsole().closeConsole();
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenDebugOutputAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenDebugOutputAction.java
@@ -42,6 +42,7 @@ public class MavenDebugOutputAction extends Action {
     setChecked(isDebug());
   }
 
+  @Override
   public void run() {
     getPreferenceStore().setValue(MavenPreferenceConstants.P_DEBUG_OUTPUT, isChecked());
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenProjectActionSupport.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenProjectActionSupport.java
@@ -24,9 +24,11 @@ public abstract class MavenProjectActionSupport extends MavenActionSupport imple
     return SelectionUtil.getProjects(selection, true);
   }
 
+  @Override
   public void dispose() {
   }
 
+  @Override
   public void init(IWorkbenchWindow window) {
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
@@ -52,6 +52,7 @@ public class MavenPropertyTester extends PropertyTester {
 
   private static final String DEFAULT_BUILD_DIR = "target"; //$NON-NLS-1$
 
+  @Override
   public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
     if(WORKSPACE_RESULUTION_ENABLE.equals(property)) {
       boolean enableWorkspaceResolution = true;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/ModuleProjectWizardAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/ModuleProjectWizardAction.java
@@ -40,6 +40,7 @@ public class ModuleProjectWizardAction implements IObjectActionDelegate {
   private Shell parent;
 
   /** Runs the action. */
+  @Override
   public void run(IAction action) {
     MavenModuleWizard wizard = new MavenModuleWizard();
     wizard.init(PlatformUI.getWorkbench(), selection);
@@ -48,11 +49,13 @@ public class ModuleProjectWizardAction implements IObjectActionDelegate {
   }
 
   /** Sets the active workbench part. */
+  @Override
   public void setActivePart(IAction action, IWorkbenchPart part) {
     parent = part.getSite().getShell();
   }
 
   /** Handles the selection change */
+  @Override
   public void selectionChanged(IAction action, ISelection selection) {
     if(selection instanceof IStructuredSelection) {
       this.selection = (IStructuredSelection) selection;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenMavenConsoleAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenMavenConsoleAction.java
@@ -25,7 +25,8 @@ import org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator;
  */
 public class OpenMavenConsoleAction extends Action {
 
-  public void run() {
+    @Override
+    public void run() {
     M2EUIPluginActivator.getDefault().getMavenConsole().showConsole();
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenPomAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/OpenPomAction.java
@@ -95,9 +95,11 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
   /* (non-Javadoc)
    * @see org.eclipse.ui.IWorkbenchWindowActionDelegate#init(org.eclipse.ui.IWorkbenchWindow)
    */
+  @Override
   public void init(IWorkbenchWindow window) {
   }
 
+  @Override
   public void selectionChanged(IAction action, ISelection selection) {
     if(selection instanceof IStructuredSelection) {
       this.selection = (IStructuredSelection) selection;
@@ -106,6 +108,7 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
     }
   }
 
+  @Override
   public void setActivePart(IAction action, IWorkbenchPart targetPart) {
     mavenProject = targetPart.getAdapter(MavenProject.class);
   }
@@ -114,6 +117,7 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
     return mavenProject;
   }
 
+  @Override
   public void run(IAction action) {
     //TODO mkleint: this asks for rewrite.. having one action that does 2 quite different things based
     // on something as vague as selection passed in is unreadable..
@@ -123,7 +127,8 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
         final ArtifactKey ak = SelectionUtil.getArtifactKey(element);
         if(ak != null) {
           new Job(Messages.OpenPomAction_job_opening) {
-            protected IStatus run(IProgressMonitor monitor) {
+              @Override
+              protected IStatus run(IProgressMonitor monitor) {
               openEditor(ak.getGroupId(), ak.getArtifactId(), ak.getVersion(), getMavenProject(), monitor);
               return Status.OK_STATUS;
             }
@@ -140,7 +145,8 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
     if(dialog.open() == Window.OK) {
       final IndexedArtifactFile iaf = (IndexedArtifactFile) dialog.getFirstResult();
       new Job(Messages.OpenPomAction_job_opening) {
-        protected IStatus run(IProgressMonitor monitor) {
+          @Override
+          protected IStatus run(IProgressMonitor monitor) {
           if(iaf != null) {
             openEditor(iaf.group, iaf.artifact, iaf.version, monitor);
           }
@@ -333,30 +339,37 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
 
     // IStorageEditorInput
 
+    @Override
     public boolean exists() {
       return true;
     }
 
+    @Override
     public String getName() {
       return this.name;
     }
 
+    @Override
     public String getToolTipText() {
       return this.tooltip;
     }
 
+    @Override
     public IStorage getStorage() {
       return new MavenStorage(name, path, content);
     }
 
+    @Override
     public ImageDescriptor getImageDescriptor() {
       return null;
     }
 
+    @Override
     public IPersistableElement getPersistable() {
       return null;
     }
 
+    @Override
     public <T> T getAdapter(Class<T> adapter) {
       return null;
     }
@@ -376,6 +389,7 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
      * @see java.lang.Object#equals(java.lang.Object)
      */
     //implemented as hinted by IPathEditorInput javadoc.
+    @Override
     public boolean equals(Object obj) {
       IPath path = getPath();
       if(path != null && obj instanceof MavenPathStorageEditorInput) {
@@ -398,22 +412,27 @@ public class OpenPomAction extends ActionDelegate implements IWorkbenchWindowAct
       this.content = content;
     }
 
+    @Override
     public String getName() {
       return name;
     }
 
+    @Override
     public IPath getFullPath() {
       return path == null ? null : new Path(path);
     }
 
+    @Override
     public InputStream getContents() {
       return new ByteArrayInputStream(content);
     }
 
+    @Override
     public boolean isReadOnly() {
       return true;
     }
 
+    @Override
     public <T> T getAdapter(Class<T> adapter) {
       return null;
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectAction.java
@@ -29,6 +29,7 @@ public class UpdateMavenProjectAction extends MavenProjectActionSupport {
   public UpdateMavenProjectAction() {
   }
 
+  @Override
   public void run(IAction action) {
     UpdateMavenProjectCommandHandler.openUpdateProjectsDialog(getShell(), getProjects());
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectCommandHandler.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/UpdateMavenProjectCommandHandler.java
@@ -46,6 +46,7 @@ public class UpdateMavenProjectCommandHandler extends AbstractHandler {
 
   private static final Logger log = LoggerFactory.getLogger(UpdateMavenProjectCommandHandler.class);
 
+  @Override
   public Object execute(final ExecutionEvent event) {
 
     ISelection selection = HandlerUtil.getCurrentSelection(event);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/MavenProjectLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/MavenProjectLabelProvider.java
@@ -30,7 +30,8 @@ import org.eclipse.m2e.core.ui.internal.MavenImages;
  * @since 1.5
  */
 public class MavenProjectLabelProvider extends LabelProvider {
-  public Image getImage(Object element) {
+    @Override
+    public Image getImage(Object element) {
     if(Beans.isDesignTime()) {
       // windowbuilder compat
       return null;
@@ -46,6 +47,7 @@ public class MavenProjectLabelProvider extends LabelProvider {
     return img;
   }
 
+  @Override
   public String getText(Object element) {
     return element instanceof IProject ? ((IProject) element).getName() : ""; //$NON-NLS-1$
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/NestedProjectsComposite.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/NestedProjectsComposite.java
@@ -105,20 +105,24 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
     codebaseViewer = new CheckboxTreeViewer(this, SWT.BORDER);
     codebaseViewer.setContentProvider(new ITreeContentProvider() {
 
-      public void dispose() {
+        @Override
+        public void dispose() {
       }
 
-      public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
       }
 
-      public Object[] getElements(Object element) {
+        @Override
+        public Object[] getElements(Object element) {
         if(element instanceof Collection) {
           return ((Collection<?>) element).toArray();
         }
         return null;
       }
 
-      public Object[] getChildren(Object parentElement) {
+        @Override
+        public Object[] getChildren(Object parentElement) {
         if(parentElement instanceof IProject) {
           String elePath = getElePath(parentElement);
           String prevPath = null;
@@ -138,7 +142,8 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
         return null;
       }
 
-      public Object getParent(Object element) {
+        @Override
+        public Object getParent(Object element) {
         String elePath = getElePath(element);
         String prevPath = null;
         for(String path : projectPaths.keySet()) {
@@ -150,7 +155,8 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
         return prevPath == null ? projects : getProject(prevPath);
       }
 
-      public boolean hasChildren(Object element) {
+        @Override
+        public boolean hasChildren(Object element) {
         if(element instanceof IProject) {
           String elePath = getElePath(element);
           for(String path : projectPaths.keySet()) {
@@ -165,7 +171,8 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
       }
     });
     codebaseViewer.setLabelProvider(new MavenProjectLabelProvider() {
-      public Image getImage(Object element) {
+        @Override
+        public Image getImage(Object element) {
         Image img = super.getImage(element);
         if(showOutOfDateUI && requiresUpdate((IProject) element)) {
           img = MavenImages.createOverlayImage(MavenImages.OOD_MVN_PROJECT, img, MavenImages.OUT_OF_DATE_OVERLAY,
@@ -425,6 +432,7 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
     menuMgr.setRemoveAllWhenShown(true);
   }
 
+  @Override
   public void menuAboutToShow(IMenuManager manager) {
     if(codebaseViewer.getSelection().isEmpty()) {
       return;
@@ -437,14 +445,16 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
   }
 
   private final Action selectTree = new Action(Messages.UpdateDepenciesDialog_selectTree) {
-    public void run() {
+      @Override
+      public void run() {
       setSubtreeChecked(getSelection(), true);
       updateSelectedProjects();
     }
   };
 
   private final Action deselectTree = new Action(Messages.UpdateDepenciesDialog_deselectTree) {
-    public void run() {
+      @Override
+      public void run() {
       setSubtreeChecked(getSelection(), false);
       updateSelectedProjects();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
@@ -70,6 +70,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
     pomsViewer.setContentProvider(new PomHeirarchyContentProvider());
   }
 
+  @Override
   public void setEnabled(boolean bool) {
     pomsViewer.getTree().setEnabled(bool);
     super.setEnabled(bool);
@@ -123,6 +124,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       return buffer.toString();
     }
 
+    @Override
     public Color getForeground(Object element) {
       if(element instanceof ParentHierarchyEntry) {
         ParentHierarchyEntry project = (ParentHierarchyEntry) element;
@@ -134,10 +136,12 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       return null;
     }
 
+    @Override
     public Color getBackground(Object element) {
       return null;
     }
 
+    @Override
     public Image getImage(Object element) {
       if(element instanceof ParentHierarchyEntry) {
         ParentHierarchyEntry project = (ParentHierarchyEntry) element;
@@ -157,6 +161,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
     public PomHeirarchyContentProvider() {
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
       if(newInput instanceof List) {
@@ -164,15 +169,18 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       }
     }
 
+    @Override
     public void dispose() {
     }
 
+    @Override
     public boolean hasChildren(Object element) {
       Object[] children = getChildren(element);
 
       return children.length != 0;
     }
 
+    @Override
     public Object getParent(Object element) {
       if(element instanceof ParentHierarchyEntry) {
         for(int i = 1; i < projects.size(); i++ ) {
@@ -184,6 +192,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       return null;
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public Object[] getElements(Object inputElement) {
       if(inputElement instanceof List) {
@@ -196,6 +205,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       return new Object[0];
     }
 
+    @Override
     public Object[] getChildren(Object parentElement) {
       if(parentElement instanceof ParentHierarchyEntry) {
         /*
@@ -228,22 +238,27 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
     }
   }
 
+  @Override
   public void addSelectionChangedListener(ISelectionChangedListener listener) {
     pomsViewer.addSelectionChangedListener(listener);
   }
 
+  @Override
   public Object getInput() {
     return pomsViewer.getInput();
   }
 
+  @Override
   public ISelection getSelection() {
     return pomsViewer.getSelection();
   }
 
+  @Override
   public void removeSelectionChangedListener(ISelectionChangedListener listener) {
     pomsViewer.removeSelectionChangedListener(listener);
   }
 
+  @Override
   public void setSelection(ISelection selection) {
     pomsViewer.setSelection(selection);
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/TextComboBoxCellEditor.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/TextComboBoxCellEditor.java
@@ -39,12 +39,14 @@ public class TextComboBoxCellEditor extends CellEditor {
     super(parent, style);
   }
 
+  @Override
   protected Control createControl(Composite parent) {
     combo = new CCombo(parent, getStyle());
     combo.setFont(parent.getFont());
 
     combo.addKeyListener(new KeyAdapter() {
-      public void keyPressed(KeyEvent e) {
+        @Override
+        public void keyPressed(KeyEvent e) {
         keyReleaseOccured(e);
       }
     });
@@ -59,16 +61,19 @@ public class TextComboBoxCellEditor extends CellEditor {
     return combo;
   }
 
+  @Override
   protected Object doGetValue() {
     Assert.isNotNull(combo);
     return combo.getText();
   }
 
+  @Override
   protected void doSetFocus() {
     Assert.isNotNull(combo);
     combo.setFocus();
   }
 
+  @Override
   protected void doSetValue(Object value) {
     Assert.isNotNull(combo);
     combo.setText(String.valueOf(value));
@@ -89,6 +94,7 @@ public class TextComboBoxCellEditor extends CellEditor {
     }
   }
 
+  @Override
   protected void keyReleaseOccured(KeyEvent keyEvent) {
     if(keyEvent.character == SWT.ESC) {
       fireCancelEditor();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
@@ -101,7 +101,8 @@ public class WorkingSetGroup {
 
     workingsetComboViewer = new ComboViewer(workingsetCombo);
     workingsetComboViewer.setContentProvider(new IStructuredContentProvider() {
-      public Object[] getElements(Object input) {
+        @Override
+        public Object[] getElements(Object input) {
         if(input instanceof IWorkingSet[]) {
           return (IWorkingSet[]) input;
         } else if(input instanceof List<?>) {
@@ -112,16 +113,19 @@ public class WorkingSetGroup {
         return new IWorkingSet[0];
       }
 
-      public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
       }
 
-      public void dispose() {
+        @Override
+        public void dispose() {
       }
     });
     workingsetComboViewer.setLabelProvider(new LabelProvider() {
       private final ResourceManager images = new LocalResourceManager(JFaceResources.getResources());
 
-      @SuppressWarnings("deprecation")
+        @Override
+        @SuppressWarnings("deprecation")
       public Image getImage(Object element) {
         if(element instanceof IWorkingSet) {
           ImageDescriptor imageDescriptor = ((IWorkingSet) element).getImage();
@@ -136,7 +140,8 @@ public class WorkingSetGroup {
         return super.getImage(element);
       }
 
-      public String getText(Object element) {
+        @Override
+        public String getText(Object element) {
         if(element instanceof IWorkingSet) {
           return ((IWorkingSet) element).getLabel();
         } else if(element instanceof List<?>) {
@@ -154,7 +159,8 @@ public class WorkingSetGroup {
         return super.getText(element);
       }
 
-      public void dispose() {
+        @Override
+        public void dispose() {
         images.dispose();
         super.dispose();
       }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleFactory.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleFactory.java
@@ -26,7 +26,8 @@ import org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator;
  */
 public class MavenConsoleFactory implements IConsoleFactory {
 
-  public void openConsole() {
+    @Override
+    public void openConsole() {
     M2EUIPluginActivator.getDefault().getMavenConsole().showConsole();
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsoleImpl.java
@@ -76,6 +76,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
     this.setConsoleDocument(new ConsoleDocument());
   }
 
+  @Override
   protected void init() {
     super.init();
 
@@ -208,6 +209,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
     ConsolePlugin.getDefault().getConsoleManager().addConsoleListener(this.newLifecycle());
   }
 
+  @Override
   public void propertyChange(PropertyChangeEvent event) {
     // font changed
     setFont(JFaceResources.getFontRegistry().get("pref_console_font")); //$NON-NLS-1$
@@ -224,6 +226,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
   }
 
   // Called when console is removed from the console view
+  @Override
   protected void dispose() {
     // Here we can't call super.dispose() because we actually want the partitioner to remain
     // connected, but we won't show lines until the console is added to the console manager
@@ -249,6 +252,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
 
   // MavenConsole
 
+  @Override
   public void debug(String message) {
     if(!M2EUIPluginActivator.getDefault().getPreferenceStore().getBoolean(MavenPreferenceConstants.P_DEBUG_OUTPUT)) {
       return;
@@ -267,6 +271,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
     }
   }
 
+  @Override
   public void info(String message) {
     if(showConsoleOnOutput()) {
       bringConsoleToFront();
@@ -282,6 +287,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
     }
   }
 
+  @Override
   public void error(String message) {
     if(showConsoleOnError()) {
       bringConsoleToFront();
@@ -386,7 +392,8 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
    */
   public class MavenConsoleLifecycle implements org.eclipse.ui.console.IConsoleListener {
 
-    public void consolesAdded(IConsole[] consoles) {
+      @Override
+      public void consolesAdded(IConsole[] consoles) {
       for(IConsole console : consoles) {
         if(console == MavenConsoleImpl.this) {
           init();
@@ -395,6 +402,7 @@ public class MavenConsoleImpl extends IOConsole implements MavenConsole, IProper
 
     }
 
+    @Override
     public void consolesRemoved(IConsole[] consoles) {
       for(IConsole console : consoles) {
         if(console == MavenConsoleImpl.this) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsolePageParticipant.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenConsolePageParticipant.java
@@ -42,6 +42,7 @@ public class MavenConsolePageParticipant implements IConsolePageParticipant {
 
   private static final String SHOW_ON_ERR_LBL = Messages.MavenConsolePageParticipant_error;
 
+  @Override
   public void init(IPageBookViewPage page, IConsole console) {
     this.consoleRemoveAction = new MavenConsoleRemoveAction();
     this.debugAction = new MavenDebugOutputAction();
@@ -60,17 +61,21 @@ public class MavenConsolePageParticipant implements IConsolePageParticipant {
     mgr.appendToGroup(IConsoleConstants.OUTPUT_GROUP, showOnErrorAction);
   }
 
+  @Override
   public void dispose() {
     this.consoleRemoveAction = null;
     this.debugAction = null;
   }
 
+  @Override
   public void activated() {
   }
 
+  @Override
   public void deactivated() {
   }
 
+  @Override
   public <T> T getAdapter(Class<T> adapter) {
     return null;
   }
@@ -84,6 +89,7 @@ public class MavenConsolePageParticipant implements IConsolePageParticipant {
     /* (non-Javadoc)
      * @see org.eclipse.m2e.ui.internal.MavenShowConsoleAction#getKey()
      */
+    @Override
     protected String getKey() {
       return MavenPreferenceConstants.P_SHOW_CONSOLE_ON_ERR;
     }
@@ -102,6 +108,7 @@ public class MavenConsolePageParticipant implements IConsolePageParticipant {
     /* (non-Javadoc)
      * @see org.eclipse.m2e.ui.internal.MavenShowConsoleAction#getKey()
      */
+    @Override
     protected String getKey() {
       return MavenPreferenceConstants.P_SHOW_CONSOLE_ON_OUTPUT;
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenShowConsoleAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/console/MavenShowConsoleAction.java
@@ -39,6 +39,7 @@ public abstract class MavenShowConsoleAction extends Action implements IProperty
   /* (non-Javadoc)
    * @see org.eclipse.jface.util.IPropertyChangeListener#propertyChange(org.eclipse.jface.util.PropertyChangeEvent)
    */
+  @Override
   public void propertyChange(PropertyChangeEvent event) {
     String property = event.getProperty();
     if(property.equals(getKey())) {
@@ -69,6 +70,7 @@ public abstract class MavenShowConsoleAction extends Action implements IProperty
   /* (non-Javadoc)
    * @see org.eclipse.jface.action.Action#run()
    */
+  @Override
   public void run() {
     IPreferenceStore store = getPreferenceStore();
     boolean show = isChecked();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/AbstractMavenDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/AbstractMavenDialog.java
@@ -66,6 +66,7 @@ public abstract class AbstractMavenDialog extends SelectionStatusDialog {
     return settings;
   }
 
+  @Override
   protected Point getInitialSize() {
     Point result = super.getInitialSize();
     if(size != null) {
@@ -78,6 +79,7 @@ public abstract class AbstractMavenDialog extends SelectionStatusDialog {
     return result;
   }
 
+  @Override
   protected Point getInitialLocation(Point initialSize) {
     Point result = super.getInitialLocation(initialSize);
     if(location != null) {
@@ -96,6 +98,7 @@ public abstract class AbstractMavenDialog extends SelectionStatusDialog {
     return result;
   }
 
+  @Override
   public boolean close() {
     writeSettings();
     return super.close();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/AssignWorkingSetDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/AssignWorkingSetDialog.java
@@ -58,6 +58,7 @@ public class AssignWorkingSetDialog extends TitleAreaDialog {
     this.initialSelection = initialSelection;
   }
 
+  @Override
   protected Control createDialogArea(Composite parent) {
     setTitle(Messages.AssignWorkingSetDialog_title);
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/EditDependencyDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/EditDependencyDialog.java
@@ -108,6 +108,7 @@ public class EditDependencyDialog extends AbstractMavenDialog {
     }
   }
 
+  @Override
   protected Control createDialogArea(Composite parent) {
     readSettings();
     Composite superComposite = (Composite) super.createDialogArea(parent);
@@ -209,6 +210,7 @@ public class EditDependencyDialog extends AbstractMavenDialog {
     return resultOperation;
   }
 
+  @Override
   protected void computeResult() {
     final String oldArtifactId = dependency.getArtifactId();
     final String oldGroupId = dependency.getGroupId();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/InputHistory.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/InputHistory.java
@@ -173,14 +173,17 @@ public class InputHistory {
       this.combo = combo;
     }
 
+    @Override
     protected String getText() {
       return combo.getText();
     }
 
+    @Override
     protected String[] getItems() {
       return combo.getItems();
     }
 
+    @Override
     protected void setItems(String[] items) {
       String value = combo.getText();
       combo.setItems(items);
@@ -201,10 +204,12 @@ public class InputHistory {
       this.combo = combo;
     }
 
+    @Override
     protected String getText() {
       return combo.getText();
     }
 
+    @Override
     protected String[] getItems() {
       try {
         return combo.getItems();
@@ -214,6 +219,7 @@ public class InputHistory {
       }
     }
 
+    @Override
     protected void setItems(String[] items) {
       String value = combo.getText();
       combo.setItems(items);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenMessageDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenMessageDialog.java
@@ -53,6 +53,7 @@ public class MavenMessageDialog extends MessageDialog {
   /* (non-Javadoc)
    * @see org.eclipse.jface.dialogs.MessageDialog#createCustomArea(org.eclipse.swt.widgets.Composite)
    */
+  @Override
   protected Control createCustomArea(Composite parent) {
     // TODO Auto-generated method createCustomArea
     this.messageArea = new StyledText(parent, SWT.WRAP | SWT.READ_ONLY | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenPropertyDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenPropertyDialog.java
@@ -61,6 +61,7 @@ public class MavenPropertyDialog extends Dialog {
   /* (non-Javadoc)
    * @see org.eclipse.jface.dialogs.Dialog#createDialogArea(org.eclipse.swt.widgets.Composite)
    */
+  @Override
   protected Control createDialogArea(Composite parent) {
     Composite comp = new Composite(parent, SWT.NONE);
     GridLayout gridLayout = new GridLayout(2, false);
@@ -129,6 +130,7 @@ public class MavenPropertyDialog extends Dialog {
   /* (non-Javadoc)
    * @see org.eclipse.jface.dialogs.Dialog#buttonPressed(int)
    */
+  @Override
   protected void buttonPressed(int buttonId) {
     if(buttonId == IDialogConstants.OK_ID) {
       name = nameText.getText();
@@ -143,6 +145,7 @@ public class MavenPropertyDialog extends Dialog {
   /* (non-Javadoc)
    * @see org.eclipse.jface.window.Window#configureShell(org.eclipse.swt.widgets.Shell)
    */
+  @Override
   protected void configureShell(Shell shell) {
     super.configureShell(shell);
     if(title != null) {
@@ -178,6 +181,7 @@ public class MavenPropertyDialog extends Dialog {
    *
    * @see org.eclipse.jface.window.Window#create()
    */
+  @Override
   public void create() {
     super.create();
     updateButtons();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenRepositorySearchDialog.java
@@ -223,6 +223,7 @@ public class MavenRepositorySearchDialog extends AbstractMavenDialog {
     this.queryText = query;
   }
 
+  @Override
   protected Control createDialogArea(Composite parent) {
     readSettings();
 
@@ -385,6 +386,7 @@ public class MavenRepositorySearchDialog extends AbstractMavenDialog {
   /* (non-Javadoc)
    * @see org.eclipse.ui.dialogs.SelectionStatusDialog#computeResult()
    */
+  @Override
   protected void computeResult() {
     if(showCoords) {
       computeResultFromField(valueOrNull(txtGroupId.getText()), valueOrNull(txtArtifactId.getText()),

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/UpdateMavenProjectsDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/UpdateMavenProjectsDialog.java
@@ -149,6 +149,7 @@ public class UpdateMavenProjectsDialog extends TitleAreaDialog {
     createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
   }
 
+  @Override
   protected void okPressed() {
     selectedProjects = nestedProjectsComposite.getSelectedProjects();
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddDependencyOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddDependencyOperation.java
@@ -34,6 +34,7 @@ public class AddDependencyOperation implements Operation {
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.editing.PomEdits.Operation#process(org.w3c.dom.Document)
    */
+  @Override
   public void process(Document document) {
     Element dependencies = getChild(document.getDocumentElement(), DEPENDENCIES);
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddExclusionOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/AddExclusionOperation.java
@@ -47,6 +47,7 @@ public class AddExclusionOperation implements Operation {
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.editing.PomEdits.Operation#process(org.w3c.dom.Document)
    */
+  @Override
   public void process(Document document) {
     Element depElement = PomHelper.findDependency(document, dependency);
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/ChangeCreator.java
@@ -108,6 +108,7 @@ public class ChangeCreator {
     /*
      * @see org.eclipse.compare.rangedifferencer.IRangeComparator#getRangeCount()
      */
+    @Override
     public int getRangeCount() {
       return document.getNumberOfLines();
     }
@@ -115,6 +116,7 @@ public class ChangeCreator {
     /*
      * @see org.eclipse.compare.rangedifferencer.IRangeComparator#rangesEqual(int, org.eclipse.compare.rangedifferencer.IRangeComparator, int)
      */
+    @Override
     public boolean rangesEqual(int thisIndex, IRangeComparator other, int otherIndex) {
       try {
         return getHash(thisIndex).equals(((LineComparator) other).getHash(otherIndex));
@@ -127,6 +129,7 @@ public class ChangeCreator {
     /*
      * @see org.eclipse.compare.rangedifferencer.IRangeComparator#skipRangeComparison(int, int, org.eclipse.compare.rangedifferencer.IRangeComparator)
      */
+    @Override
     public boolean skipRangeComparison(int length, int maxLength, IRangeComparator other) {
       return false;
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/LifecycleMappingOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/LifecycleMappingOperation.java
@@ -94,6 +94,7 @@ public class LifecycleMappingOperation implements Operation {
     this.createAtTopLevel = createAtTopLevel;
   }
 
+  @Override
   public void process(Document document) {
     Element root = document.getDocumentElement();
     Element pluginExecutions; // add the new plugins here

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
@@ -667,6 +667,7 @@ public class PomEdits {
       this.operations = operations;
     }
 
+    @Override
     public void process(Document document) {
       for(Operation oper : operations) {
         oper.process(document);
@@ -726,7 +727,8 @@ public class PomEdits {
     return new Matcher() {
       int count = 0;
 
-      public boolean matches(Element child) {
+        @Override
+        public boolean matches(Element child) {
         if(count == index) {
           return true;
         }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/RemoveDependencyOperation.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/RemoveDependencyOperation.java
@@ -34,6 +34,7 @@ public class RemoveDependencyOperation implements Operation {
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.editing.PomEdits.Operation#process(org.w3c.dom.Document)
    */
+  @Override
   public void process(Document document) {
     Element dependencyElement = PomHelper.findDependency(document, dependency);
     if(dependencyElement != null) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/AggregateMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/AggregateMappingLabelProvider.java
@@ -49,6 +49,7 @@ public class AggregateMappingLabelProvider implements ILifecycleMappingLabelProv
     this.element = element;
   }
 
+  @Override
   public String getMavenText() {
     if(element instanceof LifecycleStrategyMappingRequirement) {
       return NLS.bind("Connector {0}", ((LifecycleStrategyMappingRequirement) element).getLifecycleMappingId());
@@ -66,6 +67,7 @@ public class AggregateMappingLabelProvider implements ILifecycleMappingLabelProv
     throw new IllegalStateException();
   }
 
+  @Override
   public boolean isError(LifecycleMappingDiscoveryRequest mappingConfiguration) {
     for(ILifecycleMappingLabelProvider pr : content) {
       if(pr.isError(mappingConfiguration)) {
@@ -79,10 +81,12 @@ public class AggregateMappingLabelProvider implements ILifecycleMappingLabelProv
     return content.toArray(new ILifecycleMappingLabelProvider[content.size()]);
   }
 
+  @Override
   public ILifecycleMappingRequirement getKey() {
     return element;
   }
 
+  @Override
   public Collection<MavenProject> getProjects() {
     Set<MavenProject> projects = new HashSet<>();
     for(ILifecycleMappingLabelProvider provider : content) {
@@ -91,10 +95,12 @@ public class AggregateMappingLabelProvider implements ILifecycleMappingLabelProv
     return projects;
   }
 
+  @Override
   public int hashCode() {
     return getMavenText().hashCode();
   }
 
+  @Override
   public boolean equals(Object other) {
     if(other instanceof AggregateMappingLabelProvider) {
       return other.hashCode() == hashCode();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/MojoExecutionMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/MojoExecutionMappingLabelProvider.java
@@ -46,6 +46,7 @@ public class MojoExecutionMappingLabelProvider implements ILifecycleMappingLabel
     this.prjconf = prjconf;
   }
 
+  @Override
   public String getMavenText() {
     MojoExecutionKey execution = element.getExecution();
     if("default".equals(execution.getExecutionId())) {
@@ -58,6 +59,7 @@ public class MojoExecutionMappingLabelProvider implements ILifecycleMappingLabel
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.lifecyclemapping.ILifecycleMappingLabelProvider#isError()
    */
+  @Override
   public boolean isError(LifecycleMappingDiscoveryRequest mappingConfiguration) {
     ILifecycleMappingRequirement requirement = element.getLifecycleMappingRequirement();
     return LifecycleMappingFactory.isInterestingPhase(element.getMojoExecutionKey().getLifecyclePhase())
@@ -67,6 +69,7 @@ public class MojoExecutionMappingLabelProvider implements ILifecycleMappingLabel
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.lifecyclemapping.ILifecycleMappingLabelProvider#getKey()
    */
+  @Override
   public ILifecycleMappingRequirement getKey() {
     return element.getLifecycleMappingRequirement();
   }
@@ -74,6 +77,7 @@ public class MojoExecutionMappingLabelProvider implements ILifecycleMappingLabel
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.lifecyclemapping.ILifecycleMappingLabelProvider#getProjects()
    */
+  @Override
   public Collection<MavenProject> getProjects() {
     return Collections.singleton(prjconf.getMavenProject());
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/PackagingTypeMappingLabelProvider.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/lifecyclemapping/PackagingTypeMappingLabelProvider.java
@@ -42,6 +42,7 @@ public class PackagingTypeMappingLabelProvider implements ILifecycleMappingLabel
     this.prjconf = prjconf;
   }
 
+  @Override
   public String getMavenText() {
     return prjconf.getRelpath();
   }
@@ -49,6 +50,7 @@ public class PackagingTypeMappingLabelProvider implements ILifecycleMappingLabel
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.lifecyclemapping.ILifecycleMappingLabelProvider#isError()
    */
+  @Override
   public boolean isError(LifecycleMappingDiscoveryRequest mappingConfiguration) {
     return !mappingConfiguration.isRequirementSatisfied(getKey());
   }
@@ -56,6 +58,7 @@ public class PackagingTypeMappingLabelProvider implements ILifecycleMappingLabel
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.lifecyclemapping.ILifecycleMappingLabelProvider#getKey()
    */
+  @Override
   public ILifecycleMappingRequirement getKey() {
     return element.getLifecycleMappingRequirement();
   }
@@ -63,6 +66,7 @@ public class PackagingTypeMappingLabelProvider implements ILifecycleMappingLabel
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.ui.internal.lifecyclemapping.ILifecycleMappingLabelProvider#getProjects()
    */
+  @Override
   public Collection<MavenProject> getProjects() {
     return Collections.singleton(prjconf.getMavenProject());
   }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/EditorAwareMavenProblemResolution.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/EditorAwareMavenProblemResolution.java
@@ -44,6 +44,7 @@ public abstract class EditorAwareMavenProblemResolution extends MavenProblemReso
     this.context = context;
   }
 
+  @Override
   protected final void fix(IMarker[] markers, IDocument document, IProgressMonitor monitor) {
 
     Map<IResource, List<IMarker>> resourceMap = Stream.of(markers).collect(Collectors.groupingBy(IMarker::getResource));

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -90,6 +90,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
 
   public static final String ATTR_MANAGED_VERSION_LOCATION = "managedVersionLocation"; //$NON-NLS-1$
 
+  @Override
   public void findLocationForMarker(final IMarker marker) {
     IDOMModel domModel = null;
     try {
@@ -143,7 +144,8 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
         final String exec = marker.getAttribute(IMavenConstants.MARKER_ATTR_EXECUTION_ID, "");
         final String goal = marker.getAttribute(IMavenConstants.MARKER_ATTR_GOAL, "");
         XmlUtils.performOnRootElement((IFile) marker.getResource(), new NodeOperation<Element>() {
-          public void process(Element root, IStructuredDocument structuredDocument) {
+            @Override
+            public void process(Element root, IStructuredDocument structuredDocument) {
             Element build = findChild(root, PomEdits.BUILD);
             List<Element> candidates = new ArrayList<>();
             Element plugin = findPlugin(build, groupId, artifactId);
@@ -246,6 +248,7 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
     }
   }
 
+  @Override
   public void addEditorHintMarkers(IMavenMarkerManager markerManager, IFile pom, MavenProject mavenProject,
       String type) {
     checkForSchema(markerManager, pom, type);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerResolutionGenerator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerResolutionGenerator.java
@@ -35,10 +35,12 @@ import org.eclipse.m2e.core.ui.internal.UpdateMavenProjectJob;
 @SuppressWarnings("restriction")
 public class MarkerResolutionGenerator implements IMarkerResolutionGenerator, IMarkerResolutionGenerator2 {
 
-  public boolean hasResolutions(IMarker marker) {
+    @Override
+    public boolean hasResolutions(IMarker marker) {
     return true;
   }
 
+  @Override
   public IMarkerResolution[] getResolutions(IMarker marker) {
     return new IMarkerResolution[] {new RefreshResolution(marker)};
   }
@@ -49,27 +51,33 @@ public class MarkerResolutionGenerator implements IMarkerResolutionGenerator, IM
       super(marker);
     }
 
+    @Override
     public String getDescription() {
       return Messages.MarkerResolutionGenerator_desc;
     }
 
+    @Override
     public Image getImage() {
       return null;
     }
 
+    @Override
     public String getLabel() {
       return Messages.MarkerResolutionGenerator_label;
     }
 
+    @Override
     public boolean isSingleton() {
       return true;
     }
 
+    @Override
     public void fix(IMarker[] markers, IDocument doc, IProgressMonitor monitor) {
       final Set<IProject> projects = getProjects(Stream.of(markers));
       new UpdateMavenProjectJob(projects.toArray(new IProject[projects.size()])).schedule();
     }
 
+    @Override
     public boolean canFix(IMarker marker) throws CoreException {
       return IMavenConstants.MARKER_CONFIGURATION_ID.equals(marker.getType());
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MavenProblemResolution.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MavenProblemResolution.java
@@ -82,39 +82,48 @@ public abstract class MavenProblemResolution extends WorkbenchMarkerResolution
 
   public abstract boolean canFix(IMarker marker) throws CoreException;
 
+  @Override
   public Point getSelection(IDocument document) {
     return null;
   }
 
+  @Override
   public final String getDisplayString() {
     return getLabel();
   }
 
+  @Override
   public String getDescription() {
     return getLabel();
   }
 
+  @Override
   public String getAdditionalProposalInfo() {
     Object o = getAdditionalProposalInfo(new NullProgressMonitor());
     return o == null ? null : o.toString();
   }
 
+  @Override
   public Object getAdditionalProposalInfo(IProgressMonitor monitor) {
     return getDescription();
   }
 
+  @Override
   public IContextInformation getContextInformation() {
     return null;
   }
 
+  @Override
   public final void run(IMarker marker) {
     run(marker, null);
   }
 
+  @Override
   public final void apply(IDocument document) {
     run(marker, document);
   }
 
+  @Override
   public final void run(IMarker[] markers, IProgressMonitor monitor) {
     fix(markers, null, monitor);
   }
@@ -155,6 +164,7 @@ public abstract class MavenProblemResolution extends WorkbenchMarkerResolution
     return result.toArray(new IMarker[result.size()]);
   }
 
+  @Override
   public final IMarker[] findOtherMarkers(IMarker[] markers) {
     return findOtherMarkers(markers, false);
   }


### PR DESCRIPTION
Not sure if you care for @Override annotations and if it is useful to clean up this way? It's a lot of changes.

EclipseJdt cleanup 'AddMissingOverrideAnnotation' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
