### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unnecessary '$NON-NLS$' tag

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
@@ -118,7 +118,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       StringBuilder buffer = new StringBuilder();
       Model model = project.getProject().getModel();
       buffer.append(model.getGroupId()).append(" : ") //$NON-NLS-1$
-          .append(model.getArtifactId()).append(" : ") //$NON-NLS-2$
+          .append(model.getArtifactId()).append(" : ")
           .append(model.getVersion());
       return buffer.toString();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/PomHierarchyComposite.java
@@ -118,7 +118,7 @@ public class PomHierarchyComposite extends Composite implements IInputSelectionP
       StringBuilder buffer = new StringBuilder();
       Model model = project.getProject().getModel();
       buffer.append(model.getGroupId()).append(" : ") //$NON-NLS-1$
-          .append(model.getArtifactId()).append(" : ")
+          .append(model.getArtifactId()).append(" : ") //$NON-NLS-1$
           .append(model.getVersion());
       return buffer.toString();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/editing/PomEdits.java
@@ -502,7 +502,7 @@ public class PomEdits {
             doc.appendChild(project);
 
             Element modelVersion = doc.createElement(MODEL_VERSION);
-            modelVersion.appendChild(doc.createTextNode(MODEL_VERSION_VALUE)); //$NON-NLS-1$
+            modelVersion.appendChild(doc.createTextNode(MODEL_VERSION_VALUE));
             project.appendChild(modelVersion);
             format(project);
           }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -506,12 +506,12 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
 
     //now we have all the candidates, match them against the effective managed set
     for(Element dep : candidates) {
-      String grpString = getTextValue(findChild(dep, PomEdits.GROUP_ID)); //$NON-NLS-1$
+      String grpString = getTextValue(findChild(dep, PomEdits.GROUP_ID));
       if(grpString == null) {
         grpString = "org.apache.maven.plugins"; //$NON-NLS-1$
       }
-      String artString = getTextValue(findChild(dep, PomEdits.ARTIFACT_ID)); //$NON-NLS-1$
-      Element version = findChild(dep, PomEdits.VERSION); //$NON-NLS-1$
+      String artString = getTextValue(findChild(dep, PomEdits.ARTIFACT_ID));
+      Element version = findChild(dep, PomEdits.VERSION);
       String versionString = getTextValue(version);
       if(artString != null && versionString != null) {
         String id = Plugin.constructKey(grpString, artString);
@@ -571,11 +571,11 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
         }
       }
     }
-    Element version = findChild(root, PomEdits.VERSION); //$NON-NLS-1$
+    Element version = findChild(root, PomEdits.VERSION);
     ProblemSeverity matchingParentVersionSeverity = getMatchingParentVersionSeverity();
     if(parent != null && version != null && !ProblemSeverity.ignore.equals(matchingParentVersionSeverity)) {
       //now compare the values of parent and project version..
-      String parentString = getTextValue(findChild(parent, PomEdits.VERSION)); //$NON-NLS-1$
+      String parentString = getTextValue(findChild(parent, PomEdits.VERSION));
       String childString = getTextValue(version);
       if(parentString != null && parentString.equals(childString)) {
         //now figure out the offset

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/NexusIndexManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/NexusIndexManager.java
@@ -374,8 +374,8 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
       // query = new PrefixQuery(new Term(ArtifactInfo.GROUP_ID, term));
     } else if(IIndex.SEARCH_ARTIFACT.equals(type)) {
       BooleanQuery.Builder bq = new BooleanQuery.Builder();
-      bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD); //$NON-NLS-1$
-      bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD); //$NON-NLS-1$
+      bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD);
+      bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD);
       bq.add(
           constructQuery(MAVEN.SHA1, term.getStringValue(), term.getStringValue().length() == 40 ? SearchType.EXACT
               : SearchType.SCORED), Occur.SHOULD);
@@ -387,8 +387,8 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
         query = constructQuery(MAVEN.PACKAGING, "pom", SearchType.EXACT); //$NON-NLS-1$
       } else {
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
-        bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD); //$NON-NLS-1$
-        bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD); //$NON-NLS-1$
+        bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD);
+        bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD);
         bq.add(
             constructQuery(MAVEN.SHA1, term.getStringValue(), term.getStringValue().length() == 40 ? SearchType.EXACT
                 : SearchType.SCORED), Occur.SHOULD);
@@ -404,8 +404,8 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
         query = constructQuery(MAVEN.PACKAGING, "maven-plugin", SearchType.EXACT); //$NON-NLS-1$
       } else {
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
-        bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD); //$NON-NLS-1$
-        bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD); //$NON-NLS-1$
+        bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD);
+        bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD);
         Query tq = constructQuery(MAVEN.PACKAGING, "maven-plugin", SearchType.EXACT); //$NON-NLS-1$
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         builder.add(bq.build(), Occur.MUST);
@@ -415,8 +415,8 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
 
     } else if(IIndex.SEARCH_ARCHETYPE.equals(type)) {
       BooleanQuery.Builder bq = new BooleanQuery.Builder();
-      bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD); //$NON-NLS-1$
-      bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD); //$NON-NLS-1$
+      bq.add(constructQuery(MAVEN.GROUP_ID, term), Occur.SHOULD);
+      bq.add(constructQuery(MAVEN.ARTIFACT_ID, term), Occur.SHOULD);
       Query tq = constructQuery(MAVEN.PACKAGING, "maven-archetype", SearchType.EXACT); //$NON-NLS-1$
       BooleanQuery.Builder builder = new BooleanQuery.Builder();
       builder.add(bq.build(), Occur.MUST);
@@ -615,7 +615,7 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
         IndexingContext context = getIndexingContext(repository);
         if(context == null) {
           String msg = "Unable to find document to remove" + getDocumentKey(key);
-          log.error(msg); //$NON-NLS-1$
+          log.error(msg);
           return;
         }
         ArtifactContext artifactContext;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
@@ -176,7 +176,7 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
 
     if(embedder != null) {
       StringBuilder sb = new StringBuilder();
-      sb.append(getVersion(embedder)); //$NON-NLS-1$
+      sb.append(getVersion(embedder));
       String version = embedder.getHeaders().get(Constants.BUNDLE_VERSION);
       sb.append('/').append(version);
       return sb.toString();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/MavenMarkerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/MavenMarkerManager.java
@@ -292,16 +292,16 @@ public class MavenMarkerManager implements IMavenMarkerManager {
       CoreException cex = (CoreException) cause;
       IStatus status = cex.getStatus();
       if(status != null) {
-        addMarker(resource, type, status.getMessage(), 1, IMarker.SEVERITY_ERROR, false /*isTransient*/); //$NON-NLS-1$
+        addMarker(resource, type, status.getMessage(), 1, IMarker.SEVERITY_ERROR, false /*isTransient*/);
         IStatus[] children = status.getChildren();
         if(children != null) {
           for(IStatus childStatus : children) {
-            addMarker(resource, type, childStatus.getMessage(), 1, IMarker.SEVERITY_ERROR, false /*isTransient*/); //$NON-NLS-1$
+            addMarker(resource, type, childStatus.getMessage(), 1, IMarker.SEVERITY_ERROR, false /*isTransient*/);
           }
         }
       }
     } else {
-      addMarker(resource, type, cause.getMessage(), 1, IMarker.SEVERITY_ERROR, false /*isTransient*/); //$NON-NLS-1$
+      addMarker(resource, type, cause.getMessage(), 1, IMarker.SEVERITY_ERROR, false /*isTransient*/);
     }
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
@@ -106,7 +106,7 @@ public class LocalProjectScanner extends AbstractProjectScanner<MavenProjectInfo
       return;
     }
 
-    MavenProjectInfo projectInfo = readMavenProjectInfo(baseDir, rootRelPath, null); //$NON-NLS-1$
+    MavenProjectInfo projectInfo = readMavenProjectInfo(baseDir, rootRelPath, null);
     if(projectInfo != null) {
       addProject(projectInfo);
       return; // don't scan subfolders of the Maven project

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ProjectImportConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ProjectImportConfiguration.java
@@ -142,7 +142,7 @@ public class ProjectImportConfiguration {
     // check if project already exists
     if(workspace.getRoot().getProject(projectName).exists()) {
       return new Status(IStatus.ERROR, IMavenConstants.PLUGIN_ID, 0,
-          NLS.bind(Messages.importProjectExists, projectName), null); //$NON-NLS-1$
+          NLS.bind(Messages.importProjectExists, projectName), null);
     }
 
     return Status.OK_STATUS;

--- a/org.eclipse.m2e.editor.xml/src/org/eclipse/m2e/editor/xml/InsertArtifactProposal.java
+++ b/org.eclipse.m2e.editor.xml/src/org/eclipse/m2e/editor/xml/InsertArtifactProposal.java
@@ -172,7 +172,7 @@ public class InsertArtifactProposal implements ICompletionProposal, ICompletionP
                 }
                 plugin = createElement(getChild(build, PLUGINS), PLUGIN);
               }
-              if(BUILD.equals(currentName) || PLUGIN_MANAGEMENT.equals(currentName)) { //$NON-NLS-1$ //$NON-NLS-2$
+              if(BUILD.equals(currentName) || PLUGIN_MANAGEMENT.equals(currentName)) {
                 Element plugins = findChild(currentNode, PLUGINS);
                 if(plugins == null) {
                   plugins = insertAt(doc.createElement(PLUGINS), fOffset);
@@ -214,7 +214,7 @@ public class InsertArtifactProposal implements ICompletionProposal, ICompletionP
               String currentName = currentNode.getNodeName();
               Element dependency = null;
               Element toFormat = null;
-              if("project".equals(currentName) || DEPENDENCY_MANAGEMENT.equals(currentName) || PROFILE.equals(currentName)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+              if("project".equals(currentName) || DEPENDENCY_MANAGEMENT.equals(currentName) || PROFILE.equals(currentName)) { //$NON-NLS-1$
                 Element deps = findChild(currentNode, DEPENDENCIES);
                 if(deps == null) {
                   deps = insertAt(doc.createElement(DEPENDENCIES), fOffset);

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/AbstractPomProblemResolution.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/AbstractPomProblemResolution.java
@@ -96,7 +96,7 @@ public abstract class AbstractPomProblemResolution extends EditorAwareMavenProbl
         nextString = nextString.replace("\t", "  "); //$NON-NLS-1$ //$NON-NLS-2$
         prevString = StringUtils.convertToHTMLContent(prevString);
         nextString = StringUtils.convertToHTMLContent(nextString);
-        return "<html>...<br>" + prevString + /** "<del>" + currentLine + "</del>" + */ //$NON-NLS-0$
+        return "<html>...<br>" + prevString + /** "<del>" + currentLine + "</del>" + */
             nextString + "...<html>"; //$NON-NLS-1$
       } catch(BadLocationException e) {
         // TODO Auto-generated catch block

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/ManagedVersionRemovalResolution.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/ManagedVersionRemovalResolution.java
@@ -93,7 +93,7 @@ public class ManagedVersionRemovalResolution extends AbstractPomProblemResolutio
           LOG.error("Unable to find the marked element"); //$NON-NLS-1$
           continue;
         }
-        Element value = XmlUtils.findChild(artifact, VERSION_NODE); //$NON-NLS-1$ //$NON-NLS-2$
+        Element value = XmlUtils.findChild(artifact, VERSION_NODE);
         if(value instanceof IndexedRegion) {
           IndexedRegion off = (IndexedRegion) value;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
@@ -289,10 +289,10 @@ public abstract class MavenPomEditorPage extends FormPage {
             if(toAdd != null) {
               //errors get prepended while warnings get appended.
               if(toAdd.getAttribute(IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR) {
-                text = NLS.bind(Messages.MavenPomEditorPage_error_add, toAdd.getAttribute(IMarker.MESSAGE, "")) + text; //$NON-NLS-2$
+                text = NLS.bind(Messages.MavenPomEditorPage_error_add, toAdd.getAttribute(IMarker.MESSAGE, "")) + text;
               } else {
                 text = text
-                    + NLS.bind(Messages.MavenPomEditorPage_warning_add, toAdd.getAttribute(IMarker.MESSAGE, "")); //$NON-NLS-2$
+                    + NLS.bind(Messages.MavenPomEditorPage_warning_add, toAdd.getAttribute(IMarker.MESSAGE, ""));
               }
             }
           }

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomHyperlinkDetector.java
@@ -146,10 +146,10 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
     if(current != null) {
       Node artNode = null;
       Node groupNode = null;
-      if(ARTIFACT_ID.equals(current.getNodeName())) { //$NON-NLS-1$
+      if(ARTIFACT_ID.equals(current.getNodeName())) {
         artNode = current;
       }
-      if(GROUP_ID.equals(current.getNodeName())) { //$NON-NLS-1$
+      if(GROUP_ID.equals(current.getNodeName())) {
         groupNode = current;
       }
       //only on artifactid and groupid elements..
@@ -161,10 +161,10 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
       boolean isPlugin = false;
       if(root != null) {
         String name = root.getNodeName();
-        if(DEPENDENCY.equals(name)) { //$NON-NLS-1$
+        if(DEPENDENCY.equals(name)) {
           isDependency = true;
         }
-        if(PLUGIN.equals(name)) { //$NON-NLS-1$
+        if(PLUGIN.equals(name)) {
           isPlugin = true;
         }
       } else {
@@ -180,13 +180,13 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
         Node child = childs.item(i);
         if(child instanceof Element) {
           Element el = (Element) child;
-          if(VERSION.equals(el.getNodeName())) { //$NON-NLS-1$
+          if(VERSION.equals(el.getNodeName())) {
             return null;
           }
-          if(artNode == null && ARTIFACT_ID.equals(el.getNodeName())) { //$NON-NLS-1$
+          if(artNode == null && ARTIFACT_ID.equals(el.getNodeName())) {
             artNode = el;
           }
-          if(groupNode == null && GROUP_ID.equals(el.getNodeName())) { //$NON-NLS-1$
+          if(groupNode == null && GROUP_ID.equals(el.getNodeName())) {
             groupNode = el;
           }
         }
@@ -264,7 +264,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
         if(list != null) {
           for(Dependency dep : list) {
             if(dep.getManagementKey().startsWith(id)) {
-              InputLocation location = dep.getLocation(ARTIFACT_ID); //$NON-NLS-1$
+              InputLocation location = dep.getLocation(ARTIFACT_ID);
               //when would this be null?
               if(location != null) {
                 openLocation = location;
@@ -285,7 +285,7 @@ public class PomHyperlinkDetector implements IHyperlinkDetector {
           if(list != null) {
             for(Plugin plg : list) {
               if(id.equals(plg.getKey())) {
-                InputLocation location = plg.getLocation(ARTIFACT_ID); //$NON-NLS-1$
+                InputLocation location = plg.getLocation(ARTIFACT_ID);
                 //when would this be null?
                 if(location != null) {
                   openLocation = location;

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
@@ -365,7 +365,7 @@ public enum PomTemplateContext {
           //if groupid is the same, suggest ${project.version}
           if(groupId != null && groupId.equals(mvn.getGroupId())) {
             proposals.add(new Template("${project.version}", Messages.PomTemplateContext_project_version_hint, //$NON-NLS-1$
-                contextTypeId, "$${project.version}", false)); //$NON-NLS-3$
+                contextTypeId, "$${project.version}", false));
           }
           Properties props = mvn.getProperties();
           if(props != null) {
@@ -381,7 +381,7 @@ public enum PomTemplateContext {
               for(String key : keys) {
                 String expr = "${" + key + "}"; //$NON-NLS-1$ //$NON-NLS-2$
                 proposals.add(new Template(expr, Messages.PomTemplateContext_expression_description, contextTypeId,
-                    "$" + expr, false)); //$NON-NLS-2$ //$NON-NLS-1$
+                    "$" + expr, false)); //$NON-NLS-1$
               }
             }
           }
@@ -400,7 +400,7 @@ public enum PomTemplateContext {
             }
             if(groupId != null && groupId.equals(currentgroupid)) {
               proposals.add(new Template("${project.version}", Messages.PomTemplateContext_project_version_hint, //$NON-NLS-1$
-                  contextTypeId, "$${project.version}", false)); //$NON-NLS-3$
+                  contextTypeId, "$${project.version}", false));
             }
           }
         }

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContext.java
@@ -365,7 +365,7 @@ public enum PomTemplateContext {
           //if groupid is the same, suggest ${project.version}
           if(groupId != null && groupId.equals(mvn.getGroupId())) {
             proposals.add(new Template("${project.version}", Messages.PomTemplateContext_project_version_hint, //$NON-NLS-1$
-                contextTypeId, "$${project.version}", false));
+                contextTypeId, "$${project.version}", false));//$NON-NLS-1$
           }
           Properties props = mvn.getProperties();
           if(props != null) {
@@ -381,7 +381,7 @@ public enum PomTemplateContext {
               for(String key : keys) {
                 String expr = "${" + key + "}"; //$NON-NLS-1$ //$NON-NLS-2$
                 proposals.add(new Template(expr, Messages.PomTemplateContext_expression_description, contextTypeId,
-                    "$" + expr, false)); //$NON-NLS-1$
+                    '$' + expr, false));
               }
             }
           }
@@ -400,7 +400,7 @@ public enum PomTemplateContext {
             }
             if(groupId != null && groupId.equals(currentgroupid)) {
               proposals.add(new Template("${project.version}", Messages.PomTemplateContext_project_version_hint, //$NON-NLS-1$
-                  contextTypeId, "$${project.version}", false));
+                  contextTypeId, "$${project.version}", false));//$NON-NLS-1$
             }
           }
         }

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTextHover.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTextHover.java
@@ -110,8 +110,8 @@ public class PomTextHover implements ITextHover, ITextHoverExtension, ITextHover
       String loc = null;
       Model mdl = mavprj.getModel();
       if(mdl.getProperties() != null && mdl.getProperties().containsKey(region.property)) {
-        if(mdl.getLocation(PomEdits.PROPERTIES) != null) { //$NON-NLS-1$
-          InputLocation location = mdl.getLocation(PomEdits.PROPERTIES).getLocation(region.property); //$NON-NLS-1$
+        if(mdl.getLocation(PomEdits.PROPERTIES) != null) {
+          InputLocation location = mdl.getLocation(PomEdits.PROPERTIES).getLocation(region.property);
           if(location != null) {
             //MNGECLIPSE-2539 apparently you can have an InputLocation with null input source.
             // check!

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PropertiesSection.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PropertiesSection.java
@@ -184,7 +184,7 @@ public class PropertiesSection {
 
   void createNewProperty() {
     MavenPropertyDialog dialog = new MavenPropertyDialog(propertiesSection.getShell(), //
-        Messages.PropertiesSection_title_addProperty, "", "", listener); //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
+        Messages.PropertiesSection_title_addProperty, "", "", listener); //$NON-NLS-1$//$NON-NLS-2$
     if(dialog.open() == IDialogConstants.OK_ID) {
       final String key = dialog.getName();
       final String value = dialog.getValue();

--- a/org.eclipse.m2e.importer.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.importer.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.importer.tests
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.importer.tests/pom.xml
+++ b/org.eclipse.m2e.importer.tests/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 
   <artifactId>org.eclipse.m2e.importer.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>1.16.1-SNAPSHOT</version>
 
   <name>Tests for Maven Integration for Eclipse Importer framework</name>
 

--- a/org.eclipse.m2e.importer.tests/src/org/eclipse/m2e/importer/tests/MavenImporterTest.java
+++ b/org.eclipse.m2e.importer.tests/src/org/eclipse/m2e/importer/tests/MavenImporterTest.java
@@ -46,7 +46,7 @@ public class MavenImporterTest extends AbstractMavenProjectTestCase {
   @Before
   public void setUp() throws IOException {
     projectDirectory = new File(Files.createTempDirectory("m2e-tests").toFile(), "example1");
-    projectDirectory.mkdirs(); //$NON-NLS-1$ //$NON-NLS-2$
+    projectDirectory.mkdirs();
     copyDir(new File("resources/examples/example1"), projectDirectory);
 
     // Make sure projects don't have Eclipse metadata set

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -626,7 +626,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
       try {
         List<?> args = maven.getMojoParameterValue(mavenProject, execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
         if(args != null) {
-          generateParameters = args.contains(JavaSettingsUtils.PARAMETERS_JVM_FLAG);//$NON-NLS-1$
+          generateParameters = args.contains(JavaSettingsUtils.PARAMETERS_JVM_FLAG);
         }
       } catch(Exception ex) {
         //ignore
@@ -639,7 +639,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
         String compilerArgument = maven.getMojoParameterValue(mavenProject, execution, "compilerArgument", String.class, //$NON-NLS-1$
             monitor);
         if(compilerArgument != null) {
-          generateParameters = compilerArgument.contains(JavaSettingsUtils.PARAMETERS_JVM_FLAG);//$NON-NLS-1$
+          generateParameters = compilerArgument.contains(JavaSettingsUtils.PARAMETERS_JVM_FLAG);
         }
       } catch(CoreException ex) {
         //ignore
@@ -654,7 +654,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     //1st, check the --enable-preview flag in the compilerArgs list
     try {
       List<?> args = maven.getMojoParameterValue(mavenProject, execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
-      if(args != null && args.contains(JavaSettingsUtils.ENABLE_PREVIEW_JVM_FLAG)) {//$NON-NLS-1$
+      if(args != null && args.contains(JavaSettingsUtils.ENABLE_PREVIEW_JVM_FLAG)) {
         return true;
       }
     } catch(Exception ex) {
@@ -665,7 +665,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     try {
       String compilerArgument = maven.getMojoParameterValue(mavenProject, execution, "compilerArgument", String.class, //$NON-NLS-1$
           monitor);
-      if(compilerArgument != null && compilerArgument.contains(JavaSettingsUtils.ENABLE_PREVIEW_JVM_FLAG)) {//$NON-NLS-1$
+      if(compilerArgument != null && compilerArgument.contains(JavaSettingsUtils.ENABLE_PREVIEW_JVM_FLAG)) {
         return true;
       }
     } catch(CoreException ex) {
@@ -793,7 +793,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     } else {
       relative = absolutePath;
     }
-    return new Path(relative.replace('\\', '/')); //$NON-NLS-1$ //$NON-NLS-2$
+    return new Path(relative.replace('\\', '/'));
   }
 
   public void configureClasspath(IMavenProjectFacade facade, IClasspathDescriptor classpath, IProgressMonitor monitor) {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -220,7 +220,7 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
     }
 
     if(scope == IClasspathManager.CLASSPATH_TEST
-        && TESTKIND_ORG_ECLIPSE_JDT_JUNIT_LOADER_JUNIT5 //$NON-NLS-1$
+        && TESTKIND_ORG_ECLIPSE_JDT_JUNIT_LOADER_JUNIT5
             .equals(configuration.getAttribute(ATTRIBUTE_ORG_ECLIPSE_JDT_JUNIT_TEST_KIND, ""))) {
       addMissingJUnit5ExecutionDependencies(resolved, monitor, javaProject);
     }

--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 1.17.2.qualifier
+Bundle-Version: 1.17.3.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables,

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenRuntimeLaunchSupport.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenRuntimeLaunchSupport.java
@@ -280,7 +280,7 @@ public class MavenRuntimeLaunchSupport {
 
   public static void applyWorkspaceArtifacts(VMArguments properties) {
     File state = MavenPluginActivator.getDefault().getMavenProjectManager().getWorkspaceStateFile();
-    properties.appendProperty(WorkspaceState.SYSPROP_STATEFILE_LOCATION, quote(state.getAbsolutePath())); //$NON-NLS-1$
+    properties.appendProperty(WorkspaceState.SYSPROP_STATEFILE_LOCATION, quote(state.getAbsolutePath()));
   }
 
   public IVMRunner decorateVMRunner(final IVMRunner runner) {

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
@@ -196,7 +196,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
     gd_goalsLabel.horizontalAlignment = SWT.RIGHT;
     gd_goalsLabel.verticalIndent = 7;
     goalsLabel.setLayoutData(gd_goalsLabel);
-    goalsLabel.setText(Messages.launchGoalsLabel); //$NON-NLS-1$
+    goalsLabel.setText(Messages.launchGoalsLabel);
     goalsText = new Text(mainComposite, SWT.BORDER);
     goalsText.setData("name", "goalsText"); //$NON-NLS-1$ //$NON-NLS-2$
     GridData gd_goalsText = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
@@ -207,7 +207,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
     Label profilesLabel = new Label(mainComposite, SWT.NONE);
     profilesLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-    profilesLabel.setText(Messages.launchProfilesLabel); //$NON-NLS-1$
+    profilesLabel.setText(Messages.launchProfilesLabel);
     // profilesLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
 
     profilesText = new Text(mainComposite, SWT.BORDER);
@@ -340,19 +340,19 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
     final TableColumn propColumn = new TableColumn(this.propsTable, SWT.NONE, 0);
     propColumn.setWidth(120);
-    propColumn.setText(Messages.launchPropName); //$NON-NLS-1$
+    propColumn.setText(Messages.launchPropName);
 
     final TableColumn valueColumn = new TableColumn(this.propsTable, SWT.NONE, 1);
     valueColumn.setWidth(200);
-    valueColumn.setText(Messages.launchPropValue); //$NON-NLS-1$
+    valueColumn.setText(Messages.launchPropValue);
 
     final Button addPropButton = new Button(mainComposite, SWT.NONE);
     addPropButton.setLayoutData(new GridData(SWT.FILL, SWT.TOP, false, false));
-    addPropButton.setText(Messages.launchPropAddButton); //$NON-NLS-1$
+    addPropButton.setText(Messages.launchPropAddButton);
     addPropButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> addProperty()));
     editPropButton = new Button(mainComposite, SWT.NONE);
     editPropButton.setLayoutData(new GridData(SWT.FILL, SWT.TOP, false, false));
-    editPropButton.setText(Messages.launchPropEditButton); //$NON-NLS-1$
+    editPropButton.setText(Messages.launchPropEditButton);
     editPropButton.addSelectionListener(new SelectionAdapter() {
       public void widgetSelected(SelectionEvent e) {
         if(propsTable.getSelectionCount() > 0) {
@@ -366,7 +366,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
     editPropButton.setEnabled(false);
     removePropButton = new Button(mainComposite, SWT.NONE);
     removePropButton.setLayoutData(new GridData(SWT.FILL, SWT.TOP, false, false));
-    removePropButton.setText(Messages.launchPropRemoveButton); //$NON-NLS-1$
+    removePropButton.setText(Messages.launchPropRemoveButton);
     removePropButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
       if(propsTable.getSelectionCount() > 0) {
         propsTable.remove(propsTable.getSelectionIndices());
@@ -392,7 +392,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
   void addProperty() {
     MavenPropertyDialog dialog = getMavenPropertyDialog(
-        org.eclipse.m2e.internal.launch.Messages.MavenLaunchMainTab_property_dialog_title, "", ""); //$NON-NLS-2$ //$NON-NLS-3$
+        org.eclipse.m2e.internal.launch.Messages.MavenLaunchMainTab_property_dialog_title, "", ""); //$NON-NLS-2$
     if(dialog.open() == IDialogConstants.OK_ID) {
       TableItem item = new TableItem(propsTable, SWT.NONE);
       item.setText(0, dialog.getName());
@@ -424,7 +424,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
             variablesButton.computeSize(SWT.DEFAULT, SWT.DEFAULT, true).x);
         variablesButton.setLayoutData(gd);
         variablesButton.setFont(comp.getFont());
-        variablesButton.setText(Messages.launchPropertyDialogBrowseVariables); //$NON-NLS-1$;
+        variablesButton.setText(Messages.launchPropertyDialogBrowseVariables); //;
 
         variablesButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
           StringVariableSelectionDialog variablesDialog = new StringVariableSelectionDialog(getShell());
@@ -557,7 +557,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
   }
 
   public String getName() {
-    return Messages.launchMainTabName; //$NON-NLS-1$
+    return Messages.launchMainTabName;
   }
 
   public boolean isValid(ILaunchConfiguration launchConfig) {
@@ -631,7 +631,7 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
 
     public void widgetSelected(SelectionEvent e) {
       ContainerSelectionDialog dialog = new ContainerSelectionDialog(getShell(), //
-          ResourcesPlugin.getWorkspace().getRoot(), false, label); //$NON-NLS-1$
+          ResourcesPlugin.getWorkspace().getRoot(), false, label);
       dialog.showClosedProjects(false);
 
       int buttonId = dialog.open();


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnnecessaryNlsTag' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
