### PR TITLE
Add snapshot/latest to m2e's software repository and use it in m2e's Oomph setup (#224)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,14 +37,21 @@ pipeline {
 			steps {
 				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
+						deployM2ERepository()
+						{
+							echo Deploy m2e repo to ${1}
+							ssh genie.m2e@build.eclipse.org "\
+								rm -rf  ${1}/* && \
+								mkdir -p ${1}"
+							scp -r org.eclipse.m2e.site/target/repository/* genie.m2e@build.eclipse.org:${1}
+						}
 						M2E_VERSION=$(grep '<m2e.version>.*</m2e.version>' pom.xml | sed -e 's/.*<m2e.version>\\(.*\\)<\\/m2e.version>.*/\\1/')
-						DOWNLOAD_AREA=/home/data/httpd/download.eclipse.org/technology/m2e/snapshots/${M2E_VERSION}/latest
+						SNAPSHOT_VERSIONED_AREA=/home/data/httpd/download.eclipse.org/technology/m2e/snapshots/${M2E_VERSION}/latest
+						SNAPSHOT_LATEST_AREA=/home/data/httpd/download.eclipse.org/technology/m2e/snapshots/latest
+
 						echo M2E_VERSION=$M2E_VERSION
-						echo DOWNLOAD_AREA=$DOWNLOAD_AREA
-						ssh genie.m2e@build.eclipse.org "\
-							rm -rf  ${DOWNLOAD_AREA}/* && \
-							mkdir -p ${DOWNLOAD_AREA}"
-						scp -r org.eclipse.m2e.site/target/repository/* genie.m2e@build.eclipse.org:${DOWNLOAD_AREA}
+						deployM2ERepository $SNAPSHOT_VERSIONED_AREA
+						deployM2ERepository $SNAPSHOT_LATEST_AREA
 					'''
 				}
 			}

--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -92,7 +92,7 @@
     <requirement
         name="org.eclipse.m2e.pde.feature.feature.group"/>
     <repository
-        url="https://download.eclipse.org/technology/m2e/snapshots/1.18.0/latest/"/>
+        url="https://download.eclipse.org/technology/m2e/snapshots/latest/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
With this PR I suggest to add a `snapshot/latest` software repository for m2e like proposed in #224.
The final URL of the resulting repo should be `https://download.eclipse.org/technology/m2e/snapshots/latest`.

I'm not an expert Linux's sh shell and also have no corresponding Linux system easily available were I could test the change. Therefore I ask you to double check if the change in the Jenkins file is valid. Thanks in advance.

Additionally the new `snapshot/latest` repo is used in m2e's Oomph setup.