### PR TITLE
Update to Guava 30.1.0

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.10.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources;bundle-version="3.9.0",
  org.eclipse.core.filesystem;bundle-version="1.7.700",
- com.google.guava;bundle-version="[27.1,28.0)"
+ com.google.guava;bundle-version="[30.1,32.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.ide,
  org.eclipse.core.filesystem,
  org.eclipse.ui.forms,
- com.google.guava;bundle-version="[27.1,28.0)",
+ com.google.guava;bundle-version="[30.1,32.0)",
  org.eclipse.m2e.editor;bundle-version="1.16.0",
  org.eclipse.search;bundle-version="3.11.700",
  org.eclipse.ui.views

--- a/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
@@ -30,7 +30,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.filesystem;bundle-version="1.7.500",
  org.eclipse.m2e.discovery;bundle-version="1.16.0",
  org.eclipse.m2e.model.edit;bundle-version="1.16.0",
- com.google.guava;bundle-version="27.0.0"
+ com.google.guava;bundle-version="30.1.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.sourcelookup;singleton:=true
-Bundle-Version: 1.17.2.qualifier
+Bundle-Version: 1.17.3.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Name: %Bundle-Name
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.m2e.launching;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.expressions;bundle-version="3.4.400",
  org.eclipse.debug.ui;bundle-version="3.10.0",
  org.eclipse.core.resources,
- com.google.guava;bundle-version="[27.1,28.0)",
+ com.google.guava;bundle-version="[30.1,32.0)",
  com.google.gson;bundle-version="2.2.4",
  org.eclipse.core.variables;bundle-version="3.2.0"
 Import-Package: org.slf4j;version="[1.6.2,2.0.0)"

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -35,7 +35,6 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
 			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
 			<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
 			<unit id="ch.qos.logback.core" version="0.0.0"/>
 			<unit id="ch.qos.logback.classic" version="0.0.0"/>


### PR DESCRIPTION
- Bump minimum Guava version to 30.1.0 and eliminate 27.1.0 from target
  platform

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

@mickaelistria , anything I'm missing preventing such a change ? I recall Guava was updated in the maven-{runtime,indexer} bundles that embedded it, but I don't see why 27.1.0 was kept around for m2e.core.