### PR TITLE
Remove Maven builder and nature from projects without a pom.xml

### DIFF
--- a/org.eclipse.m2e.editor.lemminx.tests/.project
+++ b/org.eclipse.m2e.editor.lemminx.tests/.project
@@ -20,14 +20,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>

--- a/org.eclipse.m2e.editor.xml.sse.tests/.project
+++ b/org.eclipse.m2e.editor.xml.sse.tests/.project
@@ -20,14 +20,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>

--- a/target-platform/.project
+++ b/target-platform/.project
@@ -5,13 +5,7 @@
 	<projects>
 	</projects>
 	<buildSpec>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
The .project file of the `org.eclipse.m2e.editor.xml.sse.tests` and `target-platform` projects contains a Maven builder command and the Maven nature.
But both projects don't have a pom.xml file, so I think those builders and natures can be removed.
It looks like I have been the one who forgot to remove the builders and natures when removing the pom.xml files of those projects with PR #215.

