### PR TITLE
[TargetPlatform] use eclipse 4.20 release repository

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -6,7 +6,7 @@
 		<!-- Add current Eclipse to enable launches of debugged Eclipse-Applications -->
 		<location path="${eclipse_home}" type="Profile"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.20-I-builds/I20210526-2310/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.20"/>
 			<unit id="org.eclipse.platform.ide" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The integration build repositories are gone now, which is why the build fails.
This PR replaces the integration build repository with the eclipse 4.20 release repository in the target-platform.