### PR TITLE
Fix classpath for a maven project with multiple compile executions

### DIFF
--- a/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject;singleton:=true
-Bundle-Version: 1.17.3.qualifier
+Bundle-Version: 1.17.4.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Name: %Bundle-Name

--- a/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/ClasspathConfigurator.java
+++ b/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/ClasspathConfigurator.java
@@ -13,6 +13,7 @@
 package org.eclipse.m2e.binaryproject.internal;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -40,6 +41,10 @@ public class ClasspathConfigurator extends AbstractJavaProjectConfigurator {
 
   @Override
   protected void addProjectSourceFolders(IClasspathDescriptor classpath, ProjectConfigurationRequest request,
+      IProgressMonitor monitor) throws CoreException {}
+
+  @Override
+  protected void addProjectSourceFolders(IClasspathDescriptor classpath, Map<String, String> options, ProjectConfigurationRequest request,
       IProgressMonitor monitor) throws CoreException {}
 
   @Override

--- a/org.eclipse.m2e.jdt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt.tests/META-INF/MANIFEST.MF
@@ -1,10 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.jdt.tests;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.16.2.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
+ org.eclipse.ui.ide,
  org.eclipse.core.resources,
+ org.apache.commons.io;bundle-version="2.2.0",
+ org.eclipse.m2e.importer;bundle-version="[1.16.0,2.0.0)",
  org.junit;bundle-version="4.12.0",
  org.eclipse.m2e.jdt;bundle-version="1.16.0",
  org.eclipse.m2e.tests.common;bundle-version="1.16.0",

--- a/org.eclipse.m2e.jdt.tests/projects/parentproject/app/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/parentproject/app/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>parentproject</artifactId>
+    <groupId>com.example</groupId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>app</artifactId>
+  <version>1.0</version>
+
+  <name>app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>core</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+  <profiles>
+  <!-- Override the parent client.pom.xml's java11+ profile to override target of base-compile execution from 1.8 to 11-->
+    <profile>
+      <id>java-lts</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
+            <configuration>
+              <testRelease>11</testRelease>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <configuration>
+                  <release>11</release>
+                </configuration>
+              </execution>
+              <!-- Here the 'base-compile' execution section of java-lts profile defined in parent pom.xml is overridden.
+               In parent pom, this execution entry enforces java8 release compatibility. The new http APIs are not available
+               in Java8, hence here in this pom we override that release compact to 11.
+              -->
+              <execution>
+                <id>base-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <release>11</release>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/org.eclipse.m2e.jdt.tests/projects/parentproject/core/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/parentproject/core/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>parentproject</artifactId>
+    <groupId>com.example</groupId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>core</artifactId>
+  <version>1.0</version>
+
+  <name>core</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/org.eclipse.m2e.jdt.tests/projects/parentproject/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/parentproject/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parentproject</artifactId>
+  <version>1.0</version>
+  <name>parentproject</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+  <packaging>pom</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <pluginManagement>
+      <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  <modules>
+    <module>core</module>
+    <module>app</module>
+  </modules>
+
+  <profiles>
+
+    <!-- Skip module-info.java on Java 8 -->
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>[1.8,9)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Don't compile module-info.java, see java 9+ profile -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Setup for Java 11+ -->
+    <profile>
+      <id>java-lts</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
+            <configuration>
+              <testRelease>11</testRelease>
+              <compilerArgs combine.children="append">
+                <arg>-Xlint:-module</arg> <!-- FIXME: this is required for now as it introduces a build failure -->
+                <arg>-Xlint:-requires-transitive-automatic</arg> <!-- FIXME: this is required for now as it introduces a build failure -->
+              </compilerArgs>
+            </configuration>
+            <executions>
+              <!-- compile first with module-info for Java 9+ -->
+              <execution>
+                <id>default-compile</id>
+                <configuration>
+                  <release>11</release>
+                </configuration>
+              </execution>
+              <!-- then compile without module-info for Java 8 -->
+              <execution>
+                <id>base-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <release>8</release>
+                  <excludes>
+                    <exclude>module-info.java</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/ImportJavaProjectTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/ImportJavaProjectTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.m2e.jdt.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.importer.internal.MavenProjectConfigurator;
+import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+import org.eclipse.ui.internal.wizards.datatransfer.SmartImportJob;
+import org.eclipse.ui.wizards.datatransfer.ProjectConfigurator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class ImportJavaProjectTest extends AbstractMavenProjectTestCase {
+
+  private File parentproject;
+
+  @Before
+  public void setUp() throws IOException {
+    parentproject = createProjectDirectory("projects/parentproject", "parentproject");
+  }
+
+  private File createProjectDirectory(String parent, String dir) throws IOException {
+	File file = new File(Files.createTempDirectory("m2e-tests").toFile(), dir);
+	file.mkdirs();
+    copyDir(new File(parent), file);
+
+    // Make sure projects don't have Eclipse metadata set
+    new File(file, ".project").delete();
+    new File(file, ".classpath").delete();
+    new File(file, "app/.project").delete();
+    new File(file, "core/.classpath").delete();
+    return file;
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    FileUtils.deleteDirectory(this.parentproject.getParentFile());
+  }
+ 
+  @Test
+  public void testExecution() throws Exception {
+    SmartImportJob job = new SmartImportJob(parentproject, Collections.emptySet(), true, true);
+    Map<File, List<ProjectConfigurator>> proposals = job.getImportProposals(monitor);
+    Assert.assertEquals("Expected 3 projects to import", 3, proposals.size()); //$NON-NLS-1$
+    boolean mavenConfiguratorFound = false;
+    for(ProjectConfigurator configurator : proposals.values().iterator().next()) {
+      if(configurator instanceof MavenProjectConfigurator) {
+        mavenConfiguratorFound = true;
+      }
+    }
+    Assert.assertTrue("Maven configurator not found while checking directory", mavenConfiguratorFound); //$NON-NLS-1$
+    // accept proposals
+    job.setDirectoriesToImport(proposals.keySet());
+    IWorkspaceRoot wsRoot = ResourcesPlugin.getWorkspace().getRoot();
+    Set<IProject> beforeImport = new HashSet<>(Arrays.asList(wsRoot.getProjects()));
+    job.run(monitor);
+    job.join();
+    HashSet<IProject> projects = new HashSet<>(Arrays.asList(wsRoot.getProjects()));
+    projects.removeAll(beforeImport);
+    Assert.assertEquals("Expected only 3 new projects", 3, projects.size()); //$NON-NLS-1$
+    for(IProject project : projects) {
+      Assert.assertTrue(
+          project.getLocation().toFile().getCanonicalPath().startsWith(parentproject.getCanonicalPath()));
+      refreshMavenProject(project);
+      waitForJobsToComplete();
+      IMavenProjectFacade mavenProject = MavenPlugin.getMavenProjectRegistry().getProject(project);
+      Assert.assertNotNull("Project not configured as Maven", mavenProject); //$NON-NLS-1$
+    }
+    IProject core = wsRoot.getProject("core");
+    assertTrue(core.exists());
+    IJavaProject javaProject = JavaCore.create(core);
+    IClasspathEntry[] entries = javaProject.getRawClasspath();
+    for (IClasspathEntry entry:entries) {
+      if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE && "/core/src/main/java".equals(entry.getPath().toString()) ) {
+        IPath[] exclusion = entry.getExclusionPatterns();
+        assertTrue(exclusion == null || exclusion.length == 0);
+      }
+    }
+  }
+}

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 1.18.1.qualifier
+Bundle-Version: 1.18.2.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-internal:=true,


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/246 - The tool didn't
generate the correct classpath for a maven project with multiple compile executions

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>