### PR TITLE
Don't fail on empty goals list in plugin execution filter

### DIFF
--- a/org.eclipse.m2e.core/mdo/lifecycle-mapping-metadata-model.xml
+++ b/org.eclipse.m2e.core/mdo/lifecycle-mapping-metadata-model.xml
@@ -164,7 +164,7 @@
   }
 
   private void checkAllFieldsSet() {
-    if (groupId==null || artifactId==null || versionRange==null || goals==null || goals.isEmpty() ){
+    if (groupId==null || artifactId==null || versionRange==null || goals==null ){
       throw new IllegalArgumentException(
       "Missing parameter for pluginExecutionFilter. " +
       "groupId, artifactId, versionRange and goals must be specificed, but found: "+this);


### PR DESCRIPTION
Some plugins might define empty sets of goals. One example is `ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin`, it is built using takari-lifecycle which generates  lifecycle-metadata file automatically from takari-based mojos, but in this case the only mojo is plain maven mojo, so it leaves the set of goals empty.
The mojo in question is bound to package phase, so it's not supposed to be 'interesting', but this check breaks the whole build completely including unrelated dependent modules.

```
<lifecycleMappingMetadata>
  <pluginExecutions>
    <pluginExecution>
      <pluginExecutionFilter>
        <goals/>
      </pluginExecutionFilter>
      <action>
        <configurator>
          <id>io.takari.m2e.incrementalbuild.builderMojoExecutionConfigurator</id>
        </configurator>
      </action>
    </pluginExecution>
  </pluginExecutions>
</lifecycleMappingMetadata>
```