### PR TITLE
Unify Maven-runtime project Poms

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -98,10 +98,6 @@
 					</instructions>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -131,10 +131,6 @@
 					</instructions>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
@@ -59,7 +59,6 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<configuration>
 					<instructions>
-						<Embed-Directory>jars</Embed-Directory>
 						<Embed-Dependency>
 							slf4j-simple
 						</Embed-Dependency>
@@ -67,10 +66,6 @@
 						<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
 					</instructions>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -140,7 +140,6 @@
 						<Embed-Dependency>
 							*;scope=compile|runtime;artifactId=!aopalliance|apache-maven|slf4j-api|javax.inject
 						</Embed-Dependency>
-						<Embed-Directory>jars</Embed-Directory>
 						<_exportcontents>
 							META-INF.plexus;-noimport:=true,
 							META-INF.sisu;-noimport:=true,
@@ -163,10 +162,6 @@
 						<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
 					</instructions>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -138,6 +138,8 @@
 					<configuration>
 						<instructions>
 							<Embed-Transitive>true</Embed-Transitive>
+							<Embed-Directory>jars</Embed-Directory>
+
 							<_failok>true</_failok>
 							<_nouses>true</_nouses>
 							<_nodefaultversion>true</_nodefaultversion>
@@ -240,6 +242,10 @@
 							<excludeInnerJars>true</excludeInnerJars>
 							<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
 						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -13,23 +13,16 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.sonatype.forge</groupId>
-		<artifactId>forge-parent</artifactId>
-		<version>10</version>
-		<relativePath />
+		<groupId>org.eclipse.m2e</groupId>
+		<artifactId>m2e-core</artifactId>
+		<version>1.16.0-SNAPSHOT</version>
 	</parent>
 
-	<groupId>org.eclipse.m2e</groupId>
 	<artifactId>m2e-maven-runtime</artifactId>
-	<version>1.16.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>M2E - Maven runtime bundles</name>
 
-	<organization>
-		<name>Eclipse.org - m2e</name>
-		<url>www.eclipse.org</url>
-	</organization>
 	<scm>
 		<connection>scm:git:git://git.eclipse.org/gitroot/m2e/m2e-core.git</connection>
 		<developerConnection>scm:git:git://git.eclipse.org/gitroot/m2e/m2e-core.git</developerConnection>
@@ -37,10 +30,6 @@
 
 	<properties>
 		<archetype-common.version>2.4</archetype-common.version>
-		<maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
-		<tycho.version>2.3.0</tycho.version>
-		<!-- Also change in ../pom.xml -->
-		<m2e.version>1.18.2</m2e.version>
 	</properties>
 
 	<modules>
@@ -52,12 +41,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<extensions>true</extensions>
-			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
@@ -96,26 +79,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-p2-extras-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<id>check-no-version-regression</id>
-						<goals>
-							<goal>compare-version-with-baselines</goal>
-						</goals>
-						<phase>verify</phase>
-						<configuration>
-							<baselines>
-								<baseline>https://download.eclipse.org/technology/m2e/releases/latest/</baseline>
-							</baselines>
-							<comparator>zip</comparator>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 
 		<pluginManagement>
@@ -133,7 +96,7 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>${maven-bundle-plugin.version}</version>
+					<version>5.1.1</version>
 					<extensions>true</extensions>
 					<configuration>
 						<instructions>
@@ -157,30 +120,6 @@
 							<addMavenDescriptor>false</addMavenDescriptor>
 						</archive>
 					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>tycho-p2-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<executions>
-						<execution>
-							<id>p2-metadata</id>
-							<goals>
-								<goal>p2-metadata</goal>
-							</goals>
-							<phase>package</phase>
-							<configuration>
-								<baselineRepositories>
-									<repository>
-										<url>https://download.eclipse.org/technology/m2e/releases/latest/</url>
-									</repository>
-									<repository>
-										<url>https://download.eclipse.org/technology/m2e/snapshots/${m2e.version}/latest/</url>
-									</repository>
-								</baselineRepositories>
-							</configuration>
-						</execution>
-					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -214,18 +153,11 @@
 		</profile>
 		<profile>
 			<id>eclipse-sign</id>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>cbi-releases</id>
-					<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-				</pluginRepository>
-			</pluginRepositories>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.3.1</version>
 						<executions>
 							<execution>
 								<id>sign</id>
@@ -235,17 +167,19 @@
 								<phase>verify</phase>
 							</execution>
 						</executions>
-						<configuration>
-							<supportedProjectTypes>
-								<supportedProjectType>bundle</supportedProjectType>
-							</supportedProjectTypes>
-							<excludeInnerJars>true</excludeInnerJars>
-							<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-p2-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>p2-metadata</id>
+								<goals>
+									<goal>p2-metadata</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -23,11 +23,6 @@
 
 	<name>M2E - Maven runtime bundles</name>
 
-	<scm>
-		<connection>scm:git:git://git.eclipse.org/gitroot/m2e/m2e-core.git</connection>
-		<developerConnection>scm:git:git://git.eclipse.org/gitroot/m2e/m2e-core.git</developerConnection>
-	</scm>
-
 	<properties>
 		<archetype-common.version>2.4</archetype-common.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	<name>Maven Integration for Eclipse (parent)</name>
 	<description>Maven Integration for Eclipse provides tight integration
 		for Maven into the IDE</description>
-	<url>https://eclipse.org/m2e</url>
+	<url>https://www.eclipse.org/m2e</url>
 	<inceptionYear>2005</inceptionYear>
 
 	<properties>
@@ -49,7 +49,6 @@
 		<name>Eclipse Foundation</name>
 		<url>https://eclipse.org/m2e</url>
 	</organization>
-
 	<licenses>
 		<license>
 			<name>Eclipse Public License - v 2.0</name>
@@ -57,9 +56,13 @@
 		</license>
 	</licenses>
 
+	<scm>
+		<connection>scm:git:https://github.com/eclipse-m2e/m2e-core.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-m2e/m2e-core.git</developerConnection>
+	</scm>
 	<issueManagement>
-		<url>https://bugs.eclipse.org/bugs/enter_bug.cgi?product=m2e</url>
-		<system>Bugzilla</system>
+		<url>https://github.com/eclipse-m2e/m2e-core/issues</url>
+		<system>GitHub issues</system>
 	</issueManagement>
 
 	<modules>
@@ -508,16 +511,16 @@
 		<mailingList>
 			<name>Users List</name>
 			<subscribe>m2e-users@eclipse.org</subscribe>
-			<unsubscribe>https://dev.eclipse.org/mailman/listinfo/m2e-users</unsubscribe>
+			<unsubscribe>https://accounts.eclipse.org/mailing-list/m2e-users</unsubscribe>
 			<post>m2e-users@eclipse.org</post>
-			<archive>https://dev.eclipse.org/mhonarc/lists/m2e-users</archive>
+			<archive>https://www.eclipse.org/lists/m2e-users</archive>
 		</mailingList>
 		<mailingList>
-			<name>Developer List</name>
+			<name>Developers List</name>
 			<subscribe>m2e-dev@eclipse.org</subscribe>
-			<unsubscribe>https://dev.eclipse.org/mailman/listinfo/m2e-dev</unsubscribe>
+			<unsubscribe>https://accounts.eclipse.org/mailing-list/m2e-dev</unsubscribe>
 			<post>m2e-dev@eclipse.org</post>
-			<archive>https://dev.eclipse.org/mhonarc/lists/m2e-dev</archive>
+			<archive>https://www.eclipse.org/lists/m2e-dev</archive>
 		</mailingList>
 	</mailingLists>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- Current target version of m2e, used to deduce some URL at verify and publish.
-			This should usually be sync'd with the main feature version.
-			Also change it in m2e-maven-runtime/pom.xml -->
+			This should usually be sync'd with the main feature version. -->
 		<m2e.version>1.18.2</m2e.version>
 
 		<tycho-version>2.3.0</tycho-version>
@@ -316,17 +315,15 @@
 			<id>tycho-snapshots</id>
 			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
 		</pluginRepository>
+		<pluginRepository>
+			<id>cbi-releases</id>
+			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+		</pluginRepository>
 	</pluginRepositories>
 
 	<profiles>
 		<profile>
 			<id>eclipse-sign</id>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>cbi-releases</id>
-					<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-				</pluginRepository>
-			</pluginRepositories>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
This is the first step towards #223, aiming to unify the poms of the Maven-runtime projects and to avoid duplication.

The only relevant change in the resulting jar files is that all embedded jar files are now contained in a folder named `jars`. Before this was only the case for `maven.runtime` and `maven.runtime.slf4j.simple`.
Additionally the execution of the `tycho-p2-plugin:p2-metadata` goal is moved to the `eclipse-sign` profile in the first commit. So that goal is only executed on Jenkins and not locally. This behavior is the same for the 'main'-build of the other m2e projects.

Using the `m2e-core` as parent allows to remove many elements from the maven-runtime pom.xml, including evolving configuration like the tycho- or m2e-version properties which needs to be synchronized manually.
Due to this change in the second commit the goals `jacoco-maven-plugin:prepare-agent` and `tycho-source-plugin:plugin-source` are now also executed in the maven-runtime build. But I didn't expect and notice any negative impact from that.

Furthermore the project's metadata in the poms, like the issue management, scm connections and mailing-list, are unified and updated. The old mailing-list links still work, but seem to redirect to the new values. 