### PR TITLE
[Setup] perform Maven-runtime installation before TP resolution

### DIFF
--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -224,11 +224,12 @@
     </setupTask>
   </setupTask>
   <setupTask
+      xsi:type="launching:LaunchTask"
+      launcher="m2e-maven-runtime--install"
+      runEveryStartup="true"/>
+  <setupTask
       xsi:type="pde:TargetPlatformTask"
       name="m2e-target-platform"/>
-  <setupTask
-      xsi:type="launching:LaunchTask"
-      launcher="m2e-maven-runtime--install"/>
   <setupTask
       xsi:type="projects:ProjectsBuildTask"
       refresh="true"


### PR DESCRIPTION
Since the Maven-runtime bundles are included via the target-platform, it is necessary to install them before the target-platform is resolved! 
The m2e Maven-runtime bundles are not published to Maven-central and the intention is to obtain them from the local .m2 repository. But of course this this only works if they are installed into the local .m2 repository first.
This should fix the setup issues mentioned in #208

I didn't consider this when including the Maven-runtime bundles via the target-platform. For me it worked because the Maven-bundles were installed before, but it does not work for somebody who runs the setup for the first time.

Additionally the Maven-runtime installation now runs on every start-up to ensure that developers always have the latest Maven-runtime bundles installed.