### PR TITLE
[Target-Platform] include eclipse.sdk instead of running Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,12 +138,6 @@
 					<pomDependencies>consider</pomDependencies>
 					<filters>
 						<filter>
-							<!-- Remove as it is only included to be able to launch Eclipse-application for debugging -->
-							<type>p2-installable-unit</type>
-							<id>org.eclipse.sdk.feature.group</id>
-							<removeAll />
-						</filter>
-						<filter>
 							<!-- Remove as it may come as an undesired transitive dep from p2 under Java 11 -->
 							<type>p2-installable-unit</type>
 							<id>javax.xml</id>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,12 @@
 					<pomDependencies>consider</pomDependencies>
 					<filters>
 						<filter>
+							<!-- Remove as it is only included to be able to launch Eclipse-application for debugging -->
+							<type>p2-installable-unit</type>
+							<id>org.eclipse.sdk.feature.group</id>
+							<removeAll />
+						</filter>
+						<filter>
 							<!-- Remove as it may come as an undesired transitive dep from p2 under Java 11 -->
 							<type>p2-installable-unit</type>
 							<id>javax.xml</id>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -3,10 +3,10 @@
 <target name="m2e-target-platform">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<locations>
-		<!-- Add current Eclipse to enable launches of debugged Eclipse-Applications -->
-		<location path="${eclipse_home}" type="Profile"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/eclipse/updates/latest/"/>
+			<!-- Add current Eclipse-SDK to enable launches of debugged Eclipse-Applications -->
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>   
 			<unit id="org.eclipse.platform.ide" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -5,11 +5,8 @@
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/eclipse/updates/latest/"/>
-			<!-- Add current Eclipse-SDK to enable launches of debugged Eclipse-Applications -->
-			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>   
-			<unit id="org.eclipse.platform.ide" version="0.0.0"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
With issue #214 we discussed to include the bundles of the running Eclipse instance into the target-platform in order to be able to launch Eclipse-Application for debugging. To include the running Eclipse instance was favoured over including the `org.eclipse.sdk` feature because the bundles of the running Eclipse are ignored during the Maven/Tycho build.

However, even I use the Oomph-setup with the `latest Eclipse for Commiters`, I get errors about multiple versions of the same plug-in when launching the debug Eclipse application. At the moment it is one of the `wildwebdeveloper` plugin-ins.
Of course the Run-Configuration for the Eclipse application could be adjusted but this would not be very convenient because it would have to be updated continuously.

Therefore I suggest to include the `org.eclipse.sdk` instead which solves the issue.
I attempted to exclude the `org.eclipse.sdk` during build, but have the impression that this does not work (at least I didn't get a print-out that it is filtered).
@mickaelistria and @laeubi, what do you think about this? Should we just include the sdk-feature and not filter it for the build at all? I think this wouldn't be too bad.