### PR TITLE
[Doc] improve README, CONTRIBUTING and Oomph-setup button

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,16 +11,11 @@ The project license is available at [LICENSE](LICENSE).
 This Eclipse Foundation open project is governed by the Eclipse Foundation
 Development Process and operates under the terms of the Eclipse IP Policy.
 
-Before your contribution can be accepted by the project team contributors must
-electronically sign the Eclipse Contributor Agreement (ECA).
+Before your contribution can be accepted by the project team, 
+contributors must have an Eclipse Foundation account and 
+must electronically sign the Eclipse Contributor Agreement (ECA).
 
 * [http://www.eclipse.org/legal/ECA.php](http://www.eclipse.org/legal/ECA.php)
-
-Commits that are provided by non-committers must have a `Signed-off-by` field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
 
 For more information, please see the Eclipse Committer Handbook:
 [https://www.eclipse.org/projects/handbook/#resources-commit](https://www.eclipse.org/projects/handbook/#resources-commit).
@@ -30,12 +25,11 @@ For more information, please see the Eclipse Committer Handbook:
 Eclipse m2e use mainly 2 channels for strategical and technical discussions
 
 * 🐞 View and report issues through uses GitHub Issues at https://github.com/eclipse-m2e/m2e-core/issues. _📜 Migration to GitHub tracker took place in March 2021, for older tickets, see https://bugs.eclipse.org/bugs/buglist.cgi?product=m2e 📜_
-* 📧 Join the m2e-dev@eclipse.org mailing-list to get in touch with other contributors aboantiqueut project organizationa and planning, and browse archive at 📜 [https://accounts.eclipse.org/mailing-list/m2e-dev](https://accounts.eclipse.org/mailing-list/m2e-dev)
-
+* 📧 Join the m2e-dev@eclipse.org mailing-list to get in touch with other contributors and project organization and planning, and browse archive at 📜 [https://accounts.eclipse.org/mailing-list/m2e-dev](https://accounts.eclipse.org/mailing-list/m2e-dev)
 
 ## 🆕 Trying latest builds
 
-Latest builds, for testing, can usually be found at https://download.eclipse.org/technology/m2e/snapshots/`${targetRelease}`/latest/ where `${targetRelease}` is the name of the **next** release.
+Latest builds, for testing, can usually be found at `https://download.eclipse.org/technology/m2e/snapshots/latest/` .
 
 ## 🧑‍💻 Developer resources
 
@@ -48,8 +42,7 @@ Furthermore a local git installation is required and the git executable must be 
 
 Quick-Link:
 
- <a href="https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true"
-style="margin-left:2em;margin-top:1ex;margin-bottom:1ex;font-weight:bold;border:1px solid chocolate;background-color:darkorange;color:white;padding:0.25ex 0.25em;text-align:center;text-decoration:none" rel="nofollow">Create m2e Development Environment with Eclipse-Oomph...</a>
+[![Create Eclipse Development Environment for m2e](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=M2E&style=for-the-badge&logoColor=white&labelColor=darkorange&color=gray)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true)
 
 Step by Step guide:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ For more information, please see the Eclipse Committer Handbook:
 Eclipse m2e use mainly 2 channels for strategical and technical discussions
 
 * 🐞 View and report issues through uses GitHub Issues at https://github.com/eclipse-m2e/m2e-core/issues. _📜 Migration to GitHub tracker took place in March 2021, for older tickets, see https://bugs.eclipse.org/bugs/buglist.cgi?product=m2e 📜_
-* 📧 Join the m2e-dev@eclipse.org mailing-list to get in touch with other contributors and project organization and planning, and browse archive at 📜 [https://accounts.eclipse.org/mailing-list/m2e-dev](https://accounts.eclipse.org/mailing-list/m2e-dev)
+* 📧 Join the m2e-dev@eclipse.org mailing-list to get in touch with other contributors about project organization and planning, and browse archive at 📜 [https://accounts.eclipse.org/mailing-list/m2e-dev](https://accounts.eclipse.org/mailing-list/m2e-dev)
 
 ## 🆕 Trying latest builds
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Eclipse IDE integration for Maven (Eclipse m2e project)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/eclipse-m2e/m2e-core?label=Version&sort=semver)
+[![GitHub license](https://img.shields.io/github/license/eclipse-m2e/m2e-core?label=License)](https://github.com/eclipse-m2e/m2e-core/blob/master/LICENSE)
+[![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fm2e%2Fjob%2Fm2e%2Fjob%2Fmaster%2F&label=Build)](https://ci.eclipse.org/m2e/job/m2e/)
+![Jenkins tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fm2e%2Fjob%2Fm2e%2Fjob%2Fmaster%2F&label=Tests)
 
- <a href="https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true"
-style="margin-left:2em;margin-top:1ex;margin-bottom:1ex;font-weight:bold;border:1px solid chocolate;background-color:darkorange;color:white;padding:0.25ex 0.25em;text-align:center;text-decoration:none" rel="nofollow">Create m2e Development Environment...</a>
- or just 
- <a href="https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/redirect.html"><img src="https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/cloneToEclipseBadge.png" alt="Clone to Eclipse IDE"/></a>
+# Eclipse IDE integration for Maven (Eclipse m2e project)
 
 M2Eclipse provides tight integration for Apache Maven into the Eclipse IDE with the following features:
 * Rich editor for pom.xml files
@@ -17,18 +17,25 @@ M2Eclipse provides tight integration for Apache Maven into the Eclipse IDE with 
 See also https://projects.eclipse.org/projects/technology.m2e
 
 ## 📥 Installation
+The recommended way to install Eclipse-m2e is using the Eclipse marketplace. Either click on
 
-The recommended way is to install using the [Eclipse marketplace entry for m2e](https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide). Either simply by [Clicking this link](https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/redirectToMarketplace.html?entryId=3394048), or using the installation tricks possible from the website, or using the Eclipse Marketplace Client directly from within the IDE.  
+[![Eclipse Maven integration Marketplace entry](https://img.shields.io/static/v1?logo=eclipseide&label=Marketplace&message=Eclipse%20m2e&style=for-the-badge&logoColor=white&labelColor=darkorange&color=grey)](https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide)
+&nbsp;&nbsp;&nbsp;or&nbsp;&nbsp;&nbsp;
+[![Eclipse Maven integration Marketplace entry](https://img.shields.io/static/v1?logo=eclipseide&label=Drag%20to%20install&message=Eclipse%20m2e&style=for-the-badge&logoColor=white&labelColor=4B0082&color=grey)](https://marketplace.eclipse.org/marketplace-client-intro?mpc_install=5321178 "Drag to your running Eclipse workspace. Requires Eclipse Marketplace Client")
+
+into your Eclipse-IDE, or use the Eclipse Marketplace Client directly from within the IDE.
+
 ⚠️ _Some other entries exist that look like m2e. They're usually outdated or incorrect. Please use the official one, linked above._
 
 Alternatively, you can install the lastest M2Eclipse release by using the _Install New Software_ dialog in Eclipse IDE, pointing it to this p2 repository: https://download.eclipse.org/technology/m2e/releases/latest/
 
-For information about testing development builds, see [CONTRIBUTING.md](CONTRIBUTING.md).
+## 📢 Release notes
+
+See [RELEASE_NOTES.md](RELEASE_NOTES.md)
 
 ## ⌨️ Contributing
+[![Create Eclipse Development Environment for m2e](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=M2E&style=for-the-badge&logoColor=white&labelColor=darkorange&color=gray)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true)
+ or just 
+[![Clone to Eclipse IDE](https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/cloneToEclipseBadge.png)](https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/redirect.html)
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
-
-## ⚖️ License
-
-See [LICENSE](LICENSE)
+For detailed information about development, testing and builds, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
This PR aims to improve the doc and rending of links in the README.md and CONTRIBUTION.md.

- The statement about a required `signed-off` phrase in the commit message of non-committer contributions is removed, because
it is not required anymore (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=558653#c30 )
- The new snapshot-latest update-site referenced instead of a variable one

Besides those 'technical' changes I was searching for a nicer button-like representation for m2e's Oomph-setup configuration link, that is more similar to the default one for example used on the [EMF Jenkins site](https://ci.eclipse.org/emf/).
During my search I learned about the badges from https://shields.io/ and noticed that they also offers static badges and I found the `for-the-badge` style quite suitable for that case.

1. For the first shot I ended up using the following as Button for the m2e setuo configuration:
[![Create Eclipse Development Environment for m2e](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=M2E&style=for-the-badge&logoColor=white&labelColor=darkorange&color=gray)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true)

Alternatively we could use:

2. [![Create Eclipse Development Environment for m2e](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=M2E&style=for-the-badge&logoColor=white&labelColor=gray&color=darkorange)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true)
3. [![Create Eclipse Development Environment for m2e](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=M2E&style=for-the-badge&logoColor=white&labelColor=blue&color=lightgray)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true)
3. [![Create Eclipse Development Environment for m2e](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=M2E&style=for-the-badge&logoColor=white&labelColor=gray&color=blue)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-m2e/m2e-core/master/setup/m2eDevelopmentEnvironmentConfiguration.setup&show=true)

Any other combination of colors and texts is also possible. This is quite flexible. Also the logo can have any color.
Number 1 is based on the current eclipse color schema. The gray/blue schema is less bright, which I personally found more comfortable to read (at least in dark mode).

I used the same buttons for the Market-place entry of m2e in the installation section of the README, because I think this way they are more highlighted and therefore easier to use compared to plain links:

[![Eclipse Maven integration Marketplace entry](https://img.shields.io/static/v1?logo=eclipseide&label=Marketplace&message=Eclipse%20m2e&style=for-the-badge&logoColor=white&labelColor=darkorange&color=grey)](https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide) &nbsp;&nbsp;&nbsp;or&nbsp;&nbsp;&nbsp; [![Eclipse Maven integration Marketplace entry](https://img.shields.io/static/v1?logo=eclipseide&label=Drag%20to%20install&message=Eclipse%20m2e&style=for-the-badge&logoColor=white&labelColor=4B0082&color=grey)](https://marketplace.eclipse.org/marketplace-client-intro?mpc_install=5321178 "Drag to your running Eclipse workspace. Requires Eclipse Marketplace Client")

I hope they are self-explanatory. Again, colors and texts can be chosen freely.

I did not use the install-button as suggested by the market-place because, in my opinion it does not look well on github (at least in dark mode):
[![Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client](https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.svg)](http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=5321178 "Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client")

Besides that I added the badges from shields.io for Version, License, Build and Tests which I found informative.
But I used them in the default flat style so they do not appear too big.
Especially with the License-Badge I think the License section is not necessary anymore.

Additionally I moved the buttons for m2e's Oomph configuration setup and the git clone command down into the configuration section to not have too many buttons at the top.

If possible and wanted I can also change the clone-into-eclipse button into a button of the same style. Would it be possible to use a pure link or is the redirection via Mickaels github site necessary?

In order to see how those changes are rendered exactly, I recommend you to visit this branch in my m2e-core fork.

@mickaelistria, @laeubi, what do you think about those changes? (I know discussions about styles are difficult, can be heated easily and are sometimes not effective. Everybody has other preferences, so please see this as a suggestion.)