### PR TITLE
[PDE] fix bugs in properties-changed check, lastAccess file location and others

### DIFF
--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/BNDInstructions.java
@@ -43,9 +43,8 @@ public class BNDInstructions {
 	}
 
 	public static BNDInstructions getDefaultInstructions() {
-		InputStream input = MavenTargetLocation.class.getResourceAsStream(BND_DEFAULT_PROPERTIES_PATH);
-		try {
-			return new BNDInstructions("", IOUtils.toString(input, StandardCharsets.ISO_8859_1));
+		try (Reader reader = getDefaultInstructionsReader()) {
+			return new BNDInstructions("", IOUtils.toString(reader));
 		} catch (IOException e) {
 			throw new RuntimeException("load default properties failed", e);
 		}
@@ -54,18 +53,22 @@ public class BNDInstructions {
 	public Properties asProperties() {
 		Reader reader;
 		if (instructions == null || instructions.isBlank()) {
-			reader = new InputStreamReader(MavenTargetLocation.class.getResourceAsStream(BND_DEFAULT_PROPERTIES_PATH),
-					StandardCharsets.ISO_8859_1);
+			reader = getDefaultInstructionsReader();
 		} else {
 			reader = new StringReader(instructions);
 		}
 		Properties properties = new Properties();
-		try {
+		try (reader) {
 			properties.load(reader);
 		} catch (IOException e) {
 			throw new RuntimeException("conversion to properties failed", e);
 		}
 		return properties;
+	}
+
+	private static InputStreamReader getDefaultInstructionsReader() {
+		return new InputStreamReader(MavenTargetLocation.class.getResourceAsStream(BND_DEFAULT_PROPERTIES_PATH),
+				StandardCharsets.ISO_8859_1);
 	}
 
 	public boolean isEmpty() {

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -58,7 +58,7 @@ public class CacheManager {
 	private CacheManager(File folder) {
 		this.folder = folder;
 		try {
-			FileUtils.touch(new File(LASTACCESS_MARKER));
+			FileUtils.touch(new File(folder, LASTACCESS_MARKER));
 		} catch (IOException e) {
 			// can't mark last access then...
 		}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetBundle.java
@@ -161,7 +161,7 @@ public class MavenTargetBundle extends TargetBundle {
 				try (FileInputStream stream = new FileInputStream(file)) {
 					oldProperties.loadFromXML(stream);
 				}
-				return properties.equals(properties);
+				return oldProperties.equals(properties);
 			} catch (IOException e) {
 				// fall through and assume changed then
 			}

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/MavenTargetLocation.java
@@ -252,7 +252,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		}
 		String key = artifact.getGroupId() + ":" + artifact.getArtifactId();
 		String classifier = artifact.getClassifier();
-		if (classifier != null) {
+		if (classifier != null && !classifier.isBlank()) {
 			key += ":" + classifier;
 		}
 		key += ":" + artifact.getBaseVersion();


### PR DESCRIPTION
This PR fixes some (minor) bugs in m2e-PDE:
- `MavenTargetBundle.propertiesChanged()` did not compare the new and old properties right
- CacheManager placed the `lastAccess` file in the root directory of the running Eclipse instead of the root of the cache folder
- consider artifact classifier only if not blank
- close resources in BNDInstructions by making them resources of the try-block and unify creation of the reader for the default instructions

