### PR TITLE
[Maven-Runtime] make Maven-runtime projects Eclipse plug-ins (#223)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,6 @@ Latest builds, for testing, can usually be found at `https://download.eclipse.or
 ### Prerequisites
 
 Java 11 and Maven 3.6.3 (only if you want to build from the command-line), or newer.
-Furthermore a local git installation is required and the git executable must be in the PATH environment variable.
 
 ### ⌨️ Setting up the Development Environment automatically, using the Eclipse Installer (Oomph)
 
@@ -81,10 +80,16 @@ Some tests are in a separate repository which is referenced as a Git submodule i
 
 ### 🏗️ Build
 
-On the command line first run `mvn install -f m2e-maven-runtime`, then `mvn clean verify` both from the root of this repo's clone. Within the Eclipse-IDE both builds can be run using the Maven Launch-Configurations *m2e-maven-runtime--install* respectively *m2e-core--build*. The Launch-Configuration *m2e-core--build-all* runs both builds subsequently. The (long-running) integration tests are skipped by default, add `-Pits,uts` to your command in order to run them; adding `-DskipTests` will skip all tests, within Eclipse one can run *m2e-core--build-with-integration-tests*.
+The full Maven build of Eclipse m2e is performed in two subsequent steps.
+In order to build m2e on the command line, run the following commands subsequently from the root of this repo's clone
 
-If you're going to modify the Maven runtime components in _m2e-maven-runtime_ folder (typically to change version of Maven runtime, indexer, archetypes... that are shipped by default with m2e), you may want to run `mvn install -f m2e-maven-runtime` and subsequently reload the target-platform in order to make those components available as OSGi bundles for the other plugins.
-Those steps are necessary because the the Maven runtime components are originally pure Maven projects whose OSGi metadata are generated during build.
+1. `mvn generate-sources -f m2e-maven-runtime -Pgenerate-osgi-metadata`
+2. `mvn clean verify`
+
+Within the Eclipse-IDE both builds can be run using the Maven Launch-Configurations *m2e-maven-runtime--generate-OSGi-metadata* respectively *m2e-core--build*. The Launch-Configuration *m2e-core--build-all* runs both builds subsequently.
+The (long-running) integration tests are skipped by default, add `-Pits,uts` to your command in order to run them; adding `-DskipTests` will skip all tests, within Eclipse one can run *m2e-core--build-with-integration-tests*.
+
+If you have unresolved errors or are going to modify the Maven runtime components in _m2e-maven-runtime_ folder (typically to change version of Maven runtime, indexer, archetypes... that are shipped by default with m2e), you may want to launch the `m2e-maven-runtime--generate-OSGi-metadata` Run-configuration or trigger the Oomph-setup manually. See `m2e-maven-runtime/README.md` for details.
 
 ### ⬆️ Version bump
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,9 +18,9 @@ pipeline {
 		}
 		stage('Build') {
 			steps {
-				sh 'mvn clean install -f m2e-maven-runtime/pom.xml -B -Peclipse-sign -Dmaven.repo.local=$WORKSPACE/.m2/repository'
+				sh 'mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -Pgenerate-osgi-metadata'
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh 'mvn clean verify -f pom.xml -B -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Peclipse-sign,uts,its -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dtycho.surefire.timeout=7200'
+					sh 'mvn clean verify -f pom.xml -B -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Peclipse-sign,uts,its -Dtycho.surefire.timeout=7200'
 				}
 			}
 			post {

--- a/buildall.sh
+++ b/buildall.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-LOCALREPO=/tmp/m2e-core.localrepo
-
-mvn -f m2e-maven-runtime/pom.xml clean install -Dmaven.repo.local=$LOCALREPO
-mvn clean install -Dmaven.repo.local=$LOCALREPO
+mvn -f m2e-maven-runtime/pom.xml clean generate-sources -Pgenerate-osgi-metadata
+mvn clean install

--- a/m2e-maven-runtime/.gitignore
+++ b/m2e-maven-runtime/.gitignore
@@ -1,8 +1,6 @@
-target/
-.project
 .classpath
 .settings/
-bin/
 *.log
-.DS_Store
 META-INF/
+jars/
+!**/metadataTemplates/*

--- a/m2e-maven-runtime/.project
+++ b/m2e-maven-runtime/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>m2e-maven-runtime</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/m2e-maven-runtime/README.md
+++ b/m2e-maven-runtime/README.md
@@ -1,0 +1,14 @@
+
+The Maven-Runtime bundles are ordinary Eclipse-Plugins that facilitate Maven to fetch Maven-dependency jars from a Maven-repository
+and to generate corresponding Manifest and .classpath files that include all fetched jars accordingly.
+
+Therefore two builds are necessary:
+	1. A pure Maven build (tycho.mode=maven), to fetch all jars and to generate the MANIFEST.MF and .classpath file for each Maven-runtime project.
+	2. An ordinary 'Eclipse-Tycho' build, where the Maven-runtime plug-ins are build like ordinary Eclipse plug-ins together with all other m2e Eclipse-Plugins.
+
+In the Eclipse-IDE the first build is executed by the Oomph setup on every start-up or when triggered manually in order to re-generate the the mentioned files.
+In order to re-generate the OSGi metadata of the Maven-runtime bundles you can either run the first step of the Maven build as mentioned [in the Build section of the CONTRIBUTING guide](../CONTRIBUTING.md#🏗️ Build), launch the corresponding Run-configuration or perform the Oomph-setup tasks for m2e (manually or by restarting your Eclipse-IDE).
+
+This approach has the advantage, that the Maven-runtime bundles can be build together with all other m2e plug-ins.
+This avoids the need to include them via the target-platform, thus simplifies their handling in the IDE and during build.
+Additionally the Maven-runtime projects participate directly in the PDE build and are directly included when launching another Eclipse from the IDE (e.g. for testing) and don't have to be included by installing in the local .m2 repo and then including them into the target-platform.

--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/.project
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.archetype.common</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/build.properties
@@ -3,5 +3,4 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                jars/
-bin.excludes = META-INF/plexus/,\
-               META-INF/sisu/
+bin.excludes = META-INF/plexus/

--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/metadataTemplates/.classpath
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/metadataTemplates/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="output" path="target/classes"/>
+	${dependency.jars.lib.entries}
+</classpath>

--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/metadataTemplates/META-INF/plexus/dummy.txt
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/metadataTemplates/META-INF/plexus/dummy.txt
@@ -1,0 +1,1 @@
+#just here to silence PDE warnings. This file is not intended to be contained in the finally build jars.

--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -19,8 +19,8 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
-	<packaging>bundle</packaging>
+	<version>1.18.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Archetype Common Bundle</name>
 
@@ -64,39 +64,41 @@
 	</dependencies>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Embed-Dependency>
-							archetype-common,
-							archetype-catalog,
-							archetype-descriptor,
-							archetype-registry,
-							maven-invoker,
-							commons-collections,
-							commons-io,
-							commons-lang,
-							dom4j;version=2.1.3,
-							jchardet,
-							jdom,
-							oro,
-							plexus-velocity,
-							velocity
-						</Embed-Dependency>
-						<_exportcontents>
-							META-INF.plexus;-noimport:=true;x-internal:=true,
-							org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;x-internal:=true,
-							org.codehaus.plexus.velocity;provider=m2e;mandatory:=provider;x-internal:=true,
-						</_exportcontents>
-						<Import-Package>!*</Import-Package>
-						<Require-Bundle>org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)"</Require-Bundle>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<configuration>
+						<instructions>
+							<Embed-Dependency>
+								archetype-common,
+								archetype-catalog,
+								archetype-descriptor,
+								archetype-registry,
+								maven-invoker,
+								commons-collections,
+								commons-io,
+								commons-lang,
+								dom4j;version=2.1.3,
+								jchardet,
+								jdom,
+								oro,
+								plexus-velocity,
+								velocity
+							</Embed-Dependency>
+							<_exportcontents>
+								META-INF.plexus;-noimport:=true;x-internal:=true,
+								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;x-internal:=true,
+								org.codehaus.plexus.velocity;provider=m2e;mandatory:=provider;x-internal:=true,
+							</_exportcontents>
+							<Import-Package>!*</Import-Package>
+							<Require-Bundle>org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)"</Require-Bundle>
+						</instructions>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 	<dependencyManagement>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/.project
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.maven.indexer</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/build.properties
@@ -1,4 +1,6 @@
-jars.compile.order = .
-output.. = target/classes/
 source.. = src/main/java/,\
            src/main/resources/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               jars/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/metadataTemplates/.classpath
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/metadataTemplates/.classpath
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="output" path="target/classes"/>
+	${dependency.jars.lib.entries}
+</classpath>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -19,8 +19,8 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.indexer</artifactId>
-	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
-	<packaging>bundle</packaging>
+	<version>1.18.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<name>Nexus Indexer Bundle</name>
 
@@ -98,36 +98,43 @@
 				<version>0.3.4</version>
 				<executions>
 					<execution>
+						<?m2e execute onIncremental?>
 						<id>index-project</id>
 						<phase>prepare-package</phase>
 						<goals>
 							<goal>index</goal>
 						</goals>
+						<configuration>
+							<outputDirectory>${project.basedir}</outputDirectory>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Embed-Dependency>
-							*;scope=compile|runtime
-						</Embed-Dependency>
-						<_exportcontents>
-							META-INF.sisu;-noimport:=true,
-							org.apache.lucene.*;provider=m2e;mandatory:=provider,
-							org.apache.maven.*;provider=m2e;mandatory:=provider,
-						</_exportcontents>
-						<Import-Package>!*</Import-Package>
-						<Require-Bundle>
-							org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)",
-							org.eclipse.m2e.archetype.common;bundle-version="[1.18.0,1.19.0)"
-						</Require-Bundle>
-						<Include-Resource>{maven-resources},META-INF/sisu/javax.inject.Named=${project.build.outputDirectory}/META-INF/sisu/javax.inject.Named</Include-Resource>
-					</instructions>
-				</configuration>
-			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<configuration>
+						<instructions>
+							<Embed-Dependency>
+								*;scope=compile|runtime
+							</Embed-Dependency>
+							<_exportcontents>
+								META-INF.sisu;-noimport:=true,
+								org.apache.lucene.*;provider=m2e;mandatory:=provider,
+								org.apache.maven.*;provider=m2e;mandatory:=provider,
+							</_exportcontents>
+							<Import-Package>!*</Import-Package>
+							<Require-Bundle>
+								org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)",
+								org.eclipse.m2e.archetype.common;bundle-version="[1.18.0,1.19.0)"
+							</Require-Bundle>
+						</instructions>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/.project
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.maven.runtime.slf4j.simple</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/build.properties
@@ -3,5 +3,3 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                jars/
-bin.excludes = META-INF/plexus/,\
-               META-INF/sisu/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/metadataTemplates/.classpath
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/metadataTemplates/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="output" path="target/classes"/>
+	${dependency.jars.lib.entries}
+</classpath>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
@@ -19,8 +19,8 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime.slf4j.simple</artifactId>
-	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
-	<packaging>bundle</packaging>
+	<version>1.18.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<name>SLF4J-simple bundle</name>
 	<description>
@@ -53,19 +53,21 @@
 	</dependencies>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Embed-Dependency>
-							slf4j-simple
-						</Embed-Dependency>
-						<Import-Package>!*</Import-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<configuration>
+						<instructions>
+							<Embed-Dependency>
+								slf4j-simple
+							</Embed-Dependency>
+							<Import-Package>!*</Import-Package>
+						</instructions>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/.project
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.maven.runtime</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/metadataTemplates/.classpath
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/metadataTemplates/.classpath
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="output" path="target/classes"/>
+	${dependency.jars.lib.entries}
+	<!--
+	TODO: simply use the Maven-Classpath-Container entry. Then this does not need to be copied?! This should also include the sources?!  
+	And for the long term create a directory jars classpath container?! use JDTCore.newLibraryEntry to create an entry for each jar in a directory (think about the sources?!).
+	-->
+</classpath>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/metadataTemplates/META-INF/plexus/dummy.txt
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/metadataTemplates/META-INF/plexus/dummy.txt
@@ -1,0 +1,1 @@
+#just here to silence PDE warnings. This file is not intended to be contained in the finally build jars.

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/metadataTemplates/META-INF/sisu/dummy.txt
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/metadataTemplates/META-INF/sisu/dummy.txt
@@ -1,0 +1,1 @@
+#just here to silence PDE warnings. This file is not intended to be contained in the finally build jars.

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -19,8 +19,8 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
-	<packaging>bundle</packaging>
+	<version>1.18.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<name>Embedded Maven Runtime Bundle</name>
 
@@ -131,37 +131,39 @@
 	</dependencyManagement>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Embed-Dependency>
-							*;scope=compile|runtime;artifactId=!aopalliance|apache-maven|slf4j-api|javax.inject
-						</Embed-Dependency>
-						<_exportcontents>
-							META-INF.plexus;-noimport:=true,
-							META-INF.sisu;-noimport:=true,
-							org.apache.maven.*;provider=m2e;mandatory:=provider,
-							org.codehaus.plexus.*;provider=m2e;mandatory:=provider,
-							org.sonatype.plexus.*;provider=m2e;mandatory:=provider,
-							org.eclipse.aether.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version},
-							com.google.inject.*;provider=m2e;mandatory:=provider,
-							io.takari.*;provider=m2e;mandatory:=provider
-						</_exportcontents>
-						<Import-Package>
-							org.slf4j;version="[1.6.2,2.0.0)",
-							org.slf4j.spi;version="[1.6.2,2.0.0)",
-							org.slf4j.helpers;version="[1.6.2,2.0.0)",
-						</Import-Package>
-						<Require-Bundle>
-							org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="[1.18.0,1.19.0)",
-							javax.inject;bundle-version="1.0.0";visibility:=reexport
-						</Require-Bundle>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<configuration>
+						<instructions>
+							<Embed-Dependency>
+								*;scope=compile|runtime;artifactId=!aopalliance|apache-maven|slf4j-api|javax.inject
+							</Embed-Dependency>
+							<_exportcontents>
+								META-INF.plexus;-noimport:=true,
+								META-INF.sisu;-noimport:=true,
+								org.apache.maven.*;provider=m2e;mandatory:=provider,
+								org.codehaus.plexus.*;provider=m2e;mandatory:=provider,
+								org.sonatype.plexus.*;provider=m2e;mandatory:=provider,
+								org.eclipse.aether.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version},
+								com.google.inject.*;provider=m2e;mandatory:=provider,
+								io.takari.*;provider=m2e;mandatory:=provider
+							</_exportcontents>
+							<Import-Package>
+								org.slf4j;version="[1.6.2,2.0.0)",
+								org.slf4j.spi;version="[1.6.2,2.0.0)",
+								org.slf4j.helpers;version="[1.6.2,2.0.0)",
+							</Import-Package>
+							<Require-Bundle>
+								org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="[1.18.0,1.19.0)",
+								javax.inject;bundle-version="1.0.0";visibility:=reexport
+							</Require-Bundle>
+						</instructions>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -25,6 +25,8 @@
 
 	<properties>
 		<archetype-common.version>2.4</archetype-common.version>
+		<dependency.jars.folder>jars</dependency.jars.folder>
+		<metadata.templates.folder>metadataTemplates</metadata.templates.folder>
 	</properties>
 
 	<modules>
@@ -35,79 +37,32 @@
 	</modules>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-					<?m2e ignore?>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-						<phase>initialize</phase>
-						<configuration>
-							<executable>git</executable>
-							<commandlineArgs>log -1 --format='commitDate=%cd' --date=format:'%Y%m%d-%H%M' -- .</commandlineArgs>
-							<outputFile>${project.build.directory}/timestamp.properties</outputFile>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>properties-maven-plugin</artifactId>
-				<version>1.0.0</version>
-				<executions>
-					<execution>
-						<?m2e ignore?>
-						<goals>
-							<goal>read-project-properties</goal>
-						</goals>
-						<phase>initialize</phase>
-						<configuration>
-							<files>
-								<file>${project.build.directory}/timestamp.properties</file>
-							</files>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
-					<configuration>
-						<!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
-						<source>11</source>
-						<target>11</target>
-					</configuration>
-				</plugin>
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
 					<version>5.1.1</version>
 					<extensions>true</extensions>
 					<configuration>
+						<!-- PDE does not honor custom manifest location -->
+						<manifestLocation>META-INF</manifestLocation>
+						<supportedProjectTypes>eclipse-plugin</supportedProjectTypes>
 						<instructions>
 							<Embed-Transitive>true</Embed-Transitive>
-							<Embed-Directory>jars</Embed-Directory>
+							<Embed-Directory>${dependency.jars.folder}</Embed-Directory>
 
 							<_failok>true</_failok>
 							<_nouses>true</_nouses>
 							<_nodefaultversion>true</_nodefaultversion>
-							<_snapshot>${commitDate}</_snapshot>
+							<_snapshot>qualifier</_snapshot>
 
 							<Bundle-SymbolicName>${project.artifactId};singleton:=false</Bundle-SymbolicName>
 							<Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
 							<Bundle-Name>%Bundle-Name</Bundle-Name>
 							<Bundle-Vendor>%Bundle-Vendor</Bundle-Vendor>
 							<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
+							<Automatic-Module-Name>${project.name}</Automatic-Module-Name>
 
 							<Eclipse-BundleShape>dir</Eclipse-BundleShape>
 						</instructions>
@@ -116,63 +71,157 @@
 						</archive>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>3.0.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
 
 	<profiles>
 		<profile>
-			<id>m2e</id>
-			<activation>
+			<id>generate-osgi-metadata</id>
+			<!-- TODO:
+				<activation>
+
 				<property>
-					<name>m2e.version</name>
+				<name>m2e.version</name>
 				</property>
-			</activation>
-			<properties>
-				<osgi-version-qualifier>qualifier</osgi-version-qualifier>
-			</properties>
+				</activation>
+			-->
 			<build>
 				<pluginManagement>
 					<plugins>
+						<!-- Disable Tycho plug-ins that would fail in the first pure Maven build -->
 						<plugin>
-							<groupId>org.apache.felix</groupId>
-							<artifactId>maven-bundle-plugin</artifactId>
-							<configuration>
-								<!-- PDE does not honour custom manifest location -->
-								<manifestLocation>META-INF</manifestLocation>
-							</configuration>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-packaging-plugin</artifactId>
+							<version>${tycho-version}</version>
+							<executions>
+								<execution>
+									<id>default-build-qualifier</id>
+									<phase>none</phase>
+								</execution>
+								<execution>
+									<id>default-validate-id</id>
+									<phase>none</phase>
+								</execution>
+								<execution>
+									<id>default-validate-version</id>
+									<phase>none</phase>
+								</execution>
+							</executions>
 						</plugin>
 					</plugins>
 				</pluginManagement>
-			</build>
-		</profile>
-		<profile>
-			<id>eclipse-sign</id>
-			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.cbi.maven.plugins</groupId>
-						<artifactId>eclipse-jarsigner-plugin</artifactId>
+						<groupId>org.apache.felix</groupId>
+						<artifactId>maven-bundle-plugin</artifactId>
+						<configuration>
+						</configuration>
 						<executions>
 							<execution>
-								<id>sign</id>
 								<goals>
-									<goal>sign</goal>
+									<goal>bundle</goal>
 								</goals>
-								<phase>verify</phase>
+								<phase>generate-sources</phase>
 							</execution>
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>tycho-p2-plugin</artifactId>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-antrun-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>p2-metadata</id>
+								<id>unpack-jars-and-manifest-and-generate-classpathentires</id>
 								<goals>
-									<goal>p2-metadata</goal>
+									<goal>run</goal>
 								</goals>
-								<phase>package</phase>
+								<phase>generate-sources</phase>
+								<configuration>
+									<exportAntProperties>true</exportAntProperties>
+									<target>
+										<taskdef resource="net/sf/antcontrib/antlib.xml" />
+										<!-- See last answer of https://stackoverflow.com/questions/4368243/maven-antrun-with-sequential-ant-contrib-fails-to-run/45958355 -->
+										<!-- and http://ant-contrib.sourceforge.net/tasks/tasks/index.html -->
+										<if>
+											<equals arg1="${project.packaging}" arg2="pom" /> <!-- only soncider children of m2e-maven-runtime project -->
+											<then>
+												<echo message="Skip pom project" />
+											</then>
+											<else>
+												<echo message="Delete generated files in '${project.basedir}'" level="info" />
+												<delete includeemptydirs="true" failonerror="false">
+													<fileset dir="${project.basedir}">
+														<include name="${dependency.jars.folder}/**/" />
+														<include name="META-INF/*" />
+														<include name=".classpath" />
+													</fileset>
+												</delete>
+												<unzip dest="${project.basedir}">
+													<fileset file="${project.build.directory}/${project.build.finalName}.jar" />
+													<patternset>
+														<include name="META-INF/*" />
+														<include name="${dependency.jars.folder}/*" />
+													</patternset>
+												</unzip>
+												<!-- create the property 'dependency.jars.lib.entries' that contains the classpath entries for all dependency
+													libs and that is exported from ant to maven and used when the .classpath template files are filtered. -->
+												<var name="dependency.jars.lib.entries" value="" />
+												<for param="jarFile"><!--Ant-contrib tasks already defined in calling script -->
+													<fileset dir="${project.basedir}/${dependency.jars.folder}" includes="*.jar" />
+													<sequential>
+														<local name="jarFilename" />
+														<basename property="jarFilename" file="@{jarFile}" />
+														<local name="lib.entry" />
+														<property name="lib.entry"><![CDATA[<classpathentry exported="true" kind="lib" path="${dependency.jars.folder}/${jarFilename}"/>]]></property>
+														<var name="dependency.jars.lib.entries" value="${dependency.jars.lib.entries}&#xA;&#x9;${lib.entry}" />
+													</sequential>
+												</for>
+											</else>
+										</if>
+									</target>
+								</configuration>
+							</execution>
+						</executions>
+						<dependencies>
+							<dependency>
+								<groupId>ant-contrib</groupId>
+								<artifactId>ant-contrib</artifactId>
+								<version>1.0b3</version>
+								<exclusions>
+									<exclusion>
+										<groupId>ant</groupId>
+										<artifactId>ant</artifactId>
+									</exclusion>
+								</exclusions>
+							</dependency>
+						</dependencies>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-resources-plugin</artifactId>
+						<version>3.2.0</version>
+						<executions>
+							<execution>
+								<id>process-metadata-templates</id>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>copy-resources</goal>
+								</goals>
+								<configuration>
+									<resources>
+										<resource>
+											<directory>${project.basedir}/${metadata.templates.folder}</directory>
+											<filtering>true</filtering>
+										</resource>
+									</resources>
+									<overwrite>true</overwrite>
+									<outputDirectory>${project.basedir}</outputDirectory>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,9 @@
 
 	<modules>
 		<module>target-platform</module>
+
+		<module>m2e-maven-runtime</module>
+
 		<module>org.eclipse.m2e.model.edit</module>
 		<module>org.eclipse.m2e.core</module>
 		<module>org.eclipse.m2e.core.ui</module>
@@ -360,21 +363,6 @@
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-		<profile>
-			<id>selfhosted-workspace</id>
-			<!--
-				This profile is a convenience meant to help setting up m2e development workspace.
-				On command line, embedded maven runtime must be built separately, before m2e-core sources tree.
-			-->
-			<activation>
-				<property>
-					<name>m2e.version</name>
-				</property>
-			</activation>
-			<modules>
-				<module>m2e-maven-runtime</module>
-			</modules>
 		</profile>
 		<profile>
 			<id>osx</id>

--- a/setup/m2e-core--build-all.launch
+++ b/setup/m2e-core--build-all.launch
@@ -4,7 +4,7 @@
     <booleanAttribute key="org.eclipse.debug.core.launchGroup.0.adoptIfRunning" value="false"/>
     <booleanAttribute key="org.eclipse.debug.core.launchGroup.0.enabled" value="true"/>
     <stringAttribute key="org.eclipse.debug.core.launchGroup.0.mode" value="inherit"/>
-    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.name" value="m2e-maven-runtime--install"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.name" value="m2e-maven-runtime--generate-OSGi-metadata"/>
     <stringAttribute key="org.eclipse.debug.core.launchGroup.1.action" value="NONE"/>
     <booleanAttribute key="org.eclipse.debug.core.launchGroup.1.adoptIfRunning" value="false"/>
     <booleanAttribute key="org.eclipse.debug.core.launchGroup.1.enabled" value="true"/>

--- a/setup/m2e-maven-runtime--generate-OSGi-metadata.launch
+++ b/setup/m2e-maven-runtime--generate-OSGi-metadata.launch
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="clean install -f m2e-maven-runtime"/>
+    <stringAttribute key="M2_GOALS" value="clean generate-sources -f m2e-maven-runtime"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
-    <stringAttribute key="M2_PROFILES" value=""/>
-    <listAttribute key="M2_PROPERTIES"/>
+    <stringAttribute key="M2_PROFILES" value="generate-osgi-metadata"/>
+    <listAttribute key="M2_PROPERTIES">
+        <listEntry value="tycho.mode=maven"/>
+    </listAttribute>
     <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
     <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
     <intAttribute key="M2_THREADS" value="1"/>
     <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${working_set:&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#13;&#10;&lt;resources&gt;&#13;&#10;&lt;item path=&quot;/m2e-maven-runtime&quot; type=&quot;4&quot;/&gt;&#13;&#10;&lt;/resources&gt;}"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/m2e-core}"/>

--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -157,7 +157,7 @@
       </sourceLocator>
     </setupTask>
     <setupTask
-        xsi:type="maven:MavenImportTask">
+        xsi:type="projects:ProjectsImportTask">
       <sourceLocator
           rootFolder="${git.clone.m2e.core.location}/m2e-maven-runtime"
           locateNestedProjects="true">
@@ -225,7 +225,7 @@
   </setupTask>
   <setupTask
       xsi:type="launching:LaunchTask"
-      launcher="m2e-maven-runtime--install"
+      launcher="m2e-maven-runtime--generate-OSGi-metadata"
       runEveryStartup="true"/>
   <setupTask
       xsi:type="pde:TargetPlatformTask"

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -45,37 +45,10 @@
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
-		<!-- Add Maven runtime bundles to Target Platform as they are pure Maven projects whose OSGi metadata are generated only during build.
-		This target-platform needs to be reloaded if if any of those projects is changed.
-		The versions of the artificats below with groupId "org.eclipse.m2e" must be kept in sync with the version in the corresponding pom.-->
 		<location includeSource="true" missingManifest="error" type="Maven">
 			<groupId>io.takari.m2e.workspace</groupId>
 			<artifactId>org.eclipse.m2e.workspace.cli</artifactId>
 			<version>0.3.1</version>
-			<type>jar</type>
-		</location>
-		<location includeSource="true" missingManifest="generate" type="Maven">
-			<groupId>org.eclipse.m2e</groupId>
-			<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-			<version>1.18.0-SNAPSHOT</version>
-			<type>jar</type>
-		</location>
-		<location includeSource="true" missingManifest="generate" type="Maven">
-			<groupId>org.eclipse.m2e</groupId>
-			<artifactId>org.eclipse.m2e.maven.indexer</artifactId>
-			<version>1.18.0-SNAPSHOT</version>
-			<type>jar</type>
-		</location>
-		<location includeSource="true" missingManifest="generate" type="Maven">
-			<groupId>org.eclipse.m2e</groupId>
-			<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-			<version>1.18.0-SNAPSHOT</version>
-			<type>jar</type>
-		</location>
-		<location includeSource="true" missingManifest="generate" type="Maven">
-			<groupId>org.eclipse.m2e</groupId>
-			<artifactId>org.eclipse.m2e.maven.runtime.slf4j.simple</artifactId>
-			<version>1.18.0-SNAPSHOT</version>
 			<type>jar</type>
 		</location>
 	</locations>


### PR DESCRIPTION
This PR is the current state of the change to solve issue #223.
The Maven-runtime modules are converted into ordinary Eclipse Plug-ins and are integrated as such into the main m2e Maven build.

This has the main advantage that those bundles don't have to be integrated via the target platform, which simplifies their handling:
- no need to reload the target platform if the maven-runtime changes
- less versions to synchronise 

Besides that the requirement for a git installation can also be dropped.

However the build still requires two steps. In the first build step the MANIFEST.MF (and the .classpath) is generated and the jars embedded into the runtime bundles are fetched. As second step the actual m2e Maven build is performed.

The changes work for the IDE and the Maven build.

The current limitations are:
- MANIFEST.MF and .classpath cannot be generated on incremental builds since it would end in an endless loop (probably the usual problem). Therefore the meta-data are only regenerated when the corresponding build is performed, either explicitly as Maven build or as part of the Oomph setup.
- no sources are available (this isn't a regression but would be nice to have).

What do you think about it?