### PR TITLE
[Maven-Runtime] unify findbugs-jsr305 exclusion and cleanup dependencies

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -29,7 +29,6 @@
 			<groupId>org.apache.maven.archetype</groupId>
 			<artifactId>archetype-common</artifactId>
 			<version>${archetype-common.version}</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<!-- there is newer velocity with different groupId that we want -->
@@ -49,12 +48,6 @@
 					<artifactId>dom4j</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sisu</groupId>
-			<artifactId>org.eclipse.sisu.plexus</artifactId>
-			<version>0.3.4</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.dom4j</groupId>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -33,7 +33,6 @@
 			<groupId>org.apache.maven.indexer</groupId>
 			<artifactId>indexer-core</artifactId>
 			<version>6.0.0</version>
-			<optional>true</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.maven</groupId>
@@ -51,19 +50,7 @@
 					<groupId>com.google.inject</groupId>
 					<artifactId>guice</artifactId>
 				</exclusion>
-				<exclusion>
-					<!-- as of version 1.3.9 includes LGPL'ed sources, can't ship with an EPL project -->
-					<!-- http://dev.eclipse.org/ipzilla/show_bug.cgi?id=7302 -->
-					<groupId>com.google.code.findbugs</groupId>
-					<artifactId>jsr305</artifactId>
-				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sisu</groupId>
-			<artifactId>org.eclipse.sisu.plexus</artifactId>
-			<version>0.3.4</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.archetype</groupId>
@@ -75,14 +62,6 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
-			<exclusions>
-				<exclusion>
-					<!-- as of version 1.3.9 includes LGPL'ed sources, can't ship with an EPL project -->
-					<!-- http://dev.eclipse.org/ipzilla/show_bug.cgi?id=7302 -->
-					<groupId>com.google.code.findbugs</groupId>
-					<artifactId>jsr305</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
@@ -48,7 +48,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>${slf4j-simple.version}</version>
-			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -42,14 +42,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<optional>true</optional>
 			<exclusions>
-				<exclusion>
-					<!-- as of version 1.3.9 includes LGPL'ed sources, can't ship with an EPL project -->
-					<!-- http://dev.eclipse.org/ipzilla/show_bug.cgi?id=7302 -->
-					<groupId>com.google.code.findbugs</groupId>
-					<artifactId>jsr305</artifactId>
-				</exclusion>
 				<exclusion>
 					<groupId>org.checkerframework</groupId>
 					<artifactId>checker-compat-qual</artifactId>
@@ -59,23 +52,19 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-embedder</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-compat</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sisu</groupId>
 			<artifactId>org.eclipse.sisu.plexus</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.sonatype.plexus</groupId>
 			<artifactId>plexus-build-api</artifactId>
 			<version>${plexus-build-api.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.takari.aether</groupId>
@@ -91,17 +80,14 @@
 		<dependency>
 			<groupId>org.apache.maven.resolver</groupId>
 			<artifactId>maven-resolver-impl</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.resolver</groupId>
 			<artifactId>maven-resolver-connector-basic</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.resolver</groupId>
 			<artifactId>maven-resolver-transport-wagon</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
@@ -151,9 +137,9 @@
 							io.takari.*;provider=m2e;mandatory:=provider
 						</_exportcontents>
 						<Import-Package>
-							org.slf4j;version="[1.6.2,2.0.0)",
-							org.slf4j.spi;version="[1.6.2,2.0.0)",
-							org.slf4j.helpers;version="[1.6.2,2.0.0)",
+							org.slf4j;resolution:=optional;version="[1.6.2,2.0.0)",
+							org.slf4j.spi;resolution:=optional;version="[1.6.2,2.0.0)",
+							org.slf4j.helpers;resolution:=optional;version="[1.6.2,2.0.0)",
 						</Import-Package>
 						<Require-Bundle>
 							org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="[1.18.0,1.19.0)",

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -34,6 +34,18 @@
 		<module>org.eclipse.m2e.maven.runtime.slf4j.simple</module>
 	</modules>
 
+	<dependencies>
+		<!-- globally excluded transitive dependencies (set their scope to 'provided') -->
+		<dependency>
+			<!-- as of version 1.3.9 includes LGPL'ed sources, can't ship with an EPL project -->
+			<!-- http://dev.eclipse.org/ipzilla/show_bug.cgi?id=7302 -->
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>[1.0.0,)</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
The findbugs-jsr305 is now excluded globally in the `m2e-maven-runtime/pom.xml`.

Additionally unnecessary `<optional>` elements are removed. The m2e artifacts are not further used in other Maven builds, so there is no need to mark dependencies optional. However this first had the effect that the imported slf4j-API packages of m2e.maven.runtime were not marked with `;resolution:=optional` any more. While I think this would not have be a problem because slf4j.api bundle is usually present, I added the resolution directive to the BND-instructions. 

Furthermore the not required provided `org.eclipse.sisu.plexus` dependencies are removed.

I compared the content of the four jars build for the m2e-maven-runtime bundles and their content is effectively equal to the content before.