### PR TITLE
Build with Tycho 2.4.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 			This should usually be sync'd with the main feature version. -->
 		<m2e.version>1.18.2</m2e.version>
 
-		<tycho-version>2.3.0</tycho-version>
+		<tycho-version>2.4.0</tycho-version>
 
 		<tycho.testArgLine>-Xmx800m</tycho.testArgLine>
 		<tycho.surefire.timeout>7200</tycho.surefire.timeout>
@@ -153,6 +153,16 @@
 						</filter>
 					</filters>
 				</configuration>
+				<executions>
+					<execution>
+						<?m2e ignore?>
+						<id>default-target-platform</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>target-platform</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -153,16 +153,6 @@
 						</filter>
 					</filters>
 				</configuration>
-				<executions>
-					<execution>
-						<?m2e ignore?>
-						<id>default-target-platform</id>
-						<phase>initialize</phase>
-						<goals>
-							<goal>target-platform</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
Build using the latest Tycho version 2.4.0.

@laeubi or @mickaelistria do you know why the execution of the `org.eclipse.tycho:target-platform-configuration:target-platform` goal is now not covered by the lifecycle configuration any more.
Has some lifecycle-configuration been removed in Tycho?