### PR TITLE
Source bundle missing for o.e.m2e.importer

### DIFF
--- a/org.eclipse.m2e.importer/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.importer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.importer;singleton:=true
-Bundle-Version: 1.17.2.qualifier
+Bundle-Version: 1.17.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide,

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -166,4 +166,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.m2e.importer.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
I was trying to view the source for this bundle in PDE when I noticed it
was not installed with the m2e SDK feature -- it turns out this source
bundle is actually never published at all.

This change adds the missing source bundle to the SDK feature.

Signed-off-by: Mat Booth <mat.booth@gmail.com>