### PR TITLE
Remove Bundle-ClassPath headers with default value

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.10.0",
  org.eclipse.core.filesystem;bundle-version="1.7.700",
  com.google.guava;bundle-version="[30.1,32.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.m2e.core,
  org.eclipse.m2e.core.archetype;x-friends:="org.eclipse.m2e.core.ui",

--- a/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.m2e.discovery;singleton:=true
 Bundle-Version: 1.18.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
-Bundle-ClassPath: .
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.p2.ui.discovery,
  org.eclipse.equinox.p2.discovery,

--- a/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.discovery;singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
@@ -31,7 +31,6 @@ Export-Package: org.eclipse.m2e.editor.xml;x-internal:=true,
  org.eclipse.m2e.editor.xml.internal;x-internal:=true,
  org.eclipse.m2e.editor.xml.mojo;x-internal:=true,
  org.eclipse.m2e.editor.xml.preferences;x-internal:=true
-Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.slf4j;version="[1.6.2,2.0.0)"

--- a/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor.xml;singleton:=true
-Bundle-Version: 1.18.1.qualifier
+Bundle-Version: 1.18.2.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.xml.MvnIndexPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
@@ -34,7 +34,6 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
-Bundle-ClassPath: .
 Export-Package: org.eclipse.m2e.editor;x-friends:="org.eclipse.m2e.editor.xml",
  org.eclipse.m2e.editor.composites;x-friends:="org.eclipse.m2e.editor.xml",
  org.eclipse.m2e.editor.dialogs;x-friends:="org.eclipse.m2e.editor.xml",

--- a/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.18.1.qualifier
+Bundle-Version: 1.18.2.qualifier
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.model.edit;singleton:=true
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
@@ -20,5 +20,4 @@ Export-Package: org.eclipse.m2e.model.edit.pom;x-internal:=true,
  org.eclipse.m2e.model.edit.pom.impl;x-internal:=true,
  org.eclipse.m2e.model.edit.pom.provider;x-internal:=true,
  org.eclipse.m2e.model.edit.pom.util;x-internal:=true
-Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.m2e.model.edit

--- a/org.eclipse.m2e.sse.ui.feature/feature.xml
+++ b/org.eclipse.m2e.sse.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sse.ui.feature"
       label="%featureName"
-      version="1.18.1.qualifier"
+      version="1.18.2.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 1.17.3.qualifier
+Bundle-Version: 1.17.4.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)",

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -19,7 +19,6 @@ Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.jetty.io
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor
 MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.tests.common


### PR DESCRIPTION
According to the OSGi specification the dot is the default value in case of an absent Bundle-ClassPath header. So if the dot is the only value, that header can be removed:
https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#d0e1860