### PR TITLE
#308 fix NPE when distributing classpath changes to remote projects

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -139,7 +140,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
 
   final File stateLocationDir;
 
-  final Map<String, InternalModuleInfo> moduleInfosMap = new ConcurrentHashMap<>();
+  final Map<URI, InternalModuleInfo> moduleInfosMap = new ConcurrentHashMap<>();
 
   private final DownloadSourcesJob downloadSourcesJob;
 
@@ -616,7 +617,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
         log.error("Can't delete " + containerState.getAbsolutePath()); //$NON-NLS-1$
       }
 
-      moduleInfosMap.remove(project.getLocation().toString());
+      moduleInfosMap.remove(project.getLocationURI());
 
     } else if(IResourceChangeEvent.POST_CHANGE == type) {
 
@@ -666,7 +667,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
             if(moduleDescription == null) {
               return false;
             }
-            String location = p.getLocation().toString();
+            URI location = p.getLocationURI();
             InternalModuleInfo newModuleInfo = ModuleSupport.getModuleInfo(jp, monitor);
             if(monitor.isCanceled()) {
               return false;


### PR DESCRIPTION
Work with 'locationURI' rather than with 'IResource.getLocation()', as the URI is defined in remote projects too, while the location may be null.

Change-Id: Idd6d26c794a1c6199694f6a66dafdb1d8f97899c
Signed-off-by: Reguel Wermelinger <reguel.wermelinger@ivyteam.ch>