### PR TITLE
#310 fix: do not fail with an NPE on problems within remote projects

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
 
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.InputLocation;
@@ -86,8 +87,8 @@ public class SourceLocationHelper {
     }
 
     int columnNumber = Math.max(1, modelProblem.getColumnNumber());
-    String pomFile = pomResource.getLocation().toOSString();
-    if(pomFile.equals(modelProblem.getSource())) {
+    IPath pomLocation = pomResource.getLocation();
+    if(pomLocation != null && pomLocation.toOSString().equals(modelProblem.getSource())) {
       return new SourceLocation(lineNumber, 1, columnNumber - COLUMN_END_OFFSET);
     }
     SourceLocation causeLocation = new SourceLocation(modelProblem.getSource(), modelProblem.getModelId(), lineNumber,


### PR DESCRIPTION
- handle IResource.getLocation(), which can be null for remote projects.

Change-Id: Ibd5db4e39814f681c93a77936b4fde4e84bf5fa5
Signed-off-by: Reguel Wermelinger <reguel.wermelinger@ivyteam.ch>