### PR TITLE
Use try-with-resource and implement Closeable in MutableProjectRegistry

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
@@ -265,7 +265,7 @@ public class SelectionUtil {
         File tempPomFile = null;
         try (InputStream is = storage.getContents()) {
           tempPomFile = File.createTempFile("maven-pom", ".pom"); //$NON-NLS-1$ //$NON-NLS-2$
-          Files.copy(storage.getContents(), tempPomFile.toPath());
+          Files.copy(is, tempPomFile.toPath());
           return readMavenProject(tempPomFile, monitor);
         } catch(IOException ex) {
           log.error("Can't close stream", ex); //$NON-NLS-1$

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/SelectionUtil.java
@@ -14,10 +14,9 @@
 package org.eclipse.m2e.core.ui.internal.actions;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,8 +47,6 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.PlatformUI;
-
-import org.codehaus.plexus.util.IOUtil;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -266,19 +263,13 @@ public class SelectionUtil {
       IPath path = storage.getFullPath();
       if(path == null || !new File(path.toOSString()).exists()) {
         File tempPomFile = null;
-        InputStream is = null;
-        OutputStream os = null;
-        try {
+        try (InputStream is = storage.getContents()) {
           tempPomFile = File.createTempFile("maven-pom", ".pom"); //$NON-NLS-1$ //$NON-NLS-2$
-          os = new FileOutputStream(tempPomFile);
-          is = storage.getContents();
-          IOUtil.copy(is, os);
+          Files.copy(storage.getContents(), tempPomFile.toPath());
           return readMavenProject(tempPomFile, monitor);
         } catch(IOException ex) {
           log.error("Can't close stream", ex); //$NON-NLS-1$
         } finally {
-          IOUtil.close(is);
-          IOUtil.close(os);
           if(tempPomFile != null) {
             tempPomFile.delete();
           }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/ChangedFileOutputStream.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/ChangedFileOutputStream.java
@@ -64,10 +64,8 @@ public class ChangedFileOutputStream extends OutputStream {
 
   @Override
   public void close() throws IOException {
-    try {
+    try (os) {
       writeIfNewOrChanged();
-    } finally {
-      os.close();
     }
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -77,7 +77,6 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.dag.CycleDetectedException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
@@ -585,13 +584,8 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
   @Override
   @SuppressWarnings("deprecation")
   public Model readModel(File pomFile) throws CoreException {
-    try {
-      BufferedInputStream is = new BufferedInputStream(new FileInputStream(pomFile));
-      try {
+    try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(pomFile))) {
         return readModel(is);
-      } finally {
-        IOUtil.close(is);
-      }
     } catch(IOException e) {
       throw new CoreException(new Status(IStatus.ERROR, IMavenConstants.PLUGIN_ID, -1,
           Messages.MavenImpl_error_read_pom, e));
@@ -865,14 +859,9 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     }
 
     File lastUpdatedFile = getLastUpdatedFile(localRepository, artifact);
-    try {
-      lastUpdatedFile.getParentFile().mkdirs();
-      BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(lastUpdatedFile));
-      try {
-        lastUpdated.store(os, null);
-      } finally {
-        IOUtil.close(os);
-      }
+    lastUpdatedFile.getParentFile().mkdirs();
+    try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(lastUpdatedFile))) {
+      lastUpdated.store(os, null);
     } catch(IOException ex) {
       throw new CoreException(new Status(IStatus.ERROR, IMavenConstants.PLUGIN_ID, -1,
           Messages.MavenImpl_error_write_lastUpdated, ex));
@@ -936,13 +925,8 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
   private Properties loadLastUpdated(ArtifactRepository localRepository, Artifact artifact) throws CoreException {
     Properties lastUpdated = new Properties();
     File lastUpdatedFile = getLastUpdatedFile(localRepository, artifact);
-    try {
-      BufferedInputStream is = new BufferedInputStream(new FileInputStream(lastUpdatedFile));
-      try {
+    try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(lastUpdatedFile))) {
         lastUpdated.load(is);
-      } finally {
-        IOUtil.close(is);
-      }
     } catch(FileNotFoundException ex) {
       // that's okay
     } catch(IOException ex) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
@@ -245,14 +245,14 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
         parser.parse(is);
       }
 
-      ZipFile zip = null;
+      File zipFile = null;
       if(handler.mavenCore != null) {
-        zip = new ZipFile(handler.mavenCore);
+        zipFile = handler.mavenCore;
       } else if(handler.uber != null) {
-        zip = new ZipFile(handler.uber);
+        zipFile = handler.uber;
       }
-      if(zip != null) {
-        try {
+      if(zipFile != null) {
+        try (ZipFile zip = new ZipFile(zipFile)) {
           String suffix = "";
           ZipEntry zipEntry = zip.getEntry("META-INF/maven/org.apache.maven/maven-core/pom.properties"); //$NON-NLS-1$
           if(zipEntry != null) {
@@ -264,9 +264,7 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
               return version + suffix;
             }
           }
-        } finally {
-          zip.close();
-        }
+        } 
       }
     } catch(Exception e) {
       // most likely a bad location, but who knows

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
@@ -149,7 +149,7 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
     ConfigurationParser parser = new ConfigurationParser(handler, properties);
 
     try (FileInputStream is = new FileInputStream(getLauncherConfigurationFile())) {
-        parser.parse(is);
+      parser.parse(is);
     } catch(Exception e) {
       if(e instanceof ExceptionWrapper && e.getCause() instanceof CoreException) {
         throw (CoreException) e.getCause();
@@ -264,7 +264,7 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
               return version + suffix;
             }
           }
-        } 
+        }
       }
     } catch(Exception e) {
       // most likely a bad location, but who knows

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingFactory.java
@@ -56,7 +56,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.spi.RegistryContributor;
 import org.eclipse.osgi.util.NLS;
 
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.dag.CycleDetectedException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -455,7 +454,7 @@ public class LifecycleMappingFactory {
       } else if(file.isDirectory()) {
         try (InputStream is = new BufferedInputStream(
             new FileInputStream(new File(file, LIFECYCLE_MAPPING_METADATA_EMBEDDED_SOURCE_PATH)))) {
-            metadata = createLifecycleMappingMetadataSource(is);
+          metadata = createLifecycleMappingMetadataSource(is);
         } catch(FileNotFoundException e) {
           // expected and tolerated
         }
@@ -480,7 +479,7 @@ public class LifecycleMappingFactory {
     if(workspaceMetadataSource == null || reload) {
       File mappingFile = getWorkspaceMetadataFile();
       try (InputStream is = new BufferedInputStream(new FileInputStream(mappingFile))) {
-          workspaceMetadataSource = createLifecycleMappingMetadataSource(is);
+        workspaceMetadataSource = createLifecycleMappingMetadataSource(is);
       } catch(FileNotFoundException e) {
         // this is expected, ignore
       } catch(IOException | XmlPullParserException ex) {
@@ -501,10 +500,8 @@ public class LifecycleMappingFactory {
     LifecycleMappingMetadataSourceXpp3Writer writer = new LifecycleMappingMetadataSourceXpp3Writer();
     File mappingFile = getWorkspaceMetadataFile();
     mappingFile.getParentFile().mkdirs();
-    try (
-      OutputStream os = new BufferedOutputStream(new FileOutputStream(mappingFile));
-    ) {
-        writer.write(os, metadata);
+    try (OutputStream os = new BufferedOutputStream(new FileOutputStream(mappingFile))) {
+      writer.write(os, metadata);
     } catch(IOException ex) {
       log.error(ex.getMessage(), ex);
     }
@@ -1251,15 +1248,12 @@ public class LifecycleMappingFactory {
 
   private static LifecycleMappingMetadataSource createLifecycleMappingMetadataSource(String groupId, String artifactId,
       String version, File configuration) throws IOException, XmlPullParserException {
-    InputStream in = new FileInputStream(configuration);
-    try {
+    try (InputStream in = new FileInputStream(configuration)) {
       LifecycleMappingMetadataSource lifecycleMappingMetadataSource = createLifecycleMappingMetadataSource(in);
       lifecycleMappingMetadataSource.setGroupId(groupId);
       lifecycleMappingMetadataSource.setArtifactId(artifactId);
       lifecycleMappingMetadataSource.setVersion(version);
       return lifecycleMappingMetadataSource;
-    } finally {
-      IOUtil.close(in);
     }
   }
 
@@ -1294,15 +1288,10 @@ public class LifecycleMappingFactory {
     }
     URL url = bundle.getEntry(LIFECYCLE_MAPPING_METADATA_SOURCE_PATH);
     if(url != null) {
-      try {
-        InputStream in = url.openStream();
-        try {
-          LifecycleMappingMetadataSource metadata = createLifecycleMappingMetadataSource(in);
-          metadata.setSource(bundle);
-          return metadata;
-        } finally {
-          IOUtil.close(in);
-        }
+      try (InputStream in = url.openStream()) {
+        LifecycleMappingMetadataSource metadata = createLifecycleMappingMetadataSource(in);
+        metadata.setSource(bundle);
+        return metadata;
       } catch(IOException | XmlPullParserException e) {
         log.warn("Could not read lifecycle-mapping-metadata.xml for bundle {}", bundle.getSymbolicName(), e);
       }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/LifecycleMappingConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/LifecycleMappingConfiguration.java
@@ -31,7 +31,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import org.apache.maven.plugin.MojoExecution;
@@ -96,12 +95,10 @@ public class LifecycleMappingConfiguration implements ILifecycleMappingConfigura
   }
 
   private static void persist(IProject project, LifecycleMappingConfiguration configuration) {
-    try {
-      File configFile = getConfigurationFile(project);
-      try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(configFile))) {
-        oos.writeObject(configuration);
-        oos.flush();
-      }
+    File configFile = getConfigurationFile(project);
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(configFile))) {
+      oos.writeObject(configuration);
+      oos.flush();
     } catch(IOException ex) {
       log.warn("Could not persist build lifecycle mapping configuration for {}.", project.toString(), ex);
     }
@@ -144,15 +141,10 @@ public class LifecycleMappingConfiguration implements ILifecycleMappingConfigura
 
   public static LifecycleMappingConfiguration restore(IMavenProjectFacade facade, IProgressMonitor monitor) {
     File configFile = getConfigurationFile(facade.getProject());
-    try {
-      ObjectInputStream ois = new ObjectInputStream(new FileInputStream(configFile));
-      try {
-        Object obj = ois.readObject();
-        if(obj instanceof LifecycleMappingConfiguration) {
-          return (LifecycleMappingConfiguration) obj;
-        }
-      } finally {
-        IOUtil.close(ois);
+    try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(configFile))) {
+      Object obj = ois.readObject();
+      if(obj instanceof LifecycleMappingConfiguration) {
+        return (LifecycleMappingConfiguration) obj;
       }
     } catch(ClassNotFoundException ex) {
       log.warn("Could not read persistent build lifecycle mapping configuration for {}.", facade.toString(), ex);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MutableProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MutableProjectRegistry.java
@@ -35,7 +35,7 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
  *
  * @author igor
  */
-public class MutableProjectRegistry extends BasicProjectRegistry implements IProjectRegistry {
+public class MutableProjectRegistry extends BasicProjectRegistry implements IProjectRegistry, AutoCloseable {
 
   private static final long serialVersionUID = 4879169945594340946L;
 
@@ -123,9 +123,9 @@ public class MutableProjectRegistry extends BasicProjectRegistry implements IPro
     return parentVersion != parent.getVersion();
   }
 
+  @Override
   public void close() {
     this.closed = true;
-
     clear();
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -307,17 +307,11 @@ public class ProjectRegistryManager {
     SubMonitor progress = SubMonitor.convert(monitor, Messages.ProjectRegistryManager_task_refreshing, 100);
     ISchedulingRule rule = ResourcesPlugin.getWorkspace().getRoot();
     Job.getJobManager().beginRule(rule, progress);
-    try {
-      syncRefreshThread = Thread.currentThread();
+    syncRefreshThread = Thread.currentThread();
+    try (MutableProjectRegistry newState = newMutableProjectRegistry()) {
+      refresh(newState, pomFiles, progress.newChild(95));
 
-      MutableProjectRegistry newState = newMutableProjectRegistry();
-      try {
-        refresh(newState, pomFiles, progress.newChild(95));
-
-        applyMutableProjectRegistry(newState, progress.newChild(5));
-      } finally {
-        newState.close();
-      }
+      applyMutableProjectRegistry(newState, progress.newChild(5));
     } finally {
       syncRefreshThread = null;
       Job.getJobManager().endRule(rule);

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/MavenDiscovery.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/MavenDiscovery.java
@@ -37,7 +37,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.internal.Workbench;
 
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -157,11 +156,8 @@ public class MavenDiscovery {
       if(conn instanceof JarURLConnection) {
         ((JarURLConnection) conn).setDefaultUseCaches(false);
       }
-      InputStream is = conn.getInputStream();
-      try {
+      try (InputStream is = conn.getInputStream()) {
         return LifecycleMappingFactory.createLifecycleMappingMetadataSource(is);
-      } finally {
-        IOUtil.close(is);
       }
     } catch(FileNotFoundException e) {
       // CatalogItem does not contain lifecycle mapping

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContextUtil.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/PomTemplateContextUtil.java
@@ -28,8 +28,6 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 
-import org.codehaus.plexus.util.IOUtil;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -65,11 +63,10 @@ class PomTemplateContextUtil {
         String msg = "Can't resolve plugin " + name; //$NON-NLS-1$
         log.error(msg);
       } else {
-        InputStream is = null;
         try (ZipFile zf = new ZipFile(file)) {
           ZipEntry entry = zf.getEntry("META-INF/maven/plugin.xml"); //$NON-NLS-1$
           if(entry != null) {
-            is = zf.getInputStream(entry);
+            InputStream is = zf.getInputStream(entry); // closed when zipFile is closed
             PluginDescriptorBuilder builder = new PluginDescriptorBuilder();
             descriptor = builder.build(new InputStreamReader(is));
             descriptors.put(name, descriptor);
@@ -78,8 +75,6 @@ class PomTemplateContextUtil {
         } catch(Exception ex) {
           String msg = "Can't read configuration for " + name; //$NON-NLS-1$
           log.error(msg, ex);
-        } finally {
-          IOUtil.close(is);
         }
       }
 

--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 1.17.3.qualifier
+Bundle-Version: 1.17.4.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables,

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenRuntimeLaunchSupport.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenRuntimeLaunchSupport.java
@@ -139,11 +139,8 @@ public class MavenRuntimeLaunchSupport {
         File dir = new File(state, "launches"); //$NON-NLS-1$
         dir.mkdirs();
         cwconfFile = File.createTempFile("m2conf", ".tmp", dir); //$NON-NLS-1$ //$NON-NLS-2$
-        OutputStream os = new FileOutputStream(cwconfFile);
-        try {
+        try (OutputStream os = new FileOutputStream(cwconfFile)) {
           cwconf.save(os);
-        } finally {
-          os.close();
         }
       } catch(IOException e) {
         throw new CoreException(

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenSourcePathComputer.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenSourcePathComputer.java
@@ -117,32 +117,22 @@ public class MavenSourcePathComputer implements ISourcePathComputer {
       ds.scan();
       String[] files = ds.getIncludedFiles();
       for(String file : files) {
-        try {
-          BufferedInputStream is = new BufferedInputStream(new FileInputStream(new File(entryFile, file)));
-          try {
-            addArchiveRuntimeClasspathEntry(entries, entryPath, is);
-          } finally {
-            is.close();
-          }
+        try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(new File(entryFile, file)))) {
+          addArchiveRuntimeClasspathEntry(entries, entryPath, is);
         } catch(IOException e) {
           // ignore it
         }
 
       }
     } else {
-      try {
-        JarFile jar = new JarFile(entryFile);
-        try {
-          Enumeration<JarEntry> zes = jar.entries();
-          while(zes.hasMoreElements()) {
-            JarEntry ze = zes.nextElement();
-            String name = ze.getName();
-            if(!ze.isDirectory() && name.startsWith("META-INF/maven/") && name.endsWith("pom.properties")) { //$NON-NLS-1$ //$NON-NLS-2$
-              addArchiveRuntimeClasspathEntry(entries, entryPath, jar.getInputStream(ze));
-            }
+      try (JarFile jar = new JarFile(entryFile)) {
+        Enumeration<JarEntry> zes = jar.entries();
+        while(zes.hasMoreElements()) {
+          JarEntry ze = zes.nextElement();
+          String name = ze.getName();
+          if(!ze.isDirectory() && name.startsWith("META-INF/maven/") && name.endsWith("pom.properties")) { //$NON-NLS-1$ //$NON-NLS-2$
+            addArchiveRuntimeClasspathEntry(entries, entryPath, jar.getInputStream(ze));
           }
-        } finally {
-          jar.close();
         }
       } catch(IOException e) {
         // ignore it

--- a/org.eclipse.m2e.logback.configuration/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback.configuration/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.m2e.logback.configuration;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.16.2.qualifier
 Bundle-Activator: org.eclipse.m2e.logback.configuration.LogPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  ch.qos.logback.classic;bundle-version="0.9.24",

--- a/org.eclipse.m2e.logback.configuration/src/org/eclipse/m2e/logback/configuration/LogPlugin.java
+++ b/org.eclipse.m2e.logback.configuration/src/org/eclipse/m2e/logback/configuration/LogPlugin.java
@@ -14,9 +14,9 @@
 package org.eclipse.m2e.logback.configuration;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -26,16 +26,16 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.SubstituteLoggerFactory;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
+
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
-
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Plugin;
-import org.eclipse.core.runtime.Status;
 
 
 public class LogPlugin extends Plugin {
@@ -120,23 +120,10 @@ public class LogPlugin extends Plugin {
 
       if(!configFile.isFile()) {
         // Copy the default config file to the actual config file
-        InputStream is = bundleContext.getBundle().getEntry("defaultLogbackConfiguration/logback.xml").openStream(); //$NON-NLS-1$
-        try {
+        try (InputStream is = bundleContext.getBundle().getEntry("defaultLogbackConfiguration/logback.xml") //$NON-NLS-1$
+            .openStream()) {
           configFile.getParentFile().mkdirs();
-          FileOutputStream fos = new FileOutputStream(configFile);
-          try {
-            for(byte[] buffer = new byte[1024 * 4];;) {
-              int n = is.read(buffer);
-              if(n < 0) {
-                break;
-              }
-              fos.write(buffer, 0, n);
-            }
-          } finally {
-            fos.close();
-          }
-        } finally {
-          is.close();
+          Files.copy(is, configFile.toPath());
         }
       }
 

--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.logback.feature"
       label="%featureName"
-      version="1.17.1.qualifier"
+      version="1.17.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.logback.configuration"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/translators/SSESyncResource.java
+++ b/org.eclipse.m2e.model.edit/src/org/eclipse/m2e/model/edit/pom/translators/SSESyncResource.java
@@ -127,11 +127,8 @@ public class SSESyncResource extends ResourceImpl {
           domModel = (IDOMModel) modelManager.getModelForEdit(ifile);
         } else if(uri.isFile()) {
           File f = new File(uri.toFileString());
-          FileInputStream is = new FileInputStream(f);
-          try {
+          try (FileInputStream is = new FileInputStream(f)) {
             domModel = (IDOMModel) modelManager.getModelForEdit(f.getAbsolutePath(), is, null);
-          } finally {
-            is.close();
           }
         }
         // Had to comment this out, ExtensibleURIConverterImpl isn't available in Eclipse 3.3

--- a/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
+++ b/org.eclipse.m2e.pde/src/org/eclipse/m2e/pde/CacheManager.java
@@ -87,13 +87,10 @@ public class CacheManager {
 		File file = new File(gavFolder, artifact.getFile().getName());
 		File lockFile = new File(gavFolder, artifact.getFile().getName() + ".lock");
 		lockFile.deleteOnExit();
-		try (RandomAccessFile raf = new RandomAccessFile(lockFile, "rw"); FileChannel channel = raf.getChannel()) {
-			FileLock lock = channel.lock();
-			try {
-				return consumer.consume(file);
-			} finally {
-				lock.release();
-			}
+		try (RandomAccessFile raf = new RandomAccessFile(lockFile, "rw");
+				FileChannel channel = raf.getChannel();
+				FileLock lock = channel.lock()) {
+			return consumer.consume(file);
 		}
 	}
 

--- a/org.eclipse.m2e.sourcelookup.ui/src/org/eclipse/m2e/sourcelookup/ui/internal/OpenPomCommandHandler.java
+++ b/org.eclipse.m2e.sourcelookup.ui/src/org/eclipse/m2e/sourcelookup/ui/internal/OpenPomCommandHandler.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import org.codehaus.plexus.util.IOUtil;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -82,10 +81,8 @@ public class OpenPomCommandHandler extends AbstractHandler {
   }
 
   static MavenStorageEditorInput toEditorInput(String name, InputStream is) throws IOException {
-    try {
-      return new MavenStorageEditorInput(name, name, null, IOUtil.toByteArray(is));
-    } finally {
-      IOUtil.close(is);
-    }
+    try(is) {
+      return new MavenStorageEditorInput(name, name, null, is.readAllBytes());
+    }  
   }
 }

--- a/org.eclipse.m2e.sourcelookup.ui/src/org/eclipse/m2e/sourcelookup/ui/internal/OpenPomCommandHandler.java
+++ b/org.eclipse.m2e.sourcelookup.ui/src/org/eclipse/m2e/sourcelookup/ui/internal/OpenPomCommandHandler.java
@@ -83,6 +83,6 @@ public class OpenPomCommandHandler extends AbstractHandler {
   static MavenStorageEditorInput toEditorInput(String name, InputStream is) throws IOException {
     try(is) {
       return new MavenStorageEditorInput(name, name, null, is.readAllBytes());
-    }  
+    }
   }
 }

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractLifecycleMappingTest.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractLifecycleMappingTest.java
@@ -30,7 +30,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import org.apache.maven.plugin.MojoExecution;
@@ -86,13 +85,10 @@ public abstract class AbstractLifecycleMappingTest extends AbstractMavenProjectT
   private LifecycleMappingMetadataSource loadLifecycleMappingMetadataSourceInternal(File metadataFile)
       throws IOException, XmlPullParserException {
     assertTrue("File does not exist:" + metadataFile.getAbsolutePath(), metadataFile.exists());
-    InputStream in = new FileInputStream(metadataFile);
-    try {
+    try (InputStream in = new FileInputStream(metadataFile)) {
       LifecycleMappingMetadataSource lifecycleMappingMetadataSource = LifecycleMappingFactory
           .createLifecycleMappingMetadataSource(in);
       return lifecycleMappingMetadataSource;
-    } finally {
-      IOUtil.close(in);
     }
   }
 

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -64,7 +63,6 @@ import org.eclipse.jdt.core.JavaModelException;
 
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
-import org.codehaus.plexus.util.IOUtil;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Model;
@@ -268,14 +266,10 @@ public abstract class AbstractMavenProjectTestCase {
 
       IFile pomFile = project.getFile("pom.xml");
       if(!pomFile.exists()) {
-        InputStream is = null;
-        try {
-          is = new FileInputStream(pomResource);
+        try (InputStream is = new FileInputStream(pomResource)) {
           pomFile.create(is, true, monitor);
-        } catch(FileNotFoundException ex) {
+        } catch(IOException ex) {
           throw new CoreException(new Status(IStatus.ERROR, "", 0, ex.toString(), ex));
-        } finally {
-          IOUtil.close(is);
         }
       }
     }, null);


### PR DESCRIPTION
This PR aims to reduce the number of close operations in finally-blocks of try-constructs.
For this I use try-with-resources where applicable.
While in some cases this is only a syntactical difference, in some places this also has the effect that Exceptions that are thrown while closing the resource are not ignored any more. But I think this is OK, because first I think Exceptions while closing is rare and second I think that those Exceptions should be handled equivalently to for example cases where an exception is thrown while opening the resource.

At some locations I also simplified the code within the try block using Java's Files class.
Furthermore I let `MutableProjectRegistry` implement the AutoCloseable interface, because it already had a `close()` method that was only called in the finally-block of try statements. So I think this is suitable.

I started the Commit a while ago but didn't finish it yet. Alexanders recent PR(s) that also leverage try-with-resources remembered me to complete it, in order to avoid duplicated work. The currently pending PR of him also contains some try-with-resources applications that likely overlap with this PR, but the result should be the same.