### PR TITLE
Simplify DownloadSourcesJob/BuildPathManager and fix monitor work-calculation

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
@@ -313,21 +313,22 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
         if(aKey != null) { // maybe we should try to find artifactKey little harder here?
           boolean isSnapshot = aKey.getVersion().endsWith("-SNAPSHOT");
           // We should update a sources/javadoc jar for a snapshot in case they're already downloaded.
-          File plainFile = desc.getPath() != null ? desc.getPath().toFile() : null;
+          File mainFile = desc.getPath() != null ? desc.getPath().toFile() : null;
           File srcFile = srcPath != null ? srcPath.toFile() : null;
           boolean downloadSources = (srcPath == null && mavenConfiguration.isDownloadSources())
-              || (plainFile != null && plainFile.canRead() && srcFile != null && srcFile.canRead() && isSnapshot
-                  && srcFile.lastModified() < plainFile.lastModified());
+              || (isSnapshot && isLastModifiedBefore(srcFile, mainFile));
           File javaDocFile = javaDocUrl != null ? getAttachedArtifactFile(aKey, CLASSIFIER_JAVADOC) : null;
           boolean downloadJavaDoc = (javaDocUrl == null && mavenConfiguration.isDownloadJavaDoc())
-              || (plainFile != null && plainFile.canRead() && javaDocFile != null && javaDocFile.canRead() && isSnapshot
-                  && javaDocFile.lastModified() < plainFile.lastModified());
-
+              || (isSnapshot && isLastModifiedBefore(javaDocFile, mainFile));
           scheduleDownload(facade.getProject(), facade.getMavenProject(monitor), aKey, downloadSources,
               downloadJavaDoc);
         }
       }
     }
+  }
+
+  private static boolean isLastModifiedBefore(File file, File ref) {
+    return ref != null && ref.canRead() && file != null && file.canRead() && file.lastModified() < ref.lastModified();
   }
 
   private static final String ARTIFACT_TYPE_JAR = "jar";

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
@@ -14,7 +14,6 @@
 package org.eclipse.m2e.jdt.internal;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -58,6 +57,7 @@ import org.eclipse.m2e.jdt.MavenJdtPlugin;
  *
  * @author igor
  */
+@SuppressWarnings("restriction")
 class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
   private static Logger log = LoggerFactory.getLogger(DownloadSourcesJob.class);
 
@@ -85,13 +85,7 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
 
     @Override
     public int hashCode() {
-      int hash = 17;
-      hash = hash * 31 + project.hashCode();
-      hash = hash * 31 + Objects.hashCode(fragment);
-      hash = hash * 31 + Objects.hashCode(artifact);
-      hash = hash * 31 + Boolean.hashCode(downloadSources);
-      hash = hash * 31 + Boolean.hashCode(downloadJavaDoc);
-      return hash;
+      return Objects.hash(project, fragment, artifact, downloadSources, downloadJavaDoc);
     }
 
     @Override
@@ -103,7 +97,6 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
         return false;
       }
       DownloadRequest other = (DownloadRequest) o;
-
       return project.equals(other.project) && Objects.equals(fragment, other.fragment)
           && Objects.equals(artifact, other.artifact) && downloadSources == other.downloadSources
           && downloadJavaDoc == other.downloadJavaDoc;
@@ -187,17 +180,13 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
       toUpdateMavenProjects.clear();
     }
     subMonitor.done();
-    if(monitor.isCanceled()) {
-      return Status.CANCEL_STATUS;
-    }
-    return Status.OK_STATUS;
+    return monitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
   }
 
   private static void updateClasspath(BuildPathManager manager, Set<IProject> toUpdateMavenProjects,
       Map<IPackageFragmentRoot, Attachments> toUpdateAttachments, IProgressMonitor monitor) {
-    SubMonitor updateMonitor = SubMonitor.convert(monitor,
-        1 + toUpdateMavenProjects.size() + toUpdateMavenProjects.size());
-    updateMonitor.setTaskName(Messages.DownloadSourcesJob_job_associateWithClasspath);
+    SubMonitor updateMonitor = SubMonitor.convert(monitor, Messages.DownloadSourcesJob_job_associateWithClasspath,
+        1 + toUpdateMavenProjects.size() + toUpdateAttachments.size());
     ISchedulingRule schedulingRule = ResourcesPlugin.getWorkspace().getRuleFactory().buildRule();
     getJobManager().beginRule(schedulingRule, updateMonitor.split(1));
     try {
@@ -219,8 +208,6 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
   }
 
   IStatus downloadFilesAndPopulateToUpdate(DownloadRequest request, IProgressMonitor monitor) {
-    final List<IStatus> exceptions = new ArrayList<>();
-
     SubMonitor requestMonitor = SubMonitor.convert(monitor, 33);
     try {
       if(request.artifact != null) {
@@ -247,17 +234,13 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
           toUpdateAttachments.put(request.fragment, files);
         }
       }
+      return Status.OK_STATUS;
     } catch(CoreException ex) {
-      exceptions.add(ex.getStatus());
+      return new MultiStatus(MavenJdtPlugin.PLUGIN_ID, -1, new IStatus[] {ex.getStatus()},
+          "Could not download sources or javadoc", null);
+    } finally {
+      requestMonitor.done();
     }
-    requestMonitor.done();
-
-    if(!exceptions.isEmpty()) {
-      IStatus[] problems = exceptions.toArray(new IStatus[exceptions.size()]);
-      return new MultiStatus(MavenJdtPlugin.PLUGIN_ID, -1, problems, "Could not download sources or javadoc", null);
-    }
-
-    return Status.OK_STATUS;
   }
 
   private Attachments downloadMaven(IMavenProjectFacade projectFacade, ArtifactKey artifact, boolean downloadSources,
@@ -339,17 +322,12 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
 
   private void scheduleDownload(IProject project, IPackageFragmentRoot fragment, ArtifactKey artifact,
       boolean downloadSources, boolean downloadJavadoc) {
-    addDownloadRequest(project, fragment, artifact, downloadSources, downloadJavadoc);
-
-    schedule(SCHEDULE_INTERVAL);
-  }
-
-  public void addDownloadRequest(IProject project, IPackageFragmentRoot fragment, ArtifactKey artifact,
-      boolean downloadSources, boolean downloadJavadoc) {
     if(project == null || !project.isAccessible()) {
       return;
     }
-    queue.add(new DownloadRequest(project, fragment, artifact, downloadSources, downloadJavadoc));
+    DownloadRequest request = new DownloadRequest(project, fragment, artifact, downloadSources, downloadJavadoc);
+    queue.add(request);
+    schedule(SCHEDULE_INTERVAL);
   }
 
   /**


### PR DESCRIPTION
This PR contains the changes of PR #303 that are only cosmetic or do not affect the actual issue (namely fixing the work computation of the monitor).

I have extracted this PR/commit to reduce the number of changes in PR #303 to the relevant minimum.