### PR TITLE
Use try-with-resource and java.nio.file.Files

### DIFF
--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/FileHelpers.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/FileHelpers.java
@@ -80,11 +80,8 @@ public class FileHelpers {
   public static void filterXmlFile(File src, File dst, Map<String, String> tokens) throws IOException {
     String text;
 
-    Reader reader = ReaderFactory.newXmlReader(src);
-    try {
+    try (Reader reader = ReaderFactory.newXmlReader(src)) {
       text = IOUtil.toString(reader);
-    } finally {
-      reader.close();
     }
 
     for(String token : tokens.keySet()) {


### PR DESCRIPTION
Two more classes where try-with-resource can be used that somehow slipped through my previous PR.

Furthermore `java.nio.file.Files` is is used instead of `org.eclipse.jetty.util.IO`.

Additionally the Input- and OutputStreams of the request are now closed.