### PR TITLE
Replace deprecated File.toURL() by File.toURI().toURL()

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2021 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -99,7 +99,7 @@ public class RepositoryRegistry implements IRepositoryRegistry, IMavenProjectCha
 
     String localUrl;
     try {
-      localUrl = localBasedir.toURL().toExternalForm();
+      localUrl = localBasedir.toURI().toURL().toExternalForm();
     } catch(MalformedURLException ex) {
       log.error("Could not parse local repository path", ex);
       localUrl = "file://" + localBasedir.getAbsolutePath(); //$NON-NLS-1$

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2021 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -750,7 +750,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
   static String getJavaDocUrl(File file) {
     try {
       if(file != null) {
-        URL fileUrl = file.toURL();
+        URL fileUrl = file.toURI().toURL();
         return "jar:" + fileUrl.toExternalForm() + "!/" + getJavaDocPathInArchive(file); //$NON-NLS-1$ //$NON-NLS-2$
       }
     } catch(MalformedURLException ex) {

--- a/org.eclipse.m2e.logback.configuration/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback.configuration/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.m2e.logback.configuration;singleton:=true
-Bundle-Version: 1.16.2.qualifier
+Bundle-Version: 1.16.3.qualifier
 Bundle-Activator: org.eclipse.m2e.logback.configuration.LogPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  ch.qos.logback.classic;bundle-version="0.9.24",

--- a/org.eclipse.m2e.logback.configuration/src/org/eclipse/m2e/logback/configuration/LogPlugin.java
+++ b/org.eclipse.m2e.logback.configuration/src/org/eclipse/m2e/logback/configuration/LogPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Sonatype, Inc.
+ * Copyright (c) 2010, 2021 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -130,7 +130,7 @@ public class LogPlugin extends Plugin {
       if(System.getProperty(PROPERTY_LOG_DIRECTORY, "").length() <= 0) { //$NON-NLS-1$
         System.setProperty(PROPERTY_LOG_DIRECTORY, stateDir.getAbsolutePath());
       }
-      loadConfiguration(configFile.toURL());
+      loadConfiguration(configFile.toURI().toURL());
 
       isConfigured = true;
     } catch(Exception e) {


### PR DESCRIPTION
File.toURL() does not automatically escape characters that are illegal in URLs and it is therefore recommended to use File.toURI().toURL() instead.