### PR TITLE
[DownloadSourcesJob] fix final clear of requests Set (#331)

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DownloadSourcesJob.java
@@ -181,7 +181,7 @@ class DownloadSourcesJob extends Job implements IBackgroundProcessingQueue {
     }
     // updateClasspath might has added new requests to the queue. 
     requests.clear(); // Retain in requests all elements in queue (in an efficient manner)
-    requests.retainAll(queue);
+    requests.addAll(queue);
     subMonitor.done();
     return monitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
   }


### PR DESCRIPTION
My last clean-up of the DownloadSourcesJob went wrong (maybe falsely resolved merge conflicts) and damaged the logic how the requests Set is cleared of `DownloadSourcesJob.run()`.

The `requests` set was fully cleared instead of retaining all elements in it that are also in the `queue` at that moment.

This is only harmful in case a new (valid) download-request was added during the classpath-update (or externally, but I'm not sure if this is possible). 
In this case the `requests` set does not contain that request in the queue (because it was cleared instead of only retaining all elements in the queue). So when the classpath is updated after that request is processed the `requests` set likely still does not contain the request, the request can be added again to the queue and a new run will be scheduled. After the next run the requests set would contain the request but it is again cleared after the classpath update is fully completed and the circle starts again.

The described scenario only occurred when for a SNAPSHOT version the sources.jar is last modified before the main jar in the local Maven repo and download sources is called via the right-click context menu of the Maven-Classpath container as described in https://github.com/eclipse-m2e/m2e-core/issues/331#issuecomment-924310353 and previous comments.

This PR also fixes issue #331.