### PR TITLE
Build with Tycho 2.5.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.4.0</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 			This should usually be sync'd with the main feature version. -->
 		<m2e.version>1.18.2</m2e.version>
 
-		<tycho-version>2.4.0</tycho-version>
+		<tycho-version>2.5.0-SNAPSHOT</tycho-version>
 
 		<tycho.testArgLine>-Xmx800m</tycho.testArgLine>
 		<tycho.surefire.timeout>7200</tycho.surefire.timeout>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 			This should usually be sync'd with the main feature version. -->
 		<m2e.version>1.18.2</m2e.version>
 
-		<tycho-version>2.5.0-SNAPSHOT</tycho-version>
+		<tycho-version>2.5.0</tycho-version>
 
 		<tycho.testArgLine>-Xmx800m</tycho.testArgLine>
 		<tycho.surefire.timeout>7200</tycho.surefire.timeout>


### PR DESCRIPTION
This PR checks for regressions in the m2e build using the latest Tycho 2.5.0-SNAPSHOT.


It can be updated as soon as Tycho-2.5.0 is released or discarded.