### PR TITLE
[Maven-Runtime] clean-up and mark exported META-INF packages as internal

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -22,7 +22,7 @@
 	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
 	<packaging>bundle</packaging>
 
-	<name>M2E Maven Archetype Common Bundle</name>
+	<name>M2E Maven Archetype Common</name>
 
 	<dependencies>
 		<dependency>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/build.properties
@@ -1,4 +1,0 @@
-jars.compile.order = .
-output.. = target/classes/
-source.. = src/main/java/,\
-           src/main/resources/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -22,7 +22,7 @@
 	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
 	<packaging>bundle</packaging>
 
-	<name>M2E Maven/Nexus Indexer Bundle</name>
+	<name>M2E Maven/Nexus Indexer</name>
 
 	<properties>
 		<guava.version>30.1-jre</guava.version>
@@ -92,7 +92,7 @@
 				<configuration>
 					<instructions>
 						<_exportcontents>
-							META-INF.sisu;-noimport:=true,
+							META-INF.sisu;-noimport:=true;x-internal:=true,
 							org.apache.lucene.*;provider=m2e;mandatory:=provider,
 							org.apache.maven.*;provider=m2e;mandatory:=provider,
 						</_exportcontents>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/build.properties
@@ -1,4 +1,0 @@
-jars.compile.order = .
-output.. = target/classes/
-source.. = src/main/java/,\
-           src/main/resources/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -22,7 +22,7 @@
 	<version>1.18.0-SNAPSHOT</version><!--Keep it in sync with version in target-platform.target -->
 	<packaging>bundle</packaging>
 
-	<name>M2E Embedded Maven Runtime Bundle (includes Incubating components)</name>
+	<name>M2E Embedded Maven Runtime (includes Incubating components)</name>
 
 	<properties>
 		<!-- maven core version -->
@@ -138,8 +138,8 @@
 				<configuration>
 					<instructions>
 						<_exportcontents>
-							META-INF.plexus;-noimport:=true,
-							META-INF.sisu;-noimport:=true,
+							META-INF.plexus;-noimport:=true;x-internal:=true,
+							META-INF.sisu;-noimport:=true;x-internal:=true,
 							org.apache.maven.*;provider=m2e;mandatory:=provider,
 							org.codehaus.plexus.*;provider=m2e;mandatory:=provider,
 							org.sonatype.plexus.*;provider=m2e;mandatory:=provider,

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -25,6 +25,7 @@
 
 	<properties>
 		<archetype-common.version>2.4</archetype-common.version>
+		<dependency.jars.folder>jars</dependency.jars.folder>
 	</properties>
 
 	<modules>
@@ -103,13 +104,13 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>5.1.1</version>
+					<version>5.1.2</version>
 					<extensions>true</extensions>
 					<configuration>
 						<instructions>
 							<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
 							<Embed-Transitive>true</Embed-Transitive>
-							<Embed-Directory>jars</Embed-Directory>
+							<Embed-Directory>${dependency.jars.folder}</Embed-Directory>
 
 							<_failok>true</_failok>
 							<_nouses>true</_nouses>
@@ -121,13 +122,11 @@
 							<Bundle-Name>${project.name}</Bundle-Name>
 							<Bundle-Vendor>Eclipse.org - m2e</Bundle-Vendor>
 							<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
+							<Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
 
 							<Import-Package>!*</Import-Package>
 							<Eclipse-BundleShape>dir</Eclipse-BundleShape>
 						</instructions>
-						<archive>
-							<addMavenDescriptor>false</addMavenDescriptor>
-						</archive>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
This PR applies the following clean-up changes, mainly from PR #276 to reduce the number of changes there:
- mark exported META-INF packages as internal
- Remove unused build.properties files (the maven-runtime modules are pure Maven projects atm., therefore a build.properties file is not considered at all)
- update maven-bundle-plugin version
- add Automatic-Module-Name to generated MANIFEST.MF
- remove "Bundle" suffix from project-names (and thus also from the
Bundle-Names)
- add MavenDescriptor during build.
As soon as #276 is merged, the Maven pom.xml and pom.properties are embedded within `META-INF/maven` regardless of the archive-configuration of the maven-bundle-plugin because that plug-in does not build the archives then).