### PR TITLE
Workaround to prevent indexing-error: OverlappingFileLockException (#169)

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/NexusIndexManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/index/nexus/NexusIndexManager.java
@@ -534,7 +534,21 @@ public class NexusIndexManager implements IndexManager, IMavenProjectChangedList
       //IndexInfo indexInfo = getIndexInfo(indexName);
       IndexingContext context = getIndexingContext(repository);
       if(context != null) {
-        context.purge();
+        // context.purge();  // TODO: use this again as soon as maven-indexer 6.1.0 is available
+
+        // --- Workaround for https://issues.apache.org/jira/browse/MINDEXER-127, which got visible in m2e through https://github.com/eclipse-m2e/m2e-core/issues/169 ---
+
+        // Perform all calls from DefaultIndexingContext.purge() except for openAndWarmup() :
+        // calls DefaultIndexingContext.closeReaders()  and  DefaultIndexingContext.deleteIndexFiles( true )
+        getIndexer().removeIndexingContext(context, true);
+        // create a copy of the current index which calls prepareIndex( true )
+        context = getIndexer().addIndexingContextForced(context.getId(), context.getRepositoryId(),
+            context.getRepository(), context.getIndexDirectoryFile(), context.getRepositoryUrl(),
+            context.getIndexUpdateUrl(), context.getIndexCreators());
+
+        context.rebuildGroups();
+        context.updateTimestamp(true, null);
+        // ---  workaround end ---
 
         if(context.getRepository().isDirectory()) {
           getIndexer().scan(context, new ArtifactScanningMonitor(context.getRepository(), monitor), false);


### PR DESCRIPTION
The fix for m2-issue #169 was already reported and fixed upstream to the Maven-Indexer project: https://github.com/apache/maven-indexer/pull/105.
@mickaelistria already created a draft/WIP PR that uses the Maven-indexer 6.1.0 snapshot (#284) and all tests are green.

Unfortunately a new release that contains that fix seems not to happen, even though we asked for it a while ago and multiple times. Issue #169 is very annoying IMHO because it causes the only test failure in the m2e build. Therefore we have to check every build result if only that test failed. Therefore I suggest to use this workaround as long as Maven-Indexer 6.1.0 is not released.

I'm not very familiar with this part of the code but I stepped through it using the Eclipse-Debugger and it looks to me that this workaround does pretty much the same as the (fixed) `DefaultIndexingContext.purge()` method does. I only noticed the following differences:
- `DefaultIndexingContext.indexDirectory` is closed and a new one is opened via `FSDirectory.open()` when the `DefaultIndexingContext` is closed respectively created
- a new TrackingLockFactory is created as well as a new M2GavCalculator() when the new `DefaultIndexingContext` is created

@vrubezhny you have fixed the issue upstream: What do you think about this workaround?
@mickaelistria you can immediately add a commit that reverts this change to #284 in case this is merged.
