### PR TITLE
[Maven-Runtime] unify version properties

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -24,6 +24,12 @@
 
 	<name>M2E Maven Archetype Common</name>
 
+	<properties>
+		<archetype-common.version>2.4</archetype-common.version>
+		<dom4j.version>2.1.3</dom4j.version>
+		<commons-collections.version>3.2.2</commons-collections.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven.archetype</groupId>
@@ -68,9 +74,18 @@
 		<dependency>
 			<groupId>org.dom4j</groupId>
 			<artifactId>dom4j</artifactId>
-			<version>2.1.3</version>
+			<version>${dom4j.version}</version>
 		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>commons-collections</groupId>
+				<artifactId>commons-collections</artifactId>
+				<version>${commons-collections.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>
@@ -90,14 +105,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>commons-collections</groupId>
-				<artifactId>commons-collections</artifactId>
-				<version>3.2.2</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -25,14 +25,16 @@
 	<name>M2E Maven/Nexus Indexer</name>
 
 	<properties>
+		<maven-indexer.version>6.0.0</maven-indexer.version>
 		<guava.version>30.1-jre</guava.version>
+		<archetype-common.version>2.4</archetype-common.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven.indexer</groupId>
 			<artifactId>indexer-core</artifactId>
-			<version>6.0.0</version>
+			<version>${maven-indexer.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.maven</groupId>
@@ -53,7 +55,9 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<!-- TODO: this can be removed as soon as the sisu index file below is created in the main m2e maven build -->
+			<!-- TODO: this dependency is only required to compile the classes in this module and not at runtime because the org.eclipse.m2e.archetype.common
+				bundle is required by the bundle created from this module. Therefore it can be removed as soon as this bundle is build 
+				in the main m2e maven build -->
 			<groupId>org.apache.maven.archetype</groupId>
 			<artifactId>archetype-common</artifactId>
 			<version>${archetype-common.version}</version>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/pom.xml
@@ -23,6 +23,11 @@
 	<packaging>bundle</packaging>
 
 	<name>M2E SLF4J-Simple Binding for Embedded Maven Runtime</name>
+
+	<properties>
+		<slf4j-simple.version>1.7.30</slf4j-simple.version>
+	</properties>
+
 	<description>
   This bundle provides SLF4j implementation and configuration required to run m2e embedded Maven runtime
   in external JVM. This bundle is NOT a general purpose slf4j-simple OSGi bundle, it does NOT export
@@ -37,12 +42,6 @@
   this does not pollute OSGi classpath. Provide-Capability/Require-Capability would be cleaner, but
   I don't know if these are supported bu P2. 
   </description>
-
-	<properties>
-		<!-- maven core version -->
-		<slf4j-simple.version>1.7.30</slf4j-simple.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -24,7 +24,6 @@
 	<name>M2E - Maven runtime bundles</name>
 
 	<properties>
-		<archetype-common.version>2.4</archetype-common.version>
 		<dependency.jars.folder>jars</dependency.jars.folder>
 	</properties>
 


### PR DESCRIPTION
This PR unifies the version specification of embedded jars to be specified by properties that are defined in each runtime child-module rather than in the parent runtime-module. Specifying the version in the child-modules ensures that the corresponding runtime-module is touched by the git commit so the build qualifier is updated.
The only property that is really affected is `archetype-common.version`. Atm. it is duplicated in the `org.eclipse.m2e.archetype.common/pom.xml` and `org.eclipse.m2e.maven.indexer/pom.xml`, but in the latter it will be removed with PR #276.

Additionally unify the version specification to use only properties for in all modules and unify the element order.