### PR TITLE
[TargetPlatform] merge locations and specify versions

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -4,26 +4,36 @@
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.21/"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/egit/updates-5.13/"/>
 			<unit id="org.eclipse.jgit" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.27/"/>
 			<unit id="org.eclipse.emf.edit.ui.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.ecore.edit.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.22.0/R-3.22.0-20210612170523/repository/"/>
 			<unit id="org.eclipse.wst.common.uriresolver" version="0.0.0"/>
 			<unit id="org.eclipse.wst.common.emf" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-09/"/>
 			<unit id="com.google.gson" version="0.0.0"/>
 			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="ch.qos.logback.core" version="0.0.0"/>
 			<unit id="ch.qos.logback.classic" version="0.0.0"/>
 			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.21/"/>
-			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
-		</location>
+		<!-- Don't release as long as this points to SNAPSHOTs -->
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.0/"/>
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
At the moment m2e's target-file is composed of many different locations from different Eclipse project p2-repos.
But most of the IUs can be found in the `https://download.eclipse.org/releases/...` repo. Using that repo would reduce the number of locations and this simplify the target file.

With the reduced number of locations it is simpler to use stable repos (not like a latest repo that changes with each release) which gives us reproducible builds.

I have to admit that I never found and exact description of the difference between the `https://download.eclipse.org/releases/...` repos and the repos at `https://download.eclipse.org/eclipse/updates/...`, but my understanding is that the first contains all plug-ins and features used to build all of the pre-packaged Eclipse products while the latter only contains the plug-ins/features of the Eclipse platform/SDK? Is this correct?

With that understanding all IUs from the releases repo could be used for m2e's TP (because m2e only consumes them), except for `biz.aQute.bndlib`. `biz.aQute.bndlib` is included into the m2e-features and is contributed to the releases repo by m2e (at least I don't know any other Eclipse project using it, except Tycho), so if m2e would use that IU we would have boot-strapped us and could not update to a new version. This does not apply for the other IUs in the TP.

Only `org.eclipse.ui.tests.harness`, `org.eclipse.license.feature.group` and `org.eclipse.wildwebdeveloper.xml.feature.feature.group` cannot be consumed from the releases repo. The first two because they are not available and the latter because the releases repo only contains it in version 0.12.

For `biz.aQute.bndlib` I used a maven-target because we get a stable version with it and it is good if m2e uses its own features.