### PR TITLE
[Build] make build platform independent

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -70,7 +70,7 @@
 							<_snapshot>qualifier</_snapshot>
 
 							<Bundle-SymbolicName>${project.artifactId};singleton:=false</Bundle-SymbolicName>
-							<Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
+							<Bundle-RequiredExecutionEnvironment>JavaSE-${java.version}</Bundle-RequiredExecutionEnvironment>
 							<Bundle-Name>${project.name}</Bundle-Name>
 							<Bundle-Vendor>Eclipse.org - m2e</Bundle-Vendor>
 							<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 		<m2e.version>1.18.2</m2e.version>
 
 		<tycho-version>2.5.0</tycho-version>
+		<java.version>11</java.version>
 
 		<tycho.testArgLine>-Xmx800m</tycho.testArgLine>
 		<tycho.surefire.timeout>7200</tycho.surefire.timeout>
@@ -156,6 +157,23 @@
 							</restrictTo>
 						</filter>
 					</filters>
+					<environments>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
+					</environments>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -285,6 +303,7 @@
 					<artifactId>tycho-compiler-plugin</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
+						<release>${java.version}</release>
 						<!-- workaround https://bugs.eclipse.org/bugs/show_bug.cgi?id=571363 -->
 						<deriveReleaseCompilerArgumentFromTargetLevel>false</deriveReleaseCompilerArgumentFromTargetLevel>
 					</configuration>


### PR DESCRIPTION
This PR makes the build platform independent by specifying the `release` option for the compiler as well as the supported environments. The latter is actually not required because m2e does not have platform specific fragments, but it silences the warnings emitted at the beginning of each build.