### PR TITLE
[Build] ignore pomDependencies and remove unnecessary filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,23 +140,6 @@
 							<version>1.16.0-SNAPSHOT</version>
 						</artifact>
 					</target>
-					<pomDependencies>consider</pomDependencies>
-					<filters>
-						<filter>
-							<!-- Remove as it may come as an undesired transitive dep from p2 under Java 11 -->
-							<type>p2-installable-unit</type>
-							<id>javax.xml</id>
-							<removeAll />
-						</filter>
-						<filter>
-							<!-- See bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=566183 -->
-							<type>eclipse-plugin</type>
-							<id>org.apache.xerces</id>
-							<restrictTo>
-								<versionRange>[2.12.1,3.0.0)</versionRange>
-							</restrictTo>
-						</filter>
-					</filters>
 					<environments>
 						<environment>
 							<os>win32</os>


### PR DESCRIPTION
This PR suggest to ignore pom-dependencies that should not be required any more with the latest changes and to remove filters that also seem unnecessary.
The TP now contains the required `org.apache.xerces` version `2.12.1` and the build, especially the target-platform resolution is successful. Or did I miss something?