### PR TITLE
[Indexer] depend on guava, slf4j, javax instead of embedding them

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/pom.xml
@@ -26,7 +26,6 @@
 
 	<properties>
 		<maven-indexer.version>6.0.0</maven-indexer.version>
-		<guava.version>30.1-jre</guava.version>
 	</properties>
 
 	<dependencies>
@@ -51,12 +50,23 @@
 					<groupId>com.google.inject</groupId>
 					<artifactId>guice</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.inject</groupId>
+					<artifactId>javax.inject</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -97,9 +107,14 @@
 								org.apache.lucene.*;provider=m2e;mandatory:=provider,
 								org.apache.maven.*;provider=m2e;mandatory:=provider,
 							</_exportcontents>
+							<Import-Package>
+								org.slf4j;resolution:=optional;version="[1.6.2,2.0.0)"
+							</Import-Package>
 							<Require-Bundle>
 								org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)",
-								org.eclipse.m2e.archetype.common;bundle-version="[1.18.0,1.19.0)"
+								org.eclipse.m2e.archetype.common;bundle-version="[1.18.0,1.19.0)",
+								com.google.guava,
+								javax.inject
 							</Require-Bundle>
 						</instructions>
 					</configuration>


### PR DESCRIPTION
This PR removes the following embedded dependencies from the `org.eclipse.m2e.maven.indexer` bundle and adds dependencies the corresponding bundles/packages instead:

- com.google.guava-guava
Replaced by `Require-Bundle: com.google.guava`
- org.slf4j
Replaced by Import-Package: `org.slf4j` just like for `m2e.maven.runtime` (the other sub-packages imported in m2e.maven.runtime do not occur in the sources of the embedded jars).
- javax.inject
Replaced with a Require-Bundle `javax.inject` just like the m2e.maven.runtime (actually both could also just import the package `javax.inject` and I don't know if it is a good idea to re-export `javax.inject` from m2e.maven.runtime but that's another issue)
- javax.annotation
Looks like it is actually never used. At least I found no occurrence of `javax.annotation` in the sources. Therefore I just removed it.

This change safes about 3MB of jars (mainly driven by the removal of guava). Before this changes the expanded jars folder (without sources) had about ~8.6MB, now it has ~5.6MB. So we over 30% in size.