### PR TITLE
[TP] add biz.aQute.bndlib 5.3.0 via Maven-Target with fix version (#348)

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -47,7 +47,7 @@
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
-					<version>5.3.0</version>
+					<version>5.1.2</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
Don't use a latest version to avoid unintended/unaware automatic version
upgrades.

This solves issue #348 .