### PR TITLE
[MavenEmbeddedRuntime] Generalize/simplify classpath computation

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -157,6 +157,8 @@
 								org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="[1.18.0,1.19.0)",
 								javax.inject;bundle-version="1.0.0";visibility:=reexport
 							</Require-Bundle>
+							<!-- All direct dependencies specified as Require-Bundle or Import-package are added to the classpath of a launched
+								Maven-Build-JVM. See MavenEmbeddedRuntime for details. -->
 						</instructions>
 					</configuration>
 				</plugin>

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Bundles.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Bundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Igor Fedorenko
+ * Copyright (c) 2014, 2021 Igor Fedorenko
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,6 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.namespace.BundleNamespace;
 import org.osgi.framework.namespace.PackageNamespace;
-import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
 import org.slf4j.Logger;
@@ -73,14 +72,6 @@ public class Bundles {
 
   public static Bundle findDependencyBundle(Bundle bundle, String dependencyId) {
     return findDependencyBundle(bundle, dependencyId, new HashSet<Bundle>());
-  }
-
-  public static ClassLoader getBundleClassloader(Bundle bundle) {
-    BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
-    if(bundleWiring == null) {
-      return null;
-    }
-    return bundleWiring.getClassLoader();
   }
 
   public static List<String> getClasspathEntries(Bundle bundle) {
@@ -147,37 +138,6 @@ public class Bundles {
 
     log.debug("Bundle {} does not have entry {}", bundle.toString(), cp);
     return null;
-  }
-
-  private static Bundle findDependencyBundleByPackage(Bundle bundle, String packageName, Set<Bundle> visited) {
-    BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
-    if(bundleWiring == null) {
-      return null;
-    }
-    ArrayList<BundleWire> dependencies = new ArrayList<>();
-    dependencies.addAll(bundleWiring.getRequiredWires(BundleNamespace.BUNDLE_NAMESPACE));
-    dependencies.addAll(bundleWiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE));
-    for(BundleWire wire : dependencies) {
-      BundleCapability cap = wire.getCapability();
-      String pkg = (String) cap.getAttributes().get(PackageNamespace.PACKAGE_NAMESPACE);
-      Bundle requiredBundle = wire.getProviderWiring().getBundle();
-      if(requiredBundle != null) {
-        if(packageName.equals(pkg)) {
-          return requiredBundle;
-        }
-        if(visited.add(requiredBundle)) {
-          Bundle required = findDependencyBundleByPackage(requiredBundle, packageName, visited);
-          if(required != null) {
-            return required;
-          }
-        }
-      }
-    }
-    return null;
-  }
-
-  public static Bundle findDependencyBundleByPackage(Bundle bundle, String packageName) {
-    return findDependencyBundleByPackage(bundle, packageName, new HashSet<Bundle>());
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2021 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,9 @@
 
 package org.eclipse.m2e.core.internal.launch;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,6 +26,11 @@ import java.util.zip.ZipFile;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,43 +114,26 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
 
   private synchronized void initClasspath(Bundle mavenRuntimeBundle) {
     if(CLASSPATH == null) {
-      LinkedHashSet<String> allentries = new LinkedHashSet<>();
+      Set<String> allEntries = new LinkedHashSet<>();
 
-      addBundleClasspathEntries(allentries, mavenRuntimeBundle);
+      addBundleClasspathEntries(allEntries, mavenRuntimeBundle);
 
       Set<Bundle> bundles = new LinkedHashSet<>();
-      // find and add more bundles
-      for(String sname : new String[] {"org.eclipse.m2e.maven.runtime.slf4j.simple", "javax.inject"}) {
-        Bundle dependency = Bundles.findDependencyBundle(mavenRuntimeBundle, sname);
-        if(dependency != null) {
-          bundles.add(dependency);
-        } else {
-          log.warn(
-              "Could not find OSGi bundle with symbolic name ''{}'' required to launch embedded maven runtime in external process",
-              sname);
-        }
-      }
-
-      // find bundles by exported packages
-      for(String pname : new String[] {"org.slf4j", "org.slf4j.helpers", "org.slf4j.spi"}) {
-        Bundle dependency = Bundles.findDependencyBundleByPackage(mavenRuntimeBundle, pname);
-        if(dependency != null) {
-          bundles.add(dependency);
-        } else {
-          log.warn(
-              "Could not find OSGi bundle exporting package ''{}'' required to launch embedded maven runtime in external process",
-              pname);
-        }
-      }
+      // find and add required bundles and bundles providing imported packages
+      List<BundleWire> requiredWires = new ArrayList<>();
+      BundleWiring wiring = mavenRuntimeBundle.adapt(BundleWiring.class);
+      requiredWires.addAll(wiring.getRequiredWires(BundleNamespace.BUNDLE_NAMESPACE));
+      requiredWires.addAll(wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE));
+      requiredWires.stream().map(BundleWire::getProvider).map(BundleRevision::getBundle).forEach(bundles::add);
 
       for(Bundle bundle : bundles) {
-        addBundleClasspathEntries(allentries, bundle);
+        addBundleClasspathEntries(allEntries, bundle);
       }
 
       List<String> cp = new ArrayList<>();
       List<String> lcp = new ArrayList<>();
 
-      for(String entry : allentries) {
+      for(String entry : allEntries) {
         if(entry.contains("plexus-classworlds")) { //$NON-NLS-1$
           lcp.add(entry);
         } else {
@@ -203,23 +190,22 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
       }
 
       if(mavenCoreJarPath == null) {
-        throw new RuntimeException("Could not find maven core jar file");
+        throw new IllegalStateException("Could not find maven core jar file");
       }
 
       Properties pomProperties = new Properties();
 
-      File mavenCoreJar = new File(mavenCoreJarPath);
-      if(mavenCoreJar.isFile()) {
+      Path mavenCoreJar = Path.of(mavenCoreJarPath);
+      if(Files.isRegularFile(mavenCoreJar)) {
         try (ZipFile zip = new ZipFile(mavenCoreJarPath)) {
           ZipEntry zipEntry = zip.getEntry(MAVEN_CORE_POM_PROPERTIES);
           if(zipEntry != null) {
             pomProperties.load(zip.getInputStream(zipEntry));
           }
         }
-      } else if(mavenCoreJar.isDirectory()) {
-        try (InputStream is = new BufferedInputStream(
-            new FileInputStream(new File(mavenCoreJar, MAVEN_CORE_POM_PROPERTIES)))) {
-          pomProperties.load(is);
+      } else if(Files.isDirectory(mavenCoreJar)) {
+        try (Reader r = Files.newBufferedReader(mavenCoreJar.resolve(MAVEN_CORE_POM_PROPERTIES))) {
+          pomProperties.load(r);
         }
       }
 


### PR DESCRIPTION
This PR generalizes the classpath computation in `MavenEmbeddedRuntime` to add all directly required bundles of the `m2e.maven.runtime` bundle, that are specified via `Import-Package` or `Require-Bundle`, to the classpath of a launched Maven-build JVM.
At the moment the bundles to add are hard-coded into MavenEmbeddedRuntime, but are equivalent to the required-bundles/imported-packages of `m2e.maven.runtime`. But if we change the dependencies of `m2e.maven.runtime` the code in `MavenEmbeddedRuntime` would have to be adjusted as well, which brings the risk of forgetting it and different behaviour. Furthermore the new code is just simpler.


This PR also performs some minor code improvements and removes (now) unused methods.