### PR TITLE
Fix multiple SLF4J bindings warning (#354)

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
@@ -116,7 +116,7 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
     if(CLASSPATH == null) {
       Set<String> allEntries = new LinkedHashSet<>();
 
-      addBundleClasspathEntries(allEntries, mavenRuntimeBundle);
+      addBundleClasspathEntries(allEntries, mavenRuntimeBundle, true);
 
       Set<Bundle> bundles = new LinkedHashSet<>();
       // find and add required bundles and bundles providing imported packages
@@ -127,7 +127,7 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
       requiredWires.stream().map(BundleWire::getProvider).map(BundleRevision::getBundle).forEach(bundles::add);
 
       for(Bundle bundle : bundles) {
-        addBundleClasspathEntries(allEntries, bundle);
+        addBundleClasspathEntries(allEntries, bundle, false);
       }
 
       List<String> cp = new ArrayList<>();
@@ -146,10 +146,10 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
     }
   }
 
-  private void addBundleClasspathEntries(Set<String> entries, Bundle bundle) {
+  private void addBundleClasspathEntries(Set<String> entries, Bundle bundle, boolean addFragments) {
     entries.addAll(Bundles.getClasspathEntries(bundle));
-    Bundle[] fragments = Platform.getFragments(bundle);
-    if(fragments != null) {
+    Bundle[] fragments;
+    if(addFragments && (fragments = Platform.getFragments(bundle)) != null) {
       for(Bundle fragment : fragments) {
         entries.addAll(Bundles.getClasspathEntries(fragment));
       }


### PR DESCRIPTION
This PR fixes #354 by only adding fragments of `org.eclipse.m2e.maven.runtime` to the classpath of a launched Maven-build JVM.
Fragments of dependencies of `org.eclipse.m2e.maven.runtime` are now ignored.

As described in that issue, this avoids that `ch.qos.logback.slf4j` is added to the Maven-JVM's classpath and therefore avoids that multiple SLF4J bindings are present. `ch.qos.logback.slf4j` without logback.classic and -core is actually incomplete and would never work (probably NoClassDefErrors would be thrown). But luckily `ch.qos.logback.slf4j` was never chosen as binding (probably because it was placed later on the classpath).