### PR TITLE
Set m2e.version property for 1.18.3. development iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
 		<!-- Current target version of m2e, used to deduce some URL at verify and publish.
 			This should usually be sync'd with the main feature version. -->
-		<m2e.version>1.18.2</m2e.version>
+		<m2e.version>1.18.3</m2e.version>
 
 		<tycho-version>2.5.0</tycho-version>
 


### PR DESCRIPTION
To prepare for a the 1.1.8.3 development the `<m2e.version>` has to be bumped in the root `pom.xml`, otherwise the snapshots are published under the old URL.

The versions of the m2e.feature and m2e.sdk.feature were already bumped in the previous commit.