### PR TITLE
Unify/simplify Bundle-Vendor/Name data for m2e.profiles

### DIFF
--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -1,9 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %Bundle-Name
+Bundle-Name: M2E Maven Profiles Management
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
 Bundle-Version: 1.17.2.qualifier
-Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.m2e.profiles.core.internal.MavenProfilesCoreActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
@@ -11,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.16.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-Vendor: %Bundle-Vendor
+Bundle-Vendor: Eclipse.org - m2e
 Export-Package: org.eclipse.m2e.profiles.core.internal;x-friends:="org.eclipse.m2e.profiles.ui",
  org.eclipse.m2e.profiles.core.internal.management;x-internal:=true
 Automatic-Module-Name: org.eclipse.m2e.profiles.core

--- a/org.eclipse.m2e.profiles.core/build.properties
+++ b/org.eclipse.m2e.profiles.core/build.properties
@@ -2,6 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.properties,\
                about.html
 src.includes = about.html

--- a/org.eclipse.m2e.profiles.core/plugin.properties
+++ b/org.eclipse.m2e.profiles.core/plugin.properties
@@ -1,2 +1,0 @@
-Bundle-Vendor = Eclipse.org - m2e
-Bundle-Name = Maven Profiles Management


### PR DESCRIPTION
This PR performs the same metadata improvements like already done in #339 for other m2e plug-ins.
This plug-in was not changed in the mentioned PR because it would require a version-bump just for metadata adjustments, but now there was already another change.