### PR TITLE
Add repository reference for LemMinX-Editor requirements (#406)

### DIFF
--- a/org.eclipse.m2e.site/category.xml
+++ b/org.eclipse.m2e.site/category.xml
@@ -22,4 +22,6 @@
       <category name="m2e"/>
    </feature>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
+   <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.1/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.20.0/" enabled="true" />
 </site>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -34,11 +34,11 @@
 			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.1/"/>
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.1/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.site/category.xml-->
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.0/"/>
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.site/category.xml-->
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
As suggest in #406 this PR adds references pointing to the repositories providing the LemMinX requirements to the m2e-site repo. This simplifies installation of the `org.eclipse.m2e.lemminx.feature` (i.e. without need to specifiy more repo-URLs than the m2e one) for versions of m2e (release or snapshot) that were not yet assembled into an Eclipse Sim-Rel.

I added comments to m2e's target file to remind us to keep the repos-URLs in sync.
If one day any of those repos can be removed from the TP (possibly https://download.eclipse.org/lsp4e/releases if wildwebdeveloper regularly catches up), the corresponding reference should also be removed from the m2e-repo as well.