### PR TITLE
[SDK-Feature] Include all m2e features and add missing sources

### DIFF
--- a/org.eclipse.m2e.sdk.feature/feature.properties
+++ b/org.eclipse.m2e.sdk.feature/feature.properties
@@ -16,7 +16,7 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=M2E - Extensions Development Support (optional)
+featureName=M2E - Complete Development Kit (optional)
 
 # "providerName" property - name of the company that provides the feature
 providerName=Eclipse.org - m2e
@@ -25,7 +25,7 @@ providerName=Eclipse.org - m2e
 #updateSiteName=The Eclipse Project Updates
 
 # "description" property - description of the feature
-description=M2Eclipse Extensions Development Support (Optional)
+description=The full M2Eclipse Software Development Kit that contains all m2e plug-ins and features and their sources. (Optional)
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -221,11 +221,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.m2e.workspace.cli.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.18.3.qualifier"
+      version="1.19.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -18,6 +18,26 @@
    <license url="%licenseURL">
       %license
    </license>
+
+   <includes
+         id="org.eclipse.m2e.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.m2e.lemminx.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.m2e.logback.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.m2e.pde.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.m2e.sse.ui.feature"
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.m2e.tests.common"
@@ -168,6 +188,41 @@
 
    <plugin
          id="org.eclipse.m2e.importer.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="biz.aQute.bndlib.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.m2e.editor.lemminx.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.m2e.pde.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.m2e.pde.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.m2e.workspace.cli.source"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,7 @@
 								<url>https://download.eclipse.org/technology/m2e/snapshots/latest/</url>
 							</repository>
 						</baselineRepositories>
+						<baselineReplace>common</baselineReplace>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
This PR suggests to include all m2e features into the m2e.sdk feature so it transitively contains all m2e plug-ins (plus bndlib and workspace.cli). Besides that this PR adds the missing source bundles.
Only the sources of the Maven-runtime components are not added because I assume that they will not work in the form they are produced now (they have to be adjusted in later PR, but I have to make myself familiar if and how nested sources jars are supported).

Having a sdk feature that contains all plug-ins of a project and their sources simplifies development of m2e-based plug-ins because one just has to add the m2e.sdk to the target-platform and gets all m2e plug-ins and their sources.

Furthermore this ensures that the version of the m2e.sdk is always the same as the version of the whole m2e project (because whenever m2e plug-in changes its version the m2e.sdk feature is forced by the build to have a corresponding version bump). This allows to use the m2e.sdk version to automatically derive the current snapshot repo version and makes the `m2e.version` property in the root pom.xml obsolete. I'm about to prepare a follow-up PR for this.

Additionally I (IMHO) enhanced the name and description of the SDK-feature.