### PR TITLE
[PDE] update biz.aQute.bndlib and -util to version 6.2.0

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -40,6 +40,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.osgi.service.repository"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.m2e.pde.target"
          download-size="0"
          install-size="0"

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -50,13 +50,19 @@
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bnd.util</artifactId>
-					<version>6.0.0</version>
+					<version>6.3.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
-					<version>6.0.0</version>
+					<version>6.3.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.service.repository</artifactId>
+					<version>1.1.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
This PR aims to update `biz.aQute.bndlib` and `biz.aQute.bnd.util` to version 6.1.0.

But this it requires the following OSGi packages that are not yet present in Equinox:
- org.osgi.util.function version 1.2.0
- org.osgi.util.promise 1.2.0
- org.osgi.service.repository 1.1.0

For the first two packages only in version 1.1.0 respectively 1.1.1. is present in Equinox (in the bundle `org.eclipse.osgi.util`).
The latter seems not to be included in Equinox at all (at least I could not find it in the rt.equinox repos).

I think we should not ship those packages with m2e, therefore I'll see what I can do in this regard in Equinox, but we have to wait for Eclipse 2022-03 M1.
