### PR TITLE
[UITests] eliminate race-condition and rework ConsoleTest (#341)

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -8,13 +8,9 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse.org - m2e
 Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.junit;bundle-version="4.12.0",
- org.eclipse.core.resources,
  org.eclipse.core.runtime,
- org.eclipse.m2e.maven.runtime;bundle-version="1.10.0",
  org.eclipse.m2e.launching;bundle-version="1.17.2",
  org.eclipse.debug.core,
- org.eclipse.ui.console,
- org.eclipse.jface.text
-Import-Package: javax.annotation;version="1.2.0"
+ org.eclipse.ui.console
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.m2e.core.tests

--- a/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
+++ b/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
@@ -13,52 +13,124 @@
 
 package org.eclipse.m2e.core.ui.tests;
 
-import static org.junit.Assert.assertEquals;
+import static java.util.function.Predicate.not;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
-import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.m2e.actions.MavenLaunchConstants;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleListener;
+import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.TextConsole;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+@SuppressWarnings("restriction")
 public class ConsoleTest extends AbstractMavenProjectTestCase {
 
-  @Test
-  public void testConsoleHasOutput() throws Exception {
-	  var launchManager = DebugPlugin.getDefault().getLaunchManager();
-	  var configName = launchManager.generateLaunchConfigurationName("testConsole");
-	  var wc = launchManager.getLaunchConfigurationType(MavenLaunchConstants.LAUNCH_CONFIGURATION_TYPE_ID).newInstance(null, configName);
-	  var pomFile = new File(FileLocator.toFileURL(getClass().getResource("/resources/projects/simplePomOK/pom.xml")).getPath());
-	  wc.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, pomFile.getParent());
-	  wc.setAttribute(MavenLaunchConstants.ATTR_GOALS, "verify");
-	  wc.setAttribute(MavenLaunchConstants.ATTR_POM_DIR, pomFile.getParent());
-	  var consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-	  var consolesBefore = Arrays.stream(consoleManager.getConsoles()).collect(Collectors.toSet());
-	  ILaunch launch = wc.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
-	  while (!launch.isTerminated()) {
-		  Thread.sleep(200);
-	  }
-	  Set<IConsole> consolesAfter = new HashSet<>();
-	  consolesAfter.addAll(List.of(consoleManager.getConsoles()));
-	  consolesAfter.removeAll(consolesBefore);
-	  assertEquals("console not found", 1, consolesAfter.size());
-	  var mavenConsole = consolesAfter.iterator().next();
-	  System.out.println("Console Text: " + ((TextConsole)mavenConsole).getDocument().get());
-	  assertTrue("missing output in console", ((TextConsole)mavenConsole).getDocument().get().contains("BUILD SUCCESS"));
-  }
+	@BeforeClass
+	public static void initialize() {
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		if (display.getThread() == Thread.currentThread()) {
+			fail("Test cannot succeed in UI-Thread. Disable 'Run in UI thread' in this tests launch configuration.");
+			// The IOConsolePartitioner, that is responsible to transfer the print-out of
+			// the Maven build process to the Eclipse console runs in the UI-thread. If this
+			// test is running in the same thread, it blocks the UI-Thread until it
+			// terminates and consequently the awaited output is not added to the
+			// console-Document before this test can read it.
+		}
+	}
 
+	private static final String TEST_POM = "/resources/projects/simplePomOK/pom.xml";
+
+	@Test
+	public void testConsoleHasOutputAndHasNoMultipleSLF4Jwarnings() throws Exception {
+		File pomFile = new File(FileLocator.toFileURL(ConsoleTest.class.getResource(TEST_POM)).toURI());
+
+		CompletableFuture<IConsole> consoleAfterStartSupplier = getConsoleAfterLaunchSupplier();
+
+		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+		String configName = launchManager.generateLaunchConfigurationName("testConsole");
+		var configType = launchManager.getLaunchConfigurationType(MavenLaunchConstants.LAUNCH_CONFIGURATION_TYPE_ID);
+		var wc = configType.newInstance(null, configName);
+		wc.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, pomFile.getParent());
+		wc.setAttribute(MavenLaunchConstants.ATTR_GOALS, "verify");
+		wc.setAttribute(MavenLaunchConstants.ATTR_POM_DIR, pomFile.getParent());
+		wc.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
+
+		IConsole mavenConsole = consoleAfterStartSupplier.get(30, TimeUnit.SECONDS);
+		IDocument document = ((TextConsole) mavenConsole).getDocument();
+
+		CountDownLatch finishedRead = new CountDownLatch(1);
+		document.addDocumentListener(new IDocumentListener() {
+			@Override
+			public void documentChanged(DocumentEvent event) {
+				if (isBuildFinished(event.getText())) {
+					finishedRead.countDown(); // called from UI-Thread where the document updates are performed too
+				}
+			}
+
+			@Override
+			public void documentAboutToBeChanged(DocumentEvent event) { // ignore
+			}
+		});
+
+		// First check if the full build print-out was already written. If not, wait
+		// for the document-listener's signal
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		String consoleText = display.syncCall(document::get);
+		if (!isBuildFinished(consoleText) && !finishedRead.await(30, TimeUnit.SECONDS)) {
+			fail("Build timed out.");
+		}
+		consoleText = display.syncCall(document::get); // final document content could have changed
+
+		assertTrue("Expecting BUILD SUCCESS in console output but got:\n" + consoleText,
+				lines(consoleText).anyMatch(l -> l.equals("[INFO] BUILD SUCCESS")));
+		assertTrue("Expecting no 'multiple SLF4J bindings'-Warning in console output but got:\n" + consoleText,
+				lines(consoleText).noneMatch(l -> l.contains("SLF4J: Class path contains multiple SLF4J bindings")));
+	}
+
+	private static boolean isBuildFinished(String text) {
+		return lines(text).anyMatch(l -> l.startsWith("[INFO] Finished at"));
+	}
+
+	private static final Pattern LINE_SEPARATOR = Pattern.compile("\\R");
+
+	private static Stream<String> lines(String consoleText) {
+		return LINE_SEPARATOR.splitAsStream(consoleText).map(String::strip).filter(not(String::isEmpty));
+	}
+
+	private CompletableFuture<IConsole> getConsoleAfterLaunchSupplier() {
+		IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+		CompletableFuture<IConsole> container = new CompletableFuture<>();
+		consoleManager.addConsoleListener(new IConsoleListener() {
+			@Override
+			public void consolesRemoved(IConsole[] consoles) { // No-Op
+			}
+
+			@Override
+			public void consolesAdded(IConsole[] consoles) {
+				container.complete(consoles[0]);
+			}
+		});
+		return container;
+	}
 }


### PR DESCRIPTION
This PR aims to resolves issue https://github.com/eclipse-m2e/m2e-core/issues/341.

Previously test case did not ensure that the full console print-out written by the Maven-build process was transferred to the Maven-Processe's console-IDocument. The write to the console-IDocument happens in the UI-Thread while the test case is executed and reads from another (worker)-thread.
This lead to the suspected race-condition, because without synchronization it happened that, after the process had termianted, the test-thread read the console-document before the UI-thread wrote the process output to it.

Additionally this PR adds a check for a 'multiple SLF4J bindings' warning to guard against https://github.com/eclipse-m2e/m2e-core/issues/354.