### PR TITLE
[Build] remove forge-parent parent and clean up

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -26,7 +26,6 @@
 	<properties>
 		<dependency.jars.folder>jars</dependency.jars.folder>
 		<dependency.sources.folder>jars/sources</dependency.sources.folder>
-		<metadata.templates.folder>metadataTemplates</metadata.templates.folder>
 	</properties>
 
 	<modules>
@@ -84,7 +83,6 @@
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-packaging-plugin</artifactId>
-					<version>${tycho-version}</version>
 					<configuration>
 						<jgit.ignore>
 							.project
@@ -109,7 +107,6 @@
 						<plugin>
 							<groupId>org.eclipse.tycho</groupId>
 							<artifactId>tycho-packaging-plugin</artifactId>
-							<version>${tycho-version}</version>
 							<executions>
 								<execution>
 									<id>default-build-qualifier</id>
@@ -176,8 +173,6 @@
 					<plugin>
 						<groupId>org.apache.felix</groupId>
 						<artifactId>maven-bundle-plugin</artifactId>
-						<configuration>
-						</configuration>
 						<executions>
 							<execution>
 								<id>generate-manifest</id>

--- a/org.eclipse.m2e.core.tests/pom.xml
+++ b/org.eclipse.m2e.core.tests/pom.xml
@@ -36,7 +36,6 @@
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
-					<version>${tycho-version}</version>
 					<configuration>
 						<useUIHarness>false</useUIHarness>
 						<useUIThread>false</useUIThread>

--- a/org.eclipse.m2e.core.ui.tests/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/pom.xml
@@ -36,7 +36,6 @@
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
-					<version>${tycho-version}</version>
 					<configuration>
 						<useUIHarness>true</useUIHarness>
 						<useUIThread>false</useUIThread>

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -24,15 +24,12 @@
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>
 
-	<properties>
-		<modello.version>1.5</modello.version>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.modello</groupId>
 				<artifactId>modello-maven-plugin</artifactId>
+				<version>1.5</version>
 				<executions>
 					<execution>
 						<id>standard</id>
@@ -44,15 +41,13 @@
 						<configuration>
 							<outputDirectory>${project.basedir}/src-gen</outputDirectory>
 							<version>1.0.0</version>
+							<useJava5>true</useJava5>
 							<models>
 								<model>mdo/lifecycle-mapping-metadata-model.xml</model>
 							</models>
 						</configuration>
 					</execution>
 				</executions>
-				<configuration>
-					<useJava5>true</useJava5>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -28,6 +28,7 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<executions>
 					<execution>

--- a/org.eclipse.m2e.profiles.core.tests/pom.xml
+++ b/org.eclipse.m2e.profiles.core.tests/pom.xml
@@ -24,7 +24,6 @@
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
-					<version>${tycho-version}</version>
 					<configuration>
 						<useUIHarness>false</useUIHarness>
 						<useUIThread>false</useUIThread>

--- a/org.eclipse.m2e.site/pom.xml
+++ b/org.eclipse.m2e.site/pom.xml
@@ -63,7 +63,6 @@
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-p2-repository-plugin</artifactId>
-						<version>${tycho-version}</version>
 						<executions>
 							<execution>
 								<id>update</id>

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.sonatype.forge</groupId>
-		<artifactId>forge-parent</artifactId>
-		<version>10</version>
-		<relativePath />
-	</parent>
-
 	<groupId>org.eclipse.m2e</groupId>
 	<artifactId>m2e-core</artifactId>
 	<version>1.16.0-SNAPSHOT</version>
@@ -212,6 +205,11 @@
 
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-packaging-plugin</artifactId>


### PR DESCRIPTION
The currently specified `forge-parent` of m2e's root pom.xml is heavily outdated (10 years old), `forge-parent` is not maintained and its usage is generally not recommended any more (I can't find the reference at the moment). To make it short, we should remove it.

Additionally this PR contains some marginal clean-ups.