### PR TITLE
[PDE] mark package org.eclipse.m2e.pde  as internal

### DIFF
--- a/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.m2e.maven.runtime,
  org.eclipse.m2e.core,
  org.eclipse.core.resources
-Export-Package: org.eclipse.m2e.pde
+Export-Package: org.eclipse.m2e.pde;x-friends:="org.eclipse.m2e.pde.ui"
 Bundle-Activator: org.eclipse.m2e.pde.Activator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.codec.digest;version="1.14.0",


### PR DESCRIPTION
Because the only (exported) package of the `org.eclipse.m2e.pde `is not considered public API (as for example stated in https://github.com/eclipse-m2e/m2e-core/pull/440#issuecomment-993306343) we should mark the package as such to make users aware of that fact.
Otherwise downstream-adaptors could accidentally use the classes from that package like public API, unless they have searched in the depths of the m2e-github repo.

Since org.eclipse.m2e.pde has been released in this form already _actually_ it is already public API, but since this happened not so long ago and adaptors are unlikely (or if it happened there is a high chance that they are still active and can adapt accordingly or complain), I propose to make an exception and mark this package as internal afterwards.

@laeubi, @mickaelistria what do you think?