### PR TITLE
Remove unnecessary description file and buildall.sh script

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-mvn -f m2e-maven-runtime/pom.xml clean generate-sources -Dtycho.mode=maven -Pgenerate-osgi-metadata
-mvn clean install

--- a/description
+++ b/description
@@ -1,1 +1,0 @@
-m2eclipse-core repository


### PR DESCRIPTION
The `description` file in the repository root seems to be not necessary any more. It was added in Commit a9c878c2624b33d8c74062717bf75302f0ae1fa7 which says the purpose was to "Add repo description file for proper display in http://git.eclipse.org/". Because m2e is hosted at GitHub this file seems to be unnecessary.

Furthermore I think we should remove the `buildall.sh` script. It is not used in the build and does not work for developers on Windows. To build m2e locally an equivalent launch group `m2e-core--build-all` is provided now and if one wants to build from the command line, the instructions are listed in the CONTRIBUTING.md. So the mentioned script does not add much value but has to be maintained to be in sync with the current build procedure.