### PR TITLE
[Build] improve snapshot deployment (remove <version>/latest and clear)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,18 +41,16 @@ pipeline {
 						deployM2ERepository()
 						{
 							echo Deploy m2e repo to ${1}
-							ssh genie.m2e@projects-storage.eclipse.org "\
-								rm -rf  ${1}/* && \
-								mkdir -p ${1}"
+							ssh genie.m2e@projects-storage.eclipse.org "mkdir -p ${1}"
 							scp -r org.eclipse.m2e.site/target/repository/* genie.m2e@projects-storage.eclipse.org:${1}
 						}
 						M2E_VERSION=$(<"org.eclipse.m2e.sdk.feature/target/m2e.version")
-						SNAPSHOT_VERSIONED_AREA=/home/data/httpd/download.eclipse.org/technology/m2e/snapshots/${M2E_VERSION}/latest
-						SNAPSHOT_LATEST_AREA=/home/data/httpd/download.eclipse.org/technology/m2e/snapshots/latest
-
 						echo M2E_VERSION=$M2E_VERSION
-						deployM2ERepository $SNAPSHOT_VERSIONED_AREA
-						deployM2ERepository $SNAPSHOT_LATEST_AREA
+
+						ssh genie.m2e@projects-storage.eclipse.org "rm -rf /home/data/httpd/download.eclipse.org/technology/m2e/snapshots/*"
+
+						deployM2ERepository /home/data/httpd/download.eclipse.org/technology/m2e/snapshots/${M2E_VERSION}
+						deployM2ERepository /home/data/httpd/download.eclipse.org/technology/m2e/snapshots/latest
 					'''
 				}
 			}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Alternatively, you can install the lastest M2Eclipse release by using the _Insta
 To use the latest snapshot build, you can use this p2 repository:<br>
 https://download.eclipse.org/technology/m2e/snapshots/latest/
 
-To use snapshots only for the current version under development, you can add a p2 repository like the following as available software site:<br>
+To use snapshots only for the current version under development, you can add a p2 repository like the following:<br>
 `https://download.eclipse.org/technology/m2e/snapshots/<version-under-development>`<br>
 This version-specific snapshot repository is deleted at the next release so you will automatically fallback to the regular release updates.
 The variable `<version-under-development>` has to be replaced by the current version under development version.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ into your Eclipse-IDE, or use the Eclipse Marketplace Client directly from withi
 
 ⚠️ _Some other entries exist that look like m2e. They're usually outdated or incorrect. Please use the official one, linked above._
 
-Alternatively, you can install the lastest M2Eclipse release by using the _Install New Software_ dialog in Eclipse IDE, pointing it to this p2 repository:<br> https://download.eclipse.org/technology/m2e/releases/latest/
+Alternatively, you can install the lastest M2Eclipse release by using the _Install New Software_ dialog in Eclipse IDE, pointing it to this p2 repository:<br>
+https://download.eclipse.org/technology/m2e/releases/latest/
 
 To use the latest snapshot build, you can use this p2 repository:<br>
 https://download.eclipse.org/technology/m2e/snapshots/latest/

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ into your Eclipse-IDE, or use the Eclipse Marketplace Client directly from withi
 
 ⚠️ _Some other entries exist that look like m2e. They're usually outdated or incorrect. Please use the official one, linked above._
 
-Alternatively, you can install the lastest M2Eclipse release by using the _Install New Software_ dialog in Eclipse IDE, pointing it to this p2 repository: https://download.eclipse.org/technology/m2e/releases/latest/
+Alternatively, you can install the lastest M2Eclipse release by using the _Install New Software_ dialog in Eclipse IDE, pointing it to this p2 repository:<br> https://download.eclipse.org/technology/m2e/releases/latest/
 
 To use the latest snapshot build, you can use this p2 repository:<br>
-`https://download.eclipse.org/technology/m2e/snapshots/latest/`
+https://download.eclipse.org/technology/m2e/snapshots/latest/
 
-If you only want to use snapshots for the current version under development you can add a p2 repository like the following as available software site:<br>
+To use snapshots only for the current version under development, you can add a p2 repository like the following as available software site:<br>
 `https://download.eclipse.org/technology/m2e/snapshots/<version-under-development>`<br>
 This version-specific snapshot repository is deleted at the next release so you will automatically fallback to the regular release updates.
-The variable `<version-under-development>` has to be replaced by the current version under development version:
+The variable `<version-under-development>` has to be replaced by the current version under development version.
 
 ## 📢 Release notes
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ into your Eclipse-IDE, or use the Eclipse Marketplace Client directly from withi
 
 Alternatively, you can install the lastest M2Eclipse release by using the _Install New Software_ dialog in Eclipse IDE, pointing it to this p2 repository: https://download.eclipse.org/technology/m2e/releases/latest/
 
-To use the latest snapshot build, you can use this p2 repository: https://download.eclipse.org/technology/m2e/snapshots/latest/
+To use the latest snapshot build, you can use this p2 repository:<br>
+`https://download.eclipse.org/technology/m2e/snapshots/latest/`
+
+If you only want to use snapshots for the current version under development you can add a p2 repository like the following as available software site:<br>
+`https://download.eclipse.org/technology/m2e/snapshots/<version-under-development>`<br>
+This version-specific snapshot repository is deleted at the next release so you will automatically fallback to the regular release updates.
+The variable `<version-under-development>` has to be replaced by the current version under development version:
 
 ## 📢 Release notes
 


### PR DESCRIPTION
With this PR I propose to
1. remove the 'latest' subfolder for the snapshot repo with a specific version to align better with snapshots/latest and releases.
The current `https://download.eclipse.org/technology/m2e/snapshots/1.19.1/latest/` would become `https://download.eclipse.org/technology/m2e/snapshots/1.19.1/`. Because there are no subversions or similar, the latest-subfolder has no advantage.

2. completely clear `download.e.o/tech/m2e/snapshots` before the snapshot-repo of a current master build is deployed.
 This way an old version repo is removed automatically once a new one is available.

3. inline only once used variables in the Jenkins file

@mickaelistria check you please check that the syntax is correct (I'm not a master of the linux shell).