### PR TITLE
[Build] generate source-features by Tycho and include them into m2e-SDK

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/build.properties
@@ -4,4 +4,3 @@ bin.includes = META-INF/,\
                .,\
                jars/
 bin.excludes = jars/sources/
-src.includes = jars/sources/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.indexer/build.properties
@@ -5,4 +5,3 @@ bin.includes = META-INF/,\
                .,\
                jars/
 bin.excludes = jars/sources/
-src.includes = jars/sources/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime.slf4j.simple/build.properties
@@ -4,4 +4,3 @@ bin.includes = META-INF/,\
                .,\
                jars/
 bin.excludes = jars/sources/
-src.includes = jars/sources/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/build.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/build.properties
@@ -4,4 +4,3 @@ bin.includes = META-INF/,\
                .,\
                jars/
 bin.excludes = jars/sources/
-src.includes = jars/sources/

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -89,11 +89,57 @@
 							.classpath
 							.settings/
 							.polyglot.*
+							build.properties
 						</jgit.ignore>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>3.2.0</version>
+					<configuration>
+						<overWriteReleases>true</overWriteReleases>
+						<overWriteSnapshots>true</overWriteSnapshots>
+						<excludeScope>provided</excludeScope>
+						<includeScope>runtime</includeScope> <!-- only include runtime and compile time dependencies, not test or provided! -->
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-source-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<additionalFileSets>
+							<fileSet>
+								<directory>${project.build.directory}/${dependency.sources.folder}</directory>
+								<includes>
+									<include>**/*.java</include>
+								</includes>
+							</fileSet>
+						</additionalFileSets>
 					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>fetch-flat-dependency-sources</id> <!-- These are used to build source-plugins -->
+						<goals>
+							<goal>unpack-dependencies</goal>
+						</goals>
+						<phase>process-resources</phase>
+						<configuration>
+							<outputDirectory>${project.build.directory}/${dependency.sources.folder}</outputDirectory>
+							<classifier>sources</classifier>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 
 	<profiles>
@@ -139,13 +185,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>
-						<version>3.2.0</version>
-						<configuration>
-							<overWriteReleases>true</overWriteReleases>
-							<overWriteSnapshots>true</overWriteSnapshots>
-							<excludeScope>provided</excludeScope>
-							<includeScope>runtime</includeScope><!-- only include runtime and compile time dependencies, not test or provided! -->
-						</configuration>
 						<executions>
 							<execution>
 								<id>fetch-dependencies</id>
@@ -158,7 +197,7 @@
 								</configuration>
 							</execution>
 							<execution>
-								<id>fetch-dependency-sources</id>
+								<id>fetch-dependency-sources</id> <!-- These are used in the workspace -->
 								<goals>
 									<goal>copy-dependencies</goal>
 								</goals>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -113,7 +113,7 @@
 							<fileSet>
 								<directory>${project.build.directory}/${dependency.sources.folder}</directory>
 								<includes>
-									<include>**/*.java</include>
+									<include>**/*</include>
 								</includes>
 							</fileSet>
 						</additionalFileSets>
@@ -135,6 +135,50 @@
 						<configuration>
 							<outputDirectory>${project.build.directory}/${dependency.sources.folder}</outputDirectory>
 							<classifier>sources</classifier>
+							<useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>move-java-files-to-source-bundle-root</id>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<phase>process-resources</phase>
+						<configuration>
+							<target>
+								<taskdef resource="net/sf/antcontrib/antlib.xml" />
+								<for param="javaFile">
+									<!--Ant-contrib tasks already defined in calling script -->
+									<dirset dir="${project.build.directory}/${dependency.sources.folder}" erroronmissingdir="false">
+										<depth min="0" max="0" />
+									</dirset>
+									<sequential>
+										<local name="dirName" />
+										<basename property="dirName" file="@{javaFile}" />
+										<move todir="${project.build.directory}/${dependency.sources.folder}">
+											<fileset dir="${project.build.directory}/${dependency.sources.folder}/${dirName}">
+												<include name="**/*.java" />
+											</fileset>
+										</move>
+										<!-- Delete now empty directories -->
+										<delete includeemptydirs="true">
+											<fileset dir="${project.build.directory}/${dependency.sources.folder}">
+												<and>
+													<size value="0" />
+													<type type="dir" />
+												</and>
+											</fileset>
+										</delete>
+
+									</sequential>
+								</for>
+							</target>
 						</configuration>
 					</execution>
 				</executions>

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -24,7 +24,15 @@
          version="0.0.0"/>
 
    <includes
+         id="org.eclipse.m2e.feature.source"
+         version="0.0.0"/>
+
+   <includes
          id="org.eclipse.m2e.lemminx.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.m2e.lemminx.feature.source"
          version="0.0.0"/>
 
    <includes
@@ -32,11 +40,23 @@
          version="0.0.0"/>
 
    <includes
+         id="org.eclipse.m2e.logback.feature.source"
+         version="0.0.0"/>
+
+   <includes
          id="org.eclipse.m2e.pde.feature"
          version="0.0.0"/>
 
    <includes
+         id="org.eclipse.m2e.pde.feature.source"
+         version="0.0.0"/>
+
+   <includes
          id="org.eclipse.m2e.sse.ui.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.m2e.sse.ui.feature.source"
          version="0.0.0"/>
 
    <plugin
@@ -48,174 +68,6 @@
 
    <plugin
          id="org.eclipse.m2e.tests.common.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.model.edit.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.core.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.launching.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.jdt.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.jdt.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.editor.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.editor.xml.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.refactoring.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.discovery.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.core.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.scm.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.profiles.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.profiles.core.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.logback.configuration.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.logback.appender.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.sourcelookup.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.sourcelookup.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.binaryproject.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.binaryproject.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.importer.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="biz.aQute.bndlib.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.editor.lemminx.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.pde.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.m2e.pde.ui.source"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -166,10 +166,6 @@
 						</goals>
 						<configuration>
 							<excludes>
-								<plugin id="org.eclipse.m2e.archetype.common" />
-								<plugin id="org.eclipse.m2e.maven.indexer" />
-								<plugin id="org.eclipse.m2e.maven.runtime" />
-								<plugin id="org.eclipse.m2e.maven.runtime.slf4j.simple" />
 								<plugin id="org.eclipse.m2e.workspace.cli" />
 							</excludes>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,21 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>feature-source</id>
+						<goals>
+							<goal>feature-source</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<plugin id="org.eclipse.m2e.archetype.common" />
+								<plugin id="org.eclipse.m2e.maven.indexer" />
+								<plugin id="org.eclipse.m2e.maven.runtime" />
+								<plugin id="org.eclipse.m2e.maven.runtime.slf4j.simple" />
+								<plugin id="org.eclipse.m2e.workspace.cli" />
+							</excludes>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>
@@ -200,6 +215,22 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>p2-metadata</id>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+						<phase>package</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<defaultP2Metadata>false</defaultP2Metadata>
+				</configuration>
 			</plugin>
 		</plugins>
 
@@ -354,23 +385,6 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>tycho-p2-plugin</artifactId>
-						<version>${tycho-version}</version>
-						<executions>
-							<execution>
-								<id>p2-metadata</id>
-								<goals>
-									<goal>p2-metadata</goal>
-								</goals>
-								<phase>package</phase>
-							</execution>
-						</executions>
-						<configuration>
-							<defaultP2Metadata>false</defaultP2Metadata>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR has the goal to generate source features for each m2e-feature using the `tycho-source:feature-source` Mojo and to include them in the m2e-sdk as suggested in PR #408.

This simplifies the aggregation of m2e-sources because they only have to be included per feature in the m2e-sdk feature (which is published in the m2e-repo) and the individually listed source plug-ins can be removed.
Listing the source-plug-ins can be forgotten easily (I did it when upgrading to `biz.aQute.bndlib`-6.0.0 which added `biz.aQute.bnd.util`, whose sources are missing a.t.m. and in the currently pending PRs that add new plug-ins the corresponding source entry is missing in the sdk too).

To make the `tycho-source-plugin:feature-source` mojo work, it was necessary to execute the `tycho-p2-plugin:p2-metadata` Mojo. It looks like that only the `p2-metadata` mojo adds the source-artifact to the Maven-Project during build. In order to not break local builds (with profile `eclipse-sign` disabled) the `p2-metadata` mojo has to run in every build and not only when `eclipse-sign` is activated.

Furthermore the source-plugins generated for the m2e-maven-runtime bundles like `org.eclipse.m2e.maven.runtime` did not work. This is probably because the embedded source jars are nested in the corresponding source plug-in and it looks like PDE cannot handle this at all. At least this is my impression when looking at `org.eclipse.pde.internal.core.ClasspathUtilCore.getSourceAnnotation()`. Therefore I completely excluded the corresponding source bundles for now.
@laeubi or @mickaelistria do you know a way how to assemble a source-plug-in for the nested jars of a plug-in?
In general I think down-stream users would find it very helpful to have sources for the Maven-classes etc.