### PR TITLE
[Launching] automatically debug forked JVMs in Debug Maven build (#124)

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -68,7 +68,7 @@
 							<_nodefaultversion>true</_nodefaultversion>
 							<_snapshot>qualifier</_snapshot>
 
-							<Bundle-SymbolicName>${project.artifactId};singleton:=false</Bundle-SymbolicName>
+							<Bundle-SymbolicName>${project.artifactId};singleton:=true</Bundle-SymbolicName>
 							<Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
 							<Bundle-Name>${project.name}</Bundle-Name>
 							<Bundle-Vendor>Eclipse.org - m2e</Bundle-Vendor>

--- a/org.eclipse.m2e.debug/.classpath
+++ b/org.eclipse.m2e.debug/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.m2e.debug/.project
+++ b/org.eclipse.m2e.debug/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.debug</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.m2e.debug/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.debug/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.debug/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.m2e.debug/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/org.eclipse.m2e.debug/.settings/org.eclipse.m2e.core.prefs
+++ b/org.eclipse.m2e.debug/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/org.eclipse.m2e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.debug/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: M2E Debug Support
+Bundle-SymbolicName: org.eclipse.m2e.debug;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse.org - m2e
+Fragment-Host: org.eclipse.m2e.maven.runtime
+Automatic-Module-Name: org.eclipse.m2e.debug
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Import-Package: javax.inject;version="1.0.0"
+Require-Bundle: org.eclipse.m2e.launching,
+ org.eclipse.debug.core,
+ org.eclipse.equinox.common,
+ org.eclipse.m2e.core

--- a/org.eclipse.m2e.debug/META-INF/sisu/javax.inject.Named
+++ b/org.eclipse.m2e.debug/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,2 @@
+org.eclipse.m2e.debug.runtime.DebugEventSpy
+org.eclipse.m2e.debug.runtime.DebugExecutionListener

--- a/org.eclipse.m2e.debug/build.properties
+++ b/org.eclipse.m2e.debug/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               fragment.xml

--- a/org.eclipse.m2e.debug/fragment.xml
+++ b/org.eclipse.m2e.debug/fragment.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<fragment>
+   <extension
+         point="org.eclipse.m2e.launching.mavenLaunchParticipants">
+      <mavenLaunchParticipant
+            class="org.eclipse.m2e.debug.setup.DebugLaunchParticipant"
+            id="org.eclipse.m2e.debug.setup.DebugLaunchParticipant"
+            modes="debug"
+            name="M2E Debug Support Launch Participant">
+      </mavenLaunchParticipant>
+   </extension>
+
+</fragment>

--- a/org.eclipse.m2e.debug/pom.xml
+++ b/org.eclipse.m2e.debug/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2021, 2021 Hannes Wellmann and others
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License 2.0
+	which accompanies this distribution, and is available at
+	https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.m2e</groupId>
+		<artifactId>m2e-core</artifactId>
+		<version>1.16.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.m2e.debug</artifactId>
+	<version>1.18.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<name>M2E Debug Support for Maven Build Processes</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.sisu</groupId>
+				<artifactId>sisu-maven-plugin</artifactId>
+				<version>0.3.4</version>
+				<executions>
+					<execution>
+						<?m2e execute onIncremental?>
+						<id>index-project</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>index</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.basedir}</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.debug/src/org/eclipse/m2e/debug/runtime/DebugEventSpy.java
+++ b/org.eclipse.m2e.debug/src/org/eclipse/m2e/debug/runtime/DebugEventSpy.java
@@ -1,0 +1,123 @@
+package org.eclipse.m2e.debug.runtime;
+
+import static java.util.Map.entry;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.function.UnaryOperator;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.eventspy.AbstractEventSpy;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionEvent.Type;
+import org.apache.maven.plugin.MojoExecution;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named
+@Singleton
+public class DebugEventSpy extends AbstractEventSpy {
+	private static final Logger LOGGER = LoggerFactory.getLogger(DebugEventSpy.class);
+
+	private static final String DEBUG_PORT_VARIABLE = "${debugPort}";
+	public static final String DEBUG_DATA_PROPERTY = "m2e.debug.support"; //$NON-NLS-1$
+
+	public static String getEnableDebugProperty() {
+		return "-D" + DebugEventSpy.DEBUG_DATA_PROPERTY + "=" + "true";
+	}
+
+	// TODO: specify the debug setup of the supported plug-ins at a more suitable
+	// location. Ideally within the Maven-plugins directly (like for lifecycle
+	// mappings) LifecycleMappingFactory.readMavenPluginEmbeddedMetadata(), or with
+	// life-cylce mappins/connectors
+	// TODO: specify properties per Goal!
+	private static final Map<String, Entry<String, UnaryOperator<String>>> ID_2_CONFIGURATION_INJECTOR = Map.of(
+			"org.apache.maven.plugins:maven-surefire-plugin", //
+			entry("debugForkedProcess",
+					v -> "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=" + DEBUG_PORT_VARIABLE
+							+ " -Xnoagent -Djava.compiler=NONE"), // TODO: use Java-9 approach: agentlib:jdwp ?
+			"org.eclipse.tycho:tycho-surefire-plugin", entry("debugPort", v -> DEBUG_PORT_VARIABLE),
+			"org.eclipse.tycho.extras:tycho-eclipserun-plugin", //
+			entry("argLine", // TODO: use not deprecated approach with nested elements in jvmArgs
+					v -> "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=" + DEBUG_PORT_VARIABLE
+							+ " -Xnoagent")); // TODO: use Java-9 approach: agentlib:jdwp ?
+
+	private boolean isDebugLaunch = false;
+
+	@Override
+	public void init(Context context) throws Exception {
+		Map<String, Object> data = context.getData();
+		Object userProperties = data.get("userProperties");
+		if (userProperties instanceof Properties) {
+			Properties properties = (Properties) userProperties;
+			isDebugLaunch = Boolean.parseBoolean(properties.getProperty(DEBUG_DATA_PROPERTY, "false"));
+		}
+		if (isDebugLaunch) {
+			LOGGER.debug("M2E - Automatic debugging of forked VMs enabled");
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		isDebugLaunch = false;
+	}
+
+	@Override
+	public void onEvent(Object event) throws Exception {
+		if (isDebugLaunch && event instanceof ExecutionEvent) {
+			ExecutionEvent executionEvent = (ExecutionEvent) event;
+			if (executionEvent.getType() == Type.MojoStarted) {
+				MojoExecution mojoExecution = executionEvent.getMojoExecution();
+				String id = mojoExecution.getGroupId() + ":" + mojoExecution.getArtifactId();
+
+				Entry<String, UnaryOperator<String>> injector = ID_2_CONFIGURATION_INJECTOR.get(id);
+				if (injector != null) {
+					Xpp3Dom configuration = mojoExecution.getConfiguration();
+					int debugPort = getFreeDebugPort();
+					String debugElementName = injector.getKey();
+					Xpp3Dom debugElement = getOrCreateChild(configuration, debugElementName);
+					injectDebugSetupIntoConfiguration(debugElement, injector.getValue(), debugPort);
+
+					LOGGER.debug("M2E - Injected debug-port {} into configuration element <{}>", debugPort,
+							debugElementName);
+				}
+			}
+		}
+	}
+
+	private void injectDebugSetupIntoConfiguration(Xpp3Dom debugElement, UnaryOperator<String> valueComputer,
+			int debugPort) {
+		String enhancedValue = valueComputer.apply(debugElement.getValue());
+		enhancedValue = enhancedValue.replace(DEBUG_PORT_VARIABLE, Integer.toString(debugPort));
+		debugElement.setValue(enhancedValue);
+		// TODO: handle other cases
+		// - nested elements
+		// - set(but do not overwrite),
+		// - append (check if already contained?)
+	}
+
+	private static Xpp3Dom getOrCreateChild(Xpp3Dom configuration, String name) {
+		Xpp3Dom child = configuration.getChild(name);
+		if (child != null) {
+			child.setInputLocation(null); // disconnect from actual source
+		} else {
+			child = new Xpp3Dom(name);
+			configuration.addChild(child);
+		}
+		return child;
+	}
+
+	private static int getFreeDebugPort() {
+		try (ServerSocket socket = new ServerSocket(0)) {
+			return socket.getLocalPort();
+		} catch (IOException e) {
+			return 0;
+		}
+	}
+}

--- a/org.eclipse.m2e.debug/src/org/eclipse/m2e/debug/runtime/DebugExecutionListener.java
+++ b/org.eclipse.m2e.debug/src/org/eclipse/m2e/debug/runtime/DebugExecutionListener.java
@@ -1,0 +1,31 @@
+package org.eclipse.m2e.debug.runtime;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.execution.MojoExecutionEvent;
+import org.apache.maven.execution.MojoExecutionListener;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecutionException;
+
+@Named
+@Singleton
+public class DebugExecutionListener implements MojoExecutionListener {
+	// TODO: this class is likely not necessary anymore
+
+	@Override
+	public void beforeMojoExecution(MojoExecutionEvent event) throws MojoExecutionException {
+		Mojo mojo = event.getMojo();
+	}
+
+	@Override
+	public void afterMojoExecutionSuccess(MojoExecutionEvent event) throws MojoExecutionException {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void afterExecutionFailure(MojoExecutionEvent event) {
+		// TODO Auto-generated method stub
+	}
+
+}

--- a/org.eclipse.m2e.debug/src/org/eclipse/m2e/debug/setup/DebugLaunchParticipant.java
+++ b/org.eclipse.m2e.debug/src/org/eclipse/m2e/debug/setup/DebugLaunchParticipant.java
@@ -1,0 +1,42 @@
+package org.eclipse.m2e.debug.setup;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.sourcelookup.ISourceLookupParticipant;
+import org.eclipse.m2e.core.internal.launch.MavenEmbeddedRuntime;
+import org.eclipse.m2e.debug.runtime.DebugEventSpy;
+import org.eclipse.m2e.internal.launch.IMavenLaunchParticipant;
+import org.eclipse.m2e.internal.launch.MavenLaunchUtils;
+
+@SuppressWarnings("restriction")
+public class DebugLaunchParticipant implements IMavenLaunchParticipant {
+
+	@Override
+	public String getProgramArguments(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) {
+		try {
+			if (MavenLaunchUtils.getMavenRuntime(configuration) instanceof MavenEmbeddedRuntime) {
+				return DebugEventSpy.getEnableDebugProperty();
+			}
+		} catch (CoreException e) { // assume false
+		}
+		return null;
+	}
+
+	@Override
+	public String getVMArguments(ILaunchConfiguration configuration, ILaunch launch, IProgressMonitor monitor) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<ISourceLookupParticipant> getSourceLookupParticipants(ILaunchConfiguration configuration,
+			ILaunch launch, IProgressMonitor monitor) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -179,4 +179,12 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.m2e.debug"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
 </feature>

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
@@ -98,14 +98,12 @@ public class MavenConsoleLineTracker implements IConsoleLineTracker {
           testName = text.substring(RUNNING_MARKER.length());
           offset += RUNNING_MARKER.length();
 
-        } else if(text.startsWith(LISTENING_MARKER)) {
+        } else if((index = text.indexOf(LISTENING_MARKER)) > -1) {
           // create and start remote Java app launch configuration
           String baseDir = getBaseDir(launchConfiguration);
           if(baseDir != null) {
-            String portString = text.substring(LISTENING_MARKER.length()).trim();
-            MavenDebugHyperLink link = new MavenDebugHyperLink(baseDir, portString);
-            console.addLink(link, offset, LISTENING_MARKER.length() + portString.length());
-            // launchRemoteJavaApp(baseDir, portString);
+            String portString = text.substring(index + LISTENING_MARKER.length()).trim();
+            launchRemoteJavaApp(baseDir, portString);
           }
 
         } else {
@@ -149,7 +147,7 @@ public class MavenConsoleLineTracker implements IConsoleLineTracker {
     }
   }
 
-  static void launchRemoteJavaApp(String baseDir, String portString) throws CoreException {
+  private static void launchRemoteJavaApp(String baseDir, String portString) throws CoreException {
     ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
     ILaunchConfigurationType launchConfigurationType = launchManager
         .getLaunchConfigurationType(IJavaLaunchConfigurationConstants.ID_REMOTE_JAVA_APPLICATION);
@@ -163,14 +161,14 @@ public class MavenConsoleLineTracker implements IConsoleLineTracker {
         <mapEntry key="port" value="8000"/>
         <mapEntry key="hostname" value="localhost"/>
       </mapAttribute>
-
+    
       <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/foo-launch"/>
       </listAttribute>
       <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
       </listAttribute>
-
+    
       <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
         <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
       </listAttribute>
@@ -253,37 +251,4 @@ public class MavenConsoleLineTracker implements IConsoleLineTracker {
     }
 
   }
-
-  /**
-   * Creates debug launch configuration for remote Java application. For example, with surefire plugin the following
-   * property can be specified: -Dmaven.surefire.debug=
-   * "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 -Xnoagent -Djava.compiler=NONE"
-   */
-  public class MavenDebugHyperLink implements IHyperlink {
-
-    private final String baseDir;
-
-    private final String portString;
-
-    public MavenDebugHyperLink(String baseDir, String portString) {
-      this.baseDir = baseDir;
-      this.portString = portString;
-    }
-
-    public void linkActivated() {
-      try {
-        launchRemoteJavaApp(baseDir, portString);
-      } catch(CoreException ex) {
-        log.error(ex.getMessage(), ex);
-      }
-    }
-
-    public void linkEntered() {
-    }
-
-    public void linkExited() {
-    }
-
-  }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
 		<module>org.eclipse.m2e.editor.lemminx</module>
 		<module>org.eclipse.m2e.pde</module>
 		<module>org.eclipse.m2e.pde.ui</module>
+		<module>org.eclipse.m2e.debug</module>
 
 		<!-- common test helpers -->
 		<module>org.eclipse.m2e.tests.common</module>


### PR DESCRIPTION
This PR is the in progress work to resolve issue https://github.com/eclipse-m2e/m2e-core/issues/124 whose goal is to automatically attach a remote Java application debugger to VMs forked from a Maven build process, which is for example used for surefire tests.

The work is not yet in good shape but it is a prove of concept that (should) works for the following plug-ins,:
- `org.apache.maven.plugins:maven-surefire-plugin`
- `org.eclipse.tycho:tycho-surefire-plugin`
- `org.eclipse.tycho.extras:tycho-eclipserun-plugin`

What's working already:
- If a Maven build is launched in debug mode and one of the plug-ins mentioned above is executed the corresponding debug properties are injected before the mojo is executed so that the forked VM waits for a listener to be attached. The ConsoleLineTracker detects that and automatically launches a Remote Java Application in debug mode.
So if there is a break-point, for example in a test, the forked VM stops at that break point just like the VM was never forked.
If the Maven build is launched in `run` mode it behaves as usual and does not modify the mojos that fork VMs.

What has to be improved:
- [ ] Specification of the debug properties should be done via configuration files probably similar to the lifecycle-mapping metadata.
  - It should be possible for a plug-in to specify its debug-properties itself, maybe a connector should also be able to contribute debug properties (but this could be harder to implement because the connector lives in the Eclipse-VM while the DebugEventListener is in the Maven-Build-VM). M2E could ship the debug-properties for the most relevant plug-ins like maven-surefire. Tycho plug-ins could use the first way (at least for new releases). Another option would be to specify the debug-properties in the Eclipse preferences.
- [ ] The task of the `DebugLaunchParticipant` is probably better placed in the calling code of the m2e.launching plug-in. Then it would not be necessary for the m2e.maven.runtime bundle to be a singleton so the extension-points are processed (even tough I wonder why M2E's Maven runtime components are not singletons.
- [ ] Source look ups: At the moment the `MavenConsoleLineTracker` does not set the `IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME` of the launched remote Java application correctly when variables are used (which at least I usually do) so source are not available then. But I will address that in a separate PR where I want to rework the `MavenConsoleLineTracker` in general (it is almost complete).
- [ ] Clean up

My main intention with this draft PR is to gather some early feedback, in general and especially about the definition of the debug-properties.
@laeubi you created the mentioned issue issued, @mickaelistria you might be interested too. What do you think?