### PR TITLE
Verify pom co-ordinates when found via a relative path (fixes #482)

### DIFF
--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="1.19.1.qualifier"
+      version="1.19.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.profiles.core.tests/repositories/testrepo/org/eclipse/m2e/test/profiles/resolved-profiles-parent/0.0.1-SNAPSHOT/resolved-profiles-parent-0.0.1-SNAPSHOT.pom
+++ b/org.eclipse.m2e.profiles.core.tests/repositories/testrepo/org/eclipse/m2e/test/profiles/resolved-profiles-parent/0.0.1-SNAPSHOT/resolved-profiles-parent-0.0.1-SNAPSHOT.pom
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.eclipse.m2e.test.profiles</groupId>
+  <artifactId>resolved-profiles-parent</artifactId>
+  <packaging>pom</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  
+  <profiles>
+    <profile>
+      <id>resolved-one</id>
+    </profile>
+    <profile>
+      <id>resolved-two</id>
+    </profile>
+  </profiles>
+</project>

--- a/org.eclipse.m2e.profiles.core.tests/resources/projects/relative-path-profiles/poms/parent-pom/pom.xml
+++ b/org.eclipse.m2e.profiles.core.tests/resources/projects/relative-path-profiles/poms/parent-pom/pom.xml
@@ -1,7 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
-  <groupId>org.eclipse.m2e.test.profiles</groupId>
+  <parent>
+    <groupId>org.eclipse.m2e.test.profiles</groupId>
+	<artifactId>resolved-profiles-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath/>
+  </parent>
+  
   <artifactId>relative-path-profiles-parent</artifactId>
   <packaging>pom</packaging>
   <version>0.0.1-SNAPSHOT</version>

--- a/org.eclipse.m2e.profiles.core.tests/resources/projects/relative-path-profiles/poms/pom.xml
+++ b/org.eclipse.m2e.profiles.core.tests/resources/projects/relative-path-profiles/poms/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.eclipse.m2e.test.profiles</groupId>
+  <artifactId>poms-project-module-aggregator</artifactId>
+  <packaging>pom</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  
+  <profiles>
+    <profile>
+      <id>project-one</id>
+    </profile>
+    <profile>
+      <id>project-two</id>
+    </profile>
+  </profiles>
+  
+  <modules>
+    <module>classification-poms</module>
+    <module>parent-pom</module>
+  </modules>
+</project>

--- a/org.eclipse.m2e.profiles.core.tests/settings.xml
+++ b/org.eclipse.m2e.profiles.core.tests/settings.xml
@@ -1,0 +1,24 @@
+<settings>
+  
+  <localRepository>target/localrepo</localRepository>
+
+  <profiles>
+    <profile>
+      <id>active-settings-profile</id>
+      <repositories>
+      	<repository>
+        	<id>testrepo</id>
+       		<url>file:repositories/testrepo</url>
+       		<snapshots><enabled>true</enabled></snapshots>
+       		<releases><enabled>true</enabled></releases>
+			<updatePolicy>true</updatePolicy>
+     	</repository>
+      </repositories>      
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>active-settings-profile</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/org.eclipse.m2e.profiles.core.tests/src/org/eclipse/m2e/profiles/core/internal/management/MavenProfileManagerTest.java
+++ b/org.eclipse.m2e.profiles.core.tests/src/org/eclipse/m2e/profiles/core/internal/management/MavenProfileManagerTest.java
@@ -16,12 +16,15 @@ package org.eclipse.m2e.profiles.core.internal.management;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.eclipse.core.resources.IProject;
@@ -37,7 +40,6 @@ import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 public class MavenProfileManagerTest extends AbstractMavenProjectTestCase {
 
   private final IProfileManager profileManager = MavenProfilesCoreActivator.getDefault().getProfileManager();
-
 
   @Test
   public void testLoadingProfilesFromPomsResolvedViaTheirRelativePath() throws Exception {
@@ -61,7 +63,7 @@ public class MavenProfileManagerTest extends AbstractMavenProjectTestCase {
     Set<String> actualProfileIds = profiles.stream().map(ProfileData::getId).collect(Collectors.toSet());
 
     assertEquals(
-        new HashSet<>(Arrays.asList("module-one", "module-two", "api-one", "api-two", "parent-one", "parent-two")),
+        new HashSet<>(Arrays.asList("module-one", "module-two", "api-one", "api-two", "parent-one", "parent-two", "resolved-one", "resolved-two")),
         actualProfileIds);
   }
 }

--- a/org.eclipse.m2e.profiles.core.tests/src/org/eclipse/m2e/profiles/core/internal/management/MavenProfileManagerTest.java
+++ b/org.eclipse.m2e.profiles.core.tests/src/org/eclipse/m2e/profiles/core/internal/management/MavenProfileManagerTest.java
@@ -63,7 +63,7 @@ public class MavenProfileManagerTest extends AbstractMavenProjectTestCase {
     Set<String> actualProfileIds = profiles.stream().map(ProfileData::getId).collect(Collectors.toSet());
 
     assertEquals(
-        new HashSet<>(Arrays.asList("module-one", "module-two", "api-one", "api-two", "parent-one", "parent-two", "resolved-one", "resolved-two")),
+        new HashSet<>(Arrays.asList("module-one", "module-two", "api-one", "api-two", "parent-one", "parent-two", "resolved-one", "resolved-two", "active-settings-profile")),
         actualProfileIds);
   }
 }

--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Profiles Management
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
-Bundle-Version: 1.17.2.qualifier
+Bundle-Version: 1.17.3.qualifier
 Bundle-Activator: org.eclipse.m2e.profiles.core.internal.MavenProfilesCoreActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.19.1.qualifier"
+      version="1.19.2.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
When resolving a parent POM via a relative path verify that any POM found has co-ordinates that match the parent being sought.