### PR TITLE
Replace Guava with standard Java API

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.10.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources;bundle-version="3.9.0",
  org.eclipse.core.filesystem;bundle-version="1.7.700",
- com.google.guava;bundle-version="[30.1,32.0)"
+ org.apache.commons.codec;bundle-version="1.14.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.m2e.core,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/BuildProblemInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/BuildProblemInfo.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.m2e.core.internal.builder;
 
-import com.google.common.base.Throwables;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 import org.eclipse.m2e.core.internal.markers.MavenProblemInfo;
 import org.eclipse.m2e.core.internal.markers.SourceLocation;
@@ -30,7 +31,8 @@ class BuildProblemInfo extends MavenProblemInfo {
     if(mojoExecutionKey != null) {
       msg.append(" (").append(mojoExecutionKey.getKeyString()).append(')'); //$NON-NLS-1$ $NON-NLS-2$
     }
-    msg.append("\n\n").append(Throwables.getStackTraceAsString(error)); //$NON-NLS-1$
-    return msg.toString();
+    StringWriter errorStackTrace = new StringWriter();
+    error.printStackTrace(new PrintWriter(errorStackTrace));
+    return msg.append("\n\n").append(errorStackTrace).toString(); //$NON-NLS-1$
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/AnnotationMappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/AnnotationMappingMetadataSource.java
@@ -13,21 +13,20 @@
 
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
-import static java.util.Map.entry;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -230,17 +229,17 @@ public class AnnotationMappingMetadataSource implements MappingMetadataSource {
     return pis;
   }
 
-  private static final Splitter PI_SPLITTER = Splitter.on(CharMatcher.whitespace()).omitEmptyStrings().limit(2);
+  private static final Pattern PI_SPLITTER = Pattern.compile("\\s");
 
-  private static final Splitter EXECUTE_SPLITTER = Splitter.on(',').omitEmptyStrings();
+  private static final Pattern EXECUTE_SPLITTER = Pattern.compile(",");
 
-  private static final Map<String, String> EXECUTE_OPTIONS = Map.ofEntries(
-      entry("onConfiguration", LifecycleMappingFactory.ELEMENT_RUN_ON_CONFIGURATION), //$NON-NLS-1$
-      entry("onIncremental", LifecycleMappingFactory.ELEMENT_RUN_ON_INCREMENTAL)); //$NON-NLS-1$
+  private static final Map<String, String> EXECUTE_OPTIONS = Map.of( //
+      "onConfiguration", LifecycleMappingFactory.ELEMENT_RUN_ON_CONFIGURATION, //$NON-NLS-1$
+      "onIncremental", LifecycleMappingFactory.ELEMENT_RUN_ON_INCREMENTAL); //$NON-NLS-1$
 
   private static Xpp3Dom parse(String pi) {
 
-    List<String> split = PI_SPLITTER.splitToList(pi);
+    List<String> split = Arrays.stream(PI_SPLITTER.split(pi, 2)).map(String::strip).collect(Collectors.toList());
 
     PluginExecutionAction a = getAction(split.get(0));
     if(a == null) {
@@ -263,15 +262,12 @@ public class AnnotationMappingMetadataSource implements MappingMetadataSource {
       case execute:
         Xpp3Dom exec = new Xpp3Dom("execute"); //$NON-NLS-1$
         if(split.size() > 1) {
-          for(String option : EXECUTE_SPLITTER.split(split.get(1))) {
-            String value = EXECUTE_OPTIONS.get(option);
-            if(value == null) {
-              return null;
-            }
-            Xpp3Dom opt = new Xpp3Dom(value);
-            opt.setValue("true"); //$NON-NLS-1$
-            exec.addChild(opt);
-          }
+          EXECUTE_SPLITTER.splitAsStream(split.get(1)).map(String::strip).map(EXECUTE_OPTIONS::get)
+              .filter(Objects::nonNull).forEach(value -> {
+                Xpp3Dom opt = new Xpp3Dom(value);
+                opt.setValue("true"); //$NON-NLS-1$
+                exec.addChild(opt);
+              });
         }
         return exec;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/MavenMarkerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/MavenMarkerManager.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.core.internal.markers;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -21,8 +23,6 @@ import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Throwables;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -166,8 +166,9 @@ public class MavenMarkerManager implements IMavenMarkerManager {
     if(ex.getMessage() != null) {
       message.append(ex.getMessage()).append("\n\n");
     }
-    message.append(Throwables.getStackTraceAsString(ex));
-    return message.toString();
+    StringWriter errorStackTrace = new StringWriter();
+    ex.printStackTrace(new PrintWriter(errorStackTrace));
+    return message.append(errorStackTrace).toString();
   }
 
   private Throwable getRootCause(Throwable ex) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry.java
@@ -135,9 +135,9 @@ abstract class BasicProjectRegistry implements Serializable {
 
   public Map<ArtifactKey, Collection<IFile>> getWorkspaceArtifacts(String groupId, String artifactId) {
     Map<ArtifactKey, Collection<IFile>> artifacts = new HashMap<>();
-    workspaceArtifacts.forEach((workspaceKey, files) -> {
-      if(groupId.equals(workspaceKey.getGroupId()) && artifactId.equals(workspaceKey.getArtifactId())) {
-        artifacts.computeIfAbsent(workspaceKey, k -> new HashSet<>()).addAll(files);
+    workspaceArtifacts.forEach((wsKey, files) -> {
+      if(!files.isEmpty() && groupId.equals(wsKey.getGroupId()) && artifactId.equals(wsKey.getArtifactId())) {
+        artifacts.computeIfAbsent(wsKey, k -> new HashSet<>()).addAll(files);
       }
     });
     return artifacts;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry.java
@@ -17,13 +17,11 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 import org.eclipse.core.resources.IFile;
 
@@ -136,14 +134,13 @@ abstract class BasicProjectRegistry implements Serializable {
   }
 
   public Map<ArtifactKey, Collection<IFile>> getWorkspaceArtifacts(String groupId, String artifactId) {
-    Multimap<ArtifactKey, IFile> artifacts = HashMultimap.create();
-    for(Map.Entry<ArtifactKey, Set<IFile>> entry : workspaceArtifacts.entrySet()) {
-      ArtifactKey workspaceKey = entry.getKey();
+    Map<ArtifactKey, Collection<IFile>> artifacts = new HashMap<>();
+    workspaceArtifacts.forEach((workspaceKey, files) -> {
       if(groupId.equals(workspaceKey.getGroupId()) && artifactId.equals(workspaceKey.getArtifactId())) {
-        artifacts.putAll(workspaceKey, entry.getValue());
+        artifacts.computeIfAbsent(workspaceKey, k -> new HashSet<>()).addAll(files);
       }
-    }
-    return artifacts.asMap();
+    });
+    return artifacts;
   }
 
   protected void clear() {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryInfo.java
@@ -14,10 +14,10 @@
 package org.eclipse.m2e.core.internal.repository;
 
 import java.io.File;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.commons.codec.digest.DigestUtils;
 
 import org.eclipse.core.runtime.IPath;
 
@@ -125,26 +125,7 @@ public class RepositoryInfo implements IRepository {
     if(username != null) {
       sb.append('|').append(username);
     }
-    String uid;
-    try {
-      MessageDigest digest = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
-      digest.update(sb.toString().getBytes());
-      byte messageDigest[] = digest.digest();
-      StringBuilder hexString = new StringBuilder();
-      for(byte element : messageDigest) {
-        String hex = Integer.toHexString(0xFF & element);
-        if(hex.length() == 1) {
-          hexString.append('0');
-        }
-        hexString.append(hex);
-      }
-      uid = hexString.toString();
-    } catch(NoSuchAlgorithmException ex) {
-      //this shouldn't happen with MD5
-      uid = sb.toString();
-      uid = uid.replace(':', '_').replace('/', '_').replace('|', '_');
-    }
-    return uid;
+    return DigestUtils.md5Hex(sb.toString());
   }
 
   @Override

--- a/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor.xml;singleton:=true
-Bundle-Version: 1.18.2.qualifier
+Bundle-Version: 1.18.3.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.xml.MvnIndexPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,
@@ -23,7 +23,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.ide,
  org.eclipse.core.filesystem,
  org.eclipse.ui.forms,
- com.google.guava;bundle-version="[30.1,32.0)",
  org.eclipse.m2e.editor;bundle-version="1.16.0",
  org.eclipse.search;bundle-version="3.11.700",
  org.eclipse.ui.views

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/mojo/PlexusConfigHelper.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 
@@ -425,7 +424,7 @@ public class PlexusConfigHelper {
 
   static {
     // @formatter:off
-    INLINE_TYPES = ImmutableSet.<String>of(
+    INLINE_TYPES = Set.of(
       byte.class.getName(),
       Byte.class.getName(),
       short.class.getName(),

--- a/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
@@ -15,9 +15,9 @@ Require-Bundle: org.eclipse.m2e.launching;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.core.expressions;bundle-version="3.4.400",
  org.eclipse.debug.ui;bundle-version="3.10.0",
  org.eclipse.core.resources,
- com.google.guava;bundle-version="[30.1,32.0)",
  com.google.gson;bundle-version="2.2.4",
- org.eclipse.core.variables;bundle-version="3.2.0"
+ org.eclipse.core.variables;bundle-version="3.2.0",
+ org.apache.commons.codec;bundle-version="1.14.0"
 Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.m2e.sourcelookup/src/org/eclipse/m2e/sourcelookup/internal/launch/MavenArtifactIdentifier.java
+++ b/org.eclipse.m2e.sourcelookup/src/org/eclipse/m2e/sourcelookup/internal/launch/MavenArtifactIdentifier.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
@@ -36,10 +37,9 @@ import org.eclipse.m2e.core.internal.index.IIndex;
 import org.eclipse.m2e.core.internal.index.IndexedArtifactFile;
 import org.eclipse.m2e.core.internal.index.nexus.CompositeIndex;
 
-import com.google.common.hash.Hashing;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 @SuppressWarnings("restriction")
@@ -124,14 +124,17 @@ public class MavenArtifactIdentifier {
     }
 
     try {
-      String sha1 = Files.hash(file, Hashing.sha1()).toString(); // TODO use Locations for caching
+      String sha1;
+      try (InputStream fis = new FileInputStream(file)){
+        sha1 = DigestUtils.sha1Hex(fis); // TODO use Locations for caching
+      }
       URL url = new URL("https://search.maven.org/solrsearch/select?q=1:" + sha1);
       try (InputStreamReader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
         Set<ArtifactKey> result = new LinkedHashSet<>();
         JsonObject container = new Gson().fromJson(reader, JsonObject.class);
         JsonArray docs = container.get("response").getAsJsonObject().get("docs").getAsJsonArray();
-        for (int i = 0; i < docs.size(); i++) {
-          JsonObject doc = docs.get(i).getAsJsonObject();
+        for (JsonElement element : docs) {
+            JsonObject doc = element.getAsJsonObject();
           String g = doc.get("g").getAsString();
           String a = doc.get("a").getAsString();
           String v = doc.get("v").getAsString();

--- a/org.eclipse.m2e.sse.ui.feature/feature.xml
+++ b/org.eclipse.m2e.sse.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sse.ui.feature"
       label="%featureName"
-      version="1.18.2.qualifier"
+      version="1.18.3.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This PR removes the dependency to Guava for all M2E plug-ins except for:
- org.eclipse.m2e.editor
- org.eclipse.m2e.maven.indexer
- org.eclipse.m2e.maven.runtime 

In some places the elements used from guava could be replaced quite easily with modern day java classes, in other places it took some more work and the resulting code was unfortunately a bit longer than before, especially in one use case of Multimaps.

@akurtakov what do you think? Do you know some better replacement strategies?