### PR TITLE
[RelEng] Bump M2E version to 1.20.0

### DIFF
--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="1.19.2.qualifier"
+      version="1.20.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="1.19.2.qualifier"
+      version="1.20.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
At the moment the m2e-SDK (and therefore M2E itself) is at version `1.19.2` although the last release is `1.19.0`.
But since the `m2e.pde-feature` is already at `1.20.0` the M2E project itself should reflect that and should be set to `1.20.0` too. And 1.20.0 is IMHO a nice version to end the 1.x train.

Any objections?