### PR TITLE
[Console] defer build-directory retrieval for test-report links and more clean-ups

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.m2e.launching;bundle-version="1.17.2",
  org.eclipse.debug.core,
  org.eclipse.ui.console,
- org.eclipse.jdt.launching
+ org.eclipse.jdt.launching,
+ org.eclipse.jdt.junit
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.m2e.core.tests


### PR DESCRIPTION
This PR further improves the `MavenConsoleLineTracker` by deferring the retrieval of the build-directory for test-report links, further generalizing the code and the tests.