### PR TITLE
Add packagingTypes extension point

### DIFF
--- a/org.eclipse.m2e.core/plugin.properties
+++ b/org.eclipse.m2e.core/plugin.properties
@@ -44,3 +44,4 @@ extension-point.changed.name = mavenProjectChangedListeners
 extension-point.lifecycleMappingMetadataSource.name = Lifecycle Mapping Metadata Source
 extension-point.projectConversionParticipants.name= Project conversion participants
 extension-point.workspaceClassifierResolvers.name= Workspace classifier resolvers
+extension-point.artifactPackagingTypes.name= Artifact Packaging Types

--- a/org.eclipse.m2e.core/plugin.xml
+++ b/org.eclipse.m2e.core/plugin.xml
@@ -22,6 +22,7 @@
    <extension-point id="conversionEnabler" name="%extension-point.conversionEnabler.name" schema="schema/conversionEnabler.exsd"/>
    <extension-point id="incrementalBuildFrameworks" name="%extension-point.incrementalBuildFrameworks.name" schema="schema/incrementalBuildFrameworks.exsd"/>
    <extension-point id="workspaceClassifierResolvers" name="%extension-point.workspaceClassifierResolvers.name" schema="schema/workspaceClassifierResolvers.exsd"/>
+   <extension-point id="artifactPackagingTypes" name="%extension-point.artifactPackagingTypes.name" schema="schema/artifactPackagingTypes.exsd"/>
 
    <extension point="org.eclipse.core.runtime.contentTypes">
      <content-type id="pomFile" name="%content-type.name"

--- a/org.eclipse.m2e.core/schema/artifactPackagingTypes.exsd
+++ b/org.eclipse.m2e.core/schema/artifactPackagingTypes.exsd
@@ -1,0 +1,101 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.m2e.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.eclipse.m2e.core" id="artifactPackagingType" name="%extension-point.artifactPackagingType.name"/>
+      </appInfo>
+      <documentation>
+         Allows plugins to contribute their own Maven packaging types to the POM editor.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <choice>
+               <element ref="packagingType"/>
+            </choice>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="packagingType">
+      <complexType>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of the packaging type. This will be displayed to the user and will show up in the pom.xml &lt;packaging&gt; attribute.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         1.19.1
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.m2e.core/schema/artifactPackagingTypes.exsd
+++ b/org.eclipse.m2e.core/schema/artifactPackagingTypes.exsd
@@ -3,7 +3,7 @@
 <schema targetNamespace="org.eclipse.m2e.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
-         <meta.schema plugin="org.eclipse.m2e.core" id="artifactPackagingType" name="%extension-point.artifactPackagingType.name"/>
+         <meta.schema plugin="org.eclipse.m2e.core" id="artifactPackagingTypes" name="%extension-point.artifactPackagingTypes.name"/>
       </appInfo>
       <documentation>
          Allows plugins to contribute their own Maven packaging types to the POM editor.

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/OverviewPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/OverviewPage.java
@@ -50,6 +50,7 @@ import static org.eclipse.m2e.editor.pom.FormUtils.nvl;
 import static org.eclipse.m2e.editor.pom.FormUtils.setText;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -61,10 +62,14 @@ import org.w3c.dom.Element;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.notify.Notification;
@@ -240,6 +245,8 @@ public class OverviewPage extends MavenPomEditorPage {
     super(pomEditor, IMavenConstants.PLUGIN_ID + ".pom.overview", Messages.OverviewPage_title); //$NON-NLS-1$
   }
 
+  public static String PACKAGING_TYPE_EXT = "artifactPackagingTypes";
+
   @Override
   protected void createFormContent(IManagedForm managedForm) {
     FormToolkit toolkit = managedForm.getToolkit();
@@ -349,6 +356,7 @@ public class OverviewPage extends MavenPomEditorPage {
     artifactPackagingCombo.add("ear"); //$NON-NLS-1$
     artifactPackagingCombo.add("pom"); //$NON-NLS-1$
     artifactPackagingCombo.add("maven-plugin"); //$NON-NLS-1$
+    getPackagingTypes().stream().forEach(type -> artifactPackagingCombo.add(type));
 // uncomment this only if you are able to not to break the project
 //    artifactPackagingCombo.add("osgi-bundle");
 //    artifactPackagingCombo.add("eclipse-feature");
@@ -1391,5 +1399,21 @@ public class OverviewPage extends MavenPomEditorPage {
       }
       return super.getImage(element);
     }
+  }
+
+  private List<String> getPackagingTypes() {
+    IExtensionPoint extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(IMavenConstants.PLUGIN_ID,
+        PACKAGING_TYPE_EXT);
+    List<String> types = new ArrayList<>();
+    if(extensionPoint == null) {
+      return types;
+    }
+
+    IExtension[] extensions = extensionPoint.getExtensions();
+    for(IExtension extension : extensions) {
+      IConfigurationElement[] configElements = extension.getConfigurationElements();
+      Arrays.asList(configElements).stream().forEach(element -> types.add(element.getAttribute("name")));
+    }
+    return types;
   }
 }


### PR DESCRIPTION
Our application has a few custom Maven packaging types that do not show up in the drop-down and must be typed in manually in the pom.xml. This small change adds an extension point that allows the developers of the product/plugins to define packaging types that will be added to the pom editor.

The extension point is defined by the following:
![extensionpoint](https://user-images.githubusercontent.com/9405706/151862601-77c5c7ac-7989-4b8d-a103-3c74cd6b7a74.png)
which will add a packaging type `test-packaging-type`. This type does not actually exist and is only here for testing, which is why the next screenshot shows an error. The plugin developers should make sure that the packaging type actually will exist in the launched product.

Then, in the launched product, see the type in the pom editor drop-down.
![ccombo](https://user-images.githubusercontent.com/9405706/151862919-4b5650f0-3a92-4839-a36d-29a24a193c50.png)




This is my first contribution to any Eclipse project, so please let me know if I did something incorrectly.
