### PR TITLE
[Console] add link to project-pom at project headline in build printout

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.debug.core,
  org.eclipse.ui.console,
  org.eclipse.jdt.launching,
- org.eclipse.jdt.junit
+ org.eclipse.jdt.junit,
+ org.eclipse.jdt.core
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.m2e.core.tests

--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.ui.console,
  org.eclipse.jdt.launching,
  org.eclipse.jdt.junit,
- org.eclipse.jdt.core
+ org.eclipse.jdt.core,
+ org.eclipse.m2e.editor
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.m2e.core.tests

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple.projectWithJUnit-5_Test/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple.projectWithJUnit-5_Test/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.m2e.tests.projects</groupId>
-	<artifactId>simpleProjectWithJUnit5Test</artifactId>
+	<artifactId>simple.projectWithJUnit-5_Test</artifactId>
 	<version>1</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple.projectWithJUnit-5_Test/src/test/java/simple/SimpleTest.java
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple.projectWithJUnit-5_Test/src/test/java/simple/SimpleTest.java
@@ -1,4 +1,4 @@
-package simpleProjectWithJUnit5Test;
+package simple;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -6,6 +6,6 @@ import org.junit.jupiter.api.Test;
 public class SimpleTest {
 	@Test
 	public void testSimple() {
-		Assertions.assertTrue(true); // NoOp Test
+		Assertions.assertTrue(false); // NoOp Test
 	}
 }

--- a/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
+++ b/org.eclipse.m2e.core.ui.tests/src/org/eclipse/m2e/core/ui/tests/ConsoleTest.java
@@ -106,6 +106,8 @@ public class ConsoleTest extends AbstractMavenProjectTestCase {
 		}
 	}
 
+	private static final String SIMPLE_PROJECT = "simple.projectWithJUnit-5_Test";
+
 	@Test
 	public void testConsole_hasOutputAndHasNoMultipleSLF4Jwarnings() throws Exception {
 		File pomFile = getTestProjectPomFile("simplePomOK");
@@ -128,30 +130,35 @@ public class ConsoleTest extends AbstractMavenProjectTestCase {
 		// This field just ensures the mentioned required-bundle is not removed.
 		JUnitLaunchShortcut jdtJunitReference = null;
 
-		importMavenProjectIntoWorkspace("simpleProjectWithJUnit5Test");
+		importMavenProjectIntoWorkspace(SIMPLE_PROJECT);
 
-		IDocument document = runMavenBuild("${project_loc:simpleProjectWithJUnit5Test}", ILaunchManager.RUN_MODE);
+		IDocument document = runMavenBuild(projectLocVariable(SIMPLE_PROJECT), ILaunchManager.RUN_MODE);
 
 		ConsoleHyperlinkPosition linkPosition = getConsoleHyperLink(document, 1);
 		String linkText = document.get(linkPosition.getOffset(), linkPosition.getLength());
 
-		assertEquals("Invalid aligmnent of Test-Report link text", "simpleProjectWithJUnit5Test.SimpleTest", linkText);
-		assertLinkActivationOpensPartWithTitle(linkPosition, "JUnit (simpleProjectWithJUnit5Test.SimpleTest)");
+		assertEquals("Test-Report link text", "simple.SimpleTest", linkText);
+		assertLinkActivationOpensPartWithTitle(linkPosition, "JUnit (simple.SimpleTest)");
 	}
 
 	@Test
 	public void testConsole_testMavenProjectLinkAlignmentAndClickability() throws Exception {
 
-		importMavenProjectIntoWorkspace("simpleProjectWithJUnit5Test");
+		importMavenProjectIntoWorkspace(SIMPLE_PROJECT);
 
-		IDocument document = runMavenBuild("${project_loc:simpleProjectWithJUnit5Test}", ILaunchManager.RUN_MODE);
+		IDocument document = runMavenBuild(projectLocVariable(SIMPLE_PROJECT), ILaunchManager.RUN_MODE);
 
-		ConsoleHyperlinkPosition linkPosition = getConsoleHyperLink(document, 0);
-		String linkText = document.get(linkPosition.getOffset(), linkPosition.getLength());
+		ConsoleHyperlinkPosition projectHeadlineLink = getConsoleHyperLink(document, 0);
+		String headlineLinkText = document.get(projectHeadlineLink.getOffset(), projectHeadlineLink.getLength());
 
-		assertEquals("Invalid aligmnent of pom link text", "org.eclipse.m2e.tests.projects:simpleProjectWithJUnit5Test",
-				linkText);
-		assertLinkActivationOpensPartWithTitle(linkPosition, "simpleProjectWithJUnit5Test/pom.xml");
+		assertEquals("Pom link text", "org.eclipse.m2e.tests.projects:" + SIMPLE_PROJECT, headlineLinkText);
+		assertLinkActivationOpensPartWithTitle(projectHeadlineLink, SIMPLE_PROJECT + "/pom.xml");
+
+		ConsoleHyperlinkPosition failedProjectLink = getConsoleHyperLink(document, 3);
+		String failedProjectText = document.get(failedProjectLink.getOffset(), failedProjectLink.getLength());
+
+		assertEquals("Pom link text", SIMPLE_PROJECT, failedProjectText);
+		assertLinkActivationOpensPartWithTitle(failedProjectLink, SIMPLE_PROJECT + "/pom.xml");
 	}
 
 	private static ConsoleHyperlinkPosition getConsoleHyperLink(IDocument doc, int index)
@@ -172,12 +179,12 @@ public class ConsoleTest extends AbstractMavenProjectTestCase {
 	@Test
 	public void testConsole_automaticDebuggerAttachment() throws Exception {
 
-		importMavenProjectIntoWorkspace("simpleProjectWithJUnit5Test");
+		importMavenProjectIntoWorkspace(SIMPLE_PROJECT);
 
-		IDocument document = runMavenBuild("${project_loc:simpleProjectWithJUnit5Test}", ILaunchManager.RUN_MODE,
+		IDocument document = runMavenBuild(projectLocVariable(SIMPLE_PROJECT), ILaunchManager.RUN_MODE,
 				entry("maven.surefire.debug", "true"));
 
-		assertDebugeePrintOutAndDebuggerLaunch(document, "simpleProjectWithJUnit5Test");
+		assertDebugeePrintOutAndDebuggerLaunch(document, SIMPLE_PROJECT);
 	}
 
 	private static void assertDebugeePrintOutAndDebuggerLaunch(IDocument document, String debugLaunchName)
@@ -278,6 +285,10 @@ public class ConsoleTest extends AbstractMavenProjectTestCase {
 			fail("Build timed out.");
 		}
 		return document;
+	}
+
+	private static String projectLocVariable(String projectName) {
+		return "${project_loc:" + projectName + "}";
 	}
 
 	private static boolean isBuildFinished(String text) {

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
@@ -216,11 +216,11 @@ public class MavenConsoleLineTracker implements IConsoleLineTracker {
     return console.getDocument().get(lineRegion.getOffset(), lineRegion.getLength()).strip();
   }
 
-  private void addProjectLink(IRegion line2Region, Matcher gaMatcher, int startGroup, int endGroup) {
-    int start = gaMatcher.start(startGroup);
-    int end = gaMatcher.end(endGroup);
+  private void addProjectLink(IRegion line, Matcher matcher, int startGroup, int endGroup) {
     IHyperlink link = new MavenProjectHyperLink(mavenProject);
-    console.addLink(link, line2Region.getOffset() + start, end - start);
+    int start = matcher.start(startGroup);
+    int end = matcher.end(endGroup);
+    console.addLink(link, line.getOffset() + start, end - start);
   }
 
   @Override


### PR DESCRIPTION
This PR has the goal to add a link in a project's build print-out _headline_ that when being activated opens the projects `pom.xml` file in the standard editor.

If a user clicks on `org.eclipse.m2e.tests.projects:simpleProjectWithJUnit5Test` the POM-editor opens displaying the project's pom:

![grafik](https://user-images.githubusercontent.com/44067969/151876537-dc7a14ad-740b-4e8b-9474-1325f30e080b.png)
