### PR TITLE
Improve conflict handling of lifecycle mappings #549

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008, 2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -127,4 +127,11 @@ public interface IMavenConstants {
   String MARKER_CAUSE_COLUMN_END = "causeColumnEnd"; //$NON-NLS-1$
 
   String MARKER_CAUSE_LINE_NUMBER = "causeLineNumber"; //$NON-NLS-1$
+
+  String MARKER_DUPLICATEMAPPING_TYPE = "duplicateMappingType";
+
+  String MARKER_DUPLICATEMAPPING_VALUE = "duplicateMappingValue";
+
+  String MARKER_DUPLICATEMAPPING_SOURCES = "duplicateMappingSources";
+
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateLifecycleMappingMetadataException.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateLifecycleMappingMetadataException.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import java.util.Arrays;
+
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
+
+
+/**
+ * DuplicateLifecycleMappingMetadataException
+ *
+ */
+public class DuplicateLifecycleMappingMetadataException extends DuplicateMappingException {
+
+  private static final long serialVersionUID = 1L;
+  private LifecycleMappingMetadata[] lifecyclemappings;
+
+  public DuplicateLifecycleMappingMetadataException(LifecycleMappingMetadata... lifecyclemappings) {
+    super(Arrays.stream(lifecyclemappings).map(LifecycleMappingMetadata::getSource)
+        .toArray(LifecycleMappingMetadataSource[]::new));
+    this.lifecyclemappings = lifecyclemappings;
+  }
+
+  /**
+   * @return Returns the lifecyclemappings.
+   */
+  public LifecycleMappingMetadata[] getConflictingMappings() {
+    return this.lifecyclemappings;
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingSourceProblem.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingSourceProblem.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
+import org.eclipse.m2e.core.internal.markers.MavenProblemInfo;
+import org.eclipse.m2e.core.internal.markers.SourceLocation;
+
+
+/**
+ * DuplicateMappingSourceProblem
+ *
+ * @author christoph
+ */
+public class DuplicateMappingSourceProblem extends MavenProblemInfo {
+
+  private LifecycleMappingMetadataSource[] conflictingSources;
+
+  private String type;
+
+  private String value;
+
+  /**
+   * @param location
+   * @param message
+   * @param error
+   */
+  public DuplicateMappingSourceProblem(SourceLocation location, String message, String type, String value,
+      DuplicateMappingException error) {
+    super(location, message, error);
+    this.type = type;
+    this.value = value;
+    this.conflictingSources = error.getConflictingSources();
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.internal.markers.MavenProblemInfo#processMarker(org.eclipse.core.resources.IMarker)
+   */
+  @Override
+  public void processMarker(IMarker marker) throws CoreException {
+    super.processMarker(marker);
+    marker.setAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE, type);
+    marker.setAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_VALUE, value);
+
+    Bundle[] bundles = Arrays.stream(conflictingSources).map(LifecycleMappingMetadataSource::getSource)
+        .filter(Bundle.class::isInstance).map(Bundle.class::cast).toArray(Bundle[]::new);
+    marker.setAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES, bundles.length);
+    for(int i = 0; i < bundles.length; i++ ) {
+      Bundle bundle = bundles[i];
+      String prefix = IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES + "." + i + ".";
+      Version version = bundle.getVersion();
+      String v = version.getMajor() + "." + version.getMinor() + "." + version.getMicro();
+      marker.setAttribute(prefix + "bundleName",
+          Objects.requireNonNullElse(bundle.getHeaders().get(Constants.BUNDLE_NAME), bundle.getSymbolicName()));
+      marker.setAttribute(prefix + "bundleSymbolicName", bundle.getSymbolicName());
+      marker.setAttribute(prefix + "bundleVersionRange", "[" + v + ",)");
+    }
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicatePluginExecutionMetadataException.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicatePluginExecutionMetadataException.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import java.util.Arrays;
+
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
+
+
+/**
+ * DuplicatePluginExecutionMetadataException
+ *
+ */
+public class DuplicatePluginExecutionMetadataException extends DuplicateMappingException{
+
+  private static final long serialVersionUID = 1L;
+  private PluginExecutionMetadata[] pluginExecutionMetadatas;
+
+  public DuplicatePluginExecutionMetadataException(PluginExecutionMetadata... pluginExecutionMetadatas) {
+    super(
+        Arrays.stream(pluginExecutionMetadatas).map(PluginExecutionMetadata::getSource)
+            .toArray(LifecycleMappingMetadataSource[]::new));
+    this.pluginExecutionMetadatas = pluginExecutionMetadatas;
+  }
+
+  /**
+   * @return Returns the sources.
+   */
+  public PluginExecutionMetadata[] getConflictingMetadata() {
+    return this.pluginExecutionMetadatas;
+  }
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/FailedMappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/FailedMappingMetadataSource.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import java.util.List;
+
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
+import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
+
+
+/**
+ * FailedMappingMetadataSource
+ *
+ */
+public class FailedMappingMetadataSource implements MappingMetadataSource {
+
+  private DuplicateMappingException failure;
+
+  private MappingMetadataSource source;
+
+  /**
+   * @param source
+   * @param failure
+   */
+  public FailedMappingMetadataSource(MappingMetadataSource source, DuplicateMappingException e) {
+    this.source = source;
+    this.failure = e;
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.internal.lifecyclemapping.MappingMetadataSource#getLifecycleMappingMetadata(java.lang.String)
+   */
+  @Override
+  public LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType) throws DuplicateMappingException {
+    throw failure;
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.internal.lifecyclemapping.MappingMetadataSource#getPluginExecutionMetadata(org.eclipse.m2e.core.project.configurator.MojoExecutionKey)
+   */
+  @Override
+  public List<PluginExecutionMetadata> getPluginExecutionMetadata(MojoExecutionKey execution) {
+    return source.getPluginExecutionMetadata(execution);
+  }
+
+  /**
+   * @return Returns the failure.
+   */
+  public DuplicateMappingException getFailure() {
+    return this.failure;
+  }
+
+  /**
+   * @return Returns the source.
+   */
+  public MappingMetadataSource getSource() {
+    return this.source;
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingResult.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingResult.java
@@ -79,6 +79,9 @@ public class LifecycleMappingResult {
   }
 
   public AbstractLifecycleMapping getLifecycleMapping() {
+    if(getProblems().stream().anyMatch(p -> p.getError() instanceof DuplicateLifecycleMappingMetadataException)) {
+      return null;
+    }
     return lifecycleMapping;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MojoExecutionProblemInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MojoExecutionProblemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Sonatype, Inc.
+ * Copyright (c) 2010, 2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 
 
 public abstract class MojoExecutionProblemInfo extends MavenProblemInfo {
-  private final MojoExecutionKey mojoExecutionKey;
+  protected final MojoExecutionKey mojoExecutionKey;
 
   protected MojoExecutionProblemInfo(String message, MojoExecutionKey mojoExecutionKey, SourceLocation markerLocation) {
     super(message, markerLocation);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/MavenProblemInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/MavenProblemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Sonatype, Inc.
+ * Copyright (c) 2010, 2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation
+ *      Christoph Läubrich - #549 - Improve conflict handling of lifecycle mappings
  *******************************************************************************/
 
 package org.eclipse.m2e.core.internal.markers;
@@ -29,13 +30,30 @@ public class MavenProblemInfo {
 
   private final int severity;
 
+  private Throwable error;
+
   public MavenProblemInfo(int line, Throwable error) {
     this(new SourceLocation(line, 0, 0), error);
   }
 
   public MavenProblemInfo(SourceLocation location, Throwable error) {
     this.location = location;
+    this.error = error;
     this.message = getErrorMessage(error);
+    this.severity = IMarker.SEVERITY_ERROR;
+  }
+
+  public MavenProblemInfo(SourceLocation location, String message, Throwable error) {
+    this.location = location;
+    this.error = error;
+    this.message = message;
+    this.severity = IMarker.SEVERITY_ERROR;
+  }
+
+  public MavenProblemInfo(int line, String message, Throwable error) {
+    this.error = error;
+    this.location = new SourceLocation(line, 0, 0);
+    this.message = message;
     this.severity = IMarker.SEVERITY_ERROR;
   }
 
@@ -55,12 +73,6 @@ public class MavenProblemInfo {
     this.severity = IMarker.SEVERITY_ERROR;
   }
 
-  public MavenProblemInfo(int line, String message) {
-    //TODO
-    this.location = new SourceLocation(line, 0, 0);
-    this.message = message;
-    this.severity = IMarker.SEVERITY_ERROR;
-  }
 
   public MavenProblemInfo(String message, SourceLocation location) {
     this(message, IMarker.SEVERITY_ERROR, location);
@@ -111,6 +123,13 @@ public class MavenProblemInfo {
 
   public SourceLocation getLocation() {
     return location;
+  }
+
+  /**
+   * @return Returns the error.
+   */
+  public Throwable getError() {
+    return this.error;
   }
 
   private String getErrorMessage(Throwable e) {


### PR DESCRIPTION
This is a first step improving the following things

- record what is causing the conflict
- add the exception to the maven problem
- show problem markers at the correct location in the pom
- store the conflicting bundles at the marker