### PR TITLE
Add a quickfix for conflicting life-cycle mappings to be ignored on the workspace

### DIFF
--- a/org.eclipse.m2e.core/mdo/lifecycle-mapping-metadata-model.xml
+++ b/org.eclipse.m2e.core/mdo/lifecycle-mapping-metadata-model.xml
@@ -43,6 +43,13 @@
             <multiplicity>*</multiplicity>
           </association>
         </field>
+        <field>
+          <name>lifecycleMappingFilters</name>
+          <association>
+            <type>LifecycleMappingFilter</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
       </fields>
       <codeSegments>
         <codeSegment>
@@ -198,6 +205,71 @@
     return getGoals().contains(mojoExecution.getGoal());
   }
             ]]>
+          </code>
+        </codeSegment>
+      </codeSegments>
+    </class>
+    
+    <class xml.tagName="lifecycleMappingFilter" xml.standaloneRead="true" java.clone="deep">
+      <name>LifecycleMappingFilter</name>
+      <fields>
+        <field required="true">
+          <name>symbolicName</name>
+          <identifier>true</identifier>
+          <type>String</type>
+        </field>
+        <field required="true" java.setter="false">
+          <name>versionRange</name>
+          <identifier>true</identifier>
+          <type>String</type>
+        </field>
+        <field required="true">
+          <name>pluginExecutions</name>
+          <identifier>true</identifier>
+          <type>Set</type>
+          <association>
+            <type>PluginExecutionFilter</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
+        <field required="true">
+          <name>packagingTypes</name>
+          <identifier>true</identifier>
+          <type>Set</type>
+          <association>
+            <type>String</type>
+            <multiplicity>*</multiplicity>
+          </association>
+        </field>
+      </fields>
+      <codeSegments>
+        <codeSegment>
+          <code><![CDATA[
+  private transient org.apache.maven.artifact.versioning.VersionRange parsedVersionRange;
+
+  public void setVersionRange(String versionRange) {
+    this.versionRange = versionRange;
+    try {
+      parsedVersionRange = org.apache.maven.artifact.versioning.VersionRange.createFromVersionSpec(versionRange);
+    } catch(org.apache.maven.artifact.versioning.InvalidVersionSpecificationException e) {
+      throw new IllegalArgumentException("Cannot parse version range: " + versionRange, e);
+    }
+  }
+
+  public boolean matches(String version) {
+    if(parsedVersionRange == null) {
+      try {
+        parsedVersionRange = org.apache.maven.artifact.versioning.VersionRange.createFromVersionSpec(versionRange);
+      } catch(org.apache.maven.artifact.versioning.InvalidVersionSpecificationException e) {
+        throw new IllegalArgumentException("Cannot parse version range: " + versionRange, e);
+      }
+    }
+    org.apache.maven.artifact.versioning.DefaultArtifactVersion artifactVersion = new org.apache.maven.artifact.versioning.DefaultArtifactVersion(
+        version);
+    return parsedVersionRange.containsVersion(artifactVersion);
+
+  }
+          ]]>
           </code>
         </codeSegment>
       </codeSegments>

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenConstants.java
@@ -110,6 +110,8 @@ public interface IMavenConstants {
 
   String EDITOR_HINT_IMPLICIT_LIFECYCLEMAPPING = "implicit_lifecyclemaping";//$NON-NLS-1$
 
+  String EDITOR_HINT_CONFLICTING_LIFECYCLEMAPPING = "conflicting_lifecyclemaping";//$NON-NLS-1$
+
   String EDITOR_HINT_UNKNOWN_LIFECYCLE_ID = "unknown_lifecycle_id";//$NON-NLS-1$
 
   String EDITOR_HINT_MISSING_CONFIGURATOR = "missing_configurator";//$NON-NLS-1$
@@ -133,5 +135,15 @@ public interface IMavenConstants {
   String MARKER_DUPLICATEMAPPING_VALUE = "duplicateMappingValue";
 
   String MARKER_DUPLICATEMAPPING_SOURCES = "duplicateMappingSources";
+
+  String MARKER_DUPLICATEMAPPING_SOURCES_NAME = "name";
+
+  String MARKER_DUPLICATEMAPPING_SOURCES_BSN = "bundleSymbolicName";
+
+  String MARKER_DUPLICATEMAPPING_SOURCES_VERSION = "bundleVersionRange";
+
+  String MARKER_DUPLICATEMAPPING_TYPE_PACKAGING = "packaging";
+
+  String MARKER_DUPLICATEMAPPING_TYPE_GOAL = "goal";
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/AnnotationMappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/AnnotationMappingMetadataSource.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,7 @@ import org.apache.maven.model.PluginExecution;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.internal.Messages;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingFilter;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionFilter;
@@ -137,7 +139,7 @@ public class AnnotationMappingMetadataSource implements MappingMetadataSource {
   }
 
   @Override
-  public LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType) throws DuplicateMappingException {
+  public LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType, Predicate<LifecycleMappingMetadata> filter) throws DuplicateMappingException {
     return null;
   }
 
@@ -308,5 +310,13 @@ public class AnnotationMappingMetadataSource implements MappingMetadataSource {
       this.c = c;
       this.action = action;
     }
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.internal.lifecyclemapping.MappingMetadataSource#getFilters()
+   */
+  @Override
+  public List<LifecycleMappingFilter> getFilters() {
+    return Collections.emptyList();
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateExecutionMappingSourceProblem.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateExecutionMappingSourceProblem.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.markers.SourceLocation;
+import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
+
+
+/**
+ * DuplicateExecutionMappingSourceProblem
+ *
+ */
+public class DuplicateExecutionMappingSourceProblem extends DuplicateMappingSourceProblem {
+
+  private MojoExecutionKey executionKey;
+
+  /**
+   * @param location
+   * @param message
+   * @param executionKey
+   * @param error
+   */
+  public DuplicateExecutionMappingSourceProblem(SourceLocation location, String message, MojoExecutionKey executionKey,
+      DuplicatePluginExecutionMetadataException error) {
+    super(location, message, IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE_GOAL, executionKey.getGoal(), error);
+    this.executionKey = executionKey;
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.internal.lifecyclemapping.DuplicateMappingSourceProblem#processMarker(org.eclipse.core.resources.IMarker)
+   */
+  @Override
+  public void processMarker(IMarker marker) throws CoreException {
+    super.processMarker(marker);
+    MojoExecutionProblemInfo.setExecutionInfo(executionKey, marker);
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingSourceProblem.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingSourceProblem.java
@@ -72,11 +72,13 @@ public class DuplicateMappingSourceProblem extends MavenProblemInfo {
       String prefix = IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES + "." + i + ".";
       Version version = bundle.getVersion();
       String v = version.getMajor() + "." + version.getMinor() + "." + version.getMicro();
-      marker.setAttribute(prefix + "bundleName",
+      marker.setAttribute(prefix + IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES_NAME,
           Objects.requireNonNullElse(bundle.getHeaders().get(Constants.BUNDLE_NAME), bundle.getSymbolicName()));
-      marker.setAttribute(prefix + "bundleSymbolicName", bundle.getSymbolicName());
-      marker.setAttribute(prefix + "bundleVersionRange", "[" + v + ",)");
+      marker.setAttribute(prefix + IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES_BSN, bundle.getSymbolicName());
+      marker.setAttribute(prefix + IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES_VERSION, v);
     }
+    marker.setAttribute(IMavenConstants.MARKER_ATTR_EDITOR_HINT,
+        IMavenConstants.EDITOR_HINT_CONFLICTING_LIFECYCLEMAPPING);
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/FailedMappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/FailedMappingMetadataSource.java
@@ -12,8 +12,11 @@
  *******************************************************************************/
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingFilter;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -42,7 +45,7 @@ public class FailedMappingMetadataSource implements MappingMetadataSource {
    * @see org.eclipse.m2e.core.internal.lifecyclemapping.MappingMetadataSource#getLifecycleMappingMetadata(java.lang.String)
    */
   @Override
-  public LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType) throws DuplicateMappingException {
+  public LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType, Predicate<LifecycleMappingMetadata> filter) throws DuplicateMappingException {
     throw failure;
   }
 
@@ -66,6 +69,14 @@ public class FailedMappingMetadataSource implements MappingMetadataSource {
    */
   public MappingMetadataSource getSource() {
     return this.source;
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.internal.lifecyclemapping.MappingMetadataSource#getFilters()
+   */
+  @Override
+  public List<LifecycleMappingFilter> getFilters() {
+    return Collections.emptyList();
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MappingMetadataSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Sonatype, Inc.
+ * Copyright (c) 2010, 2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,15 @@
  *
  * Contributors:
  *      Sonatype, Inc. - initial API and implementation
+ *      Christoph Läubrich - #549 - Improve conflict handling of lifecycle mappings
  *******************************************************************************/
 
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
 import java.util.List;
+import java.util.function.Predicate;
 
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingFilter;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -26,8 +29,10 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
  * @author igor
  */
 public interface MappingMetadataSource {
-  LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType) throws DuplicateMappingException;
+  LifecycleMappingMetadata getLifecycleMappingMetadata(String packagingType, Predicate<LifecycleMappingMetadata> filter) throws DuplicateMappingException;
 
   List<PluginExecutionMetadata> getPluginExecutionMetadata(MojoExecutionKey execution);
+
+  List<LifecycleMappingFilter> getFilters();
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MojoExecutionFilter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MojoExecutionFilter.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingFilter;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
+import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
+
+
+/**
+ * A {@link Predicate} that returns true if the given {@link PluginExecutionMetadata} is filtered for the goal by any of
+ * the filters.
+ */
+public class MojoExecutionFilter implements Predicate<PluginExecutionMetadata> {
+  private List<LifecycleMappingFilter> filters;
+
+
+  public MojoExecutionFilter(List<MappingMetadataSource> metadataSources, MojoExecutionKey executionKey) {
+    filters = metadataSources.stream().flatMap(s -> s.getFilters().stream())
+        .filter(filter -> filter.getPluginExecutions().stream()
+            .anyMatch(pluginFilter -> pluginFilter.match(executionKey)))
+        .collect(Collectors.toList());
+  }
+
+  /* (non-Javadoc)
+   * @see java.util.function.Predicate#test(java.lang.Object)
+   */
+  @Override
+  public boolean test(PluginExecutionMetadata metadata) {
+    return Optional.ofNullable(metadata.getSource())//
+        .map(LifecycleMappingMetadataSource::getSource)//
+        .filter(Bundle.class::isInstance)//
+        .map(Bundle.class::cast)//
+        .filter(bundle -> {
+          return filters.stream().anyMatch(filter -> {
+            if(filter.getSymbolicName().equals(bundle.getSymbolicName())) {
+              Version version = bundle.getVersion();
+              if(filter.matches(version.getMajor() + "." + version.getMinor() + "." + version.getMicro())) {
+                return true;
+              }
+            }
+            return false;
+          });
+        }).isPresent();
+  }
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MojoExecutionProblemInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/MojoExecutionProblemInfo.java
@@ -40,6 +40,10 @@ public abstract class MojoExecutionProblemInfo extends MavenProblemInfo {
   public void processMarker(IMarker marker) throws CoreException {
     super.processMarker(marker);
 
+    setExecutionInfo(mojoExecutionKey, marker);
+  }
+
+  static void setExecutionInfo(MojoExecutionKey mojoExecutionKey, IMarker marker) throws CoreException {
     //TODO what parameters are important here for the hints?
     marker.setAttribute(IMavenConstants.MARKER_ATTR_GROUP_ID, mojoExecutionKey.getGroupId());
     marker.setAttribute(IMavenConstants.MARKER_ATTR_ARTIFACT_ID, mojoExecutionKey.getArtifactId());

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/PackagingTypeFilter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/PackagingTypeFilter.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.internal.lifecyclemapping;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingFilter;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
+
+
+/**
+ * A {@link Predicate} that returns true if the given {@link LifecycleMappingMetadata} is filtered for the packaging
+ * type by any of the filters.
+ */
+public class PackagingTypeFilter implements Predicate<LifecycleMappingMetadata> {
+  private List<LifecycleMappingFilter> filters;
+
+  /**
+   * 
+   */
+  public PackagingTypeFilter(List<MappingMetadataSource> metadataSources, String packagingType) {
+    filters = metadataSources.stream().flatMap(s -> s.getFilters().stream())
+        .filter(filter -> filter.getPackagingTypes().contains(packagingType)).collect(Collectors.toList());
+  }
+
+  /* (non-Javadoc)
+   * @see java.util.function.Predicate#test(java.lang.Object)
+   */
+  @Override
+  public boolean test(LifecycleMappingMetadata metadata) {
+
+    return Optional.ofNullable(metadata.getSource())//
+        .map(LifecycleMappingMetadataSource::getSource)//
+        .filter(Bundle.class::isInstance)//
+        .map(Bundle.class::cast)//
+        .filter(bundle -> {
+          return filters.stream().anyMatch(filter -> {
+            if(filter.getSymbolicName().equals(bundle.getSymbolicName())) {
+              Version version = bundle.getVersion();
+              return filter.matches(version.getMajor() + "." + version.getMinor() + "." + version.getMicro());
+            }
+            return false;
+          });
+        }).isPresent();
+  }
+}

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/Messages.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/Messages.java
@@ -355,6 +355,8 @@ public class Messages extends NLS {
 
   public static String LifecycleMappingProposal_workspaceIgnore_label;
 
+  public static String LifecycleMappingProposal_sourceIgnore_label;
+
   static {
     // initialize resource bundle
     NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/ConflictingLifecycleMappingResolution.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/ConflictingLifecycleMappingResolution.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.editor.internal.lifecycle;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.osgi.util.NLS;
+
+import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
+import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
+import org.eclipse.m2e.core.lifecyclemapping.model.PluginExecutionAction;
+import org.eclipse.m2e.core.ui.internal.UpdateMavenProjectJob;
+import org.eclipse.m2e.editor.internal.Messages;
+
+
+/**
+ * ConflictingLifecycleMappingResolution
+ */
+@SuppressWarnings("restriction")
+public class ConflictingLifecycleMappingResolution extends AbstractLifecycleMappingResolution {
+
+  private String prefix;
+
+  /**
+   * @param marker
+   * @param action
+   */
+  public ConflictingLifecycleMappingResolution(IMarker marker, int index) {
+    super(marker, PluginExecutionAction.ignore);
+    prefix = IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES + "." + index + ".";
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.ui.IMarkerResolution#getLabel()
+   */
+  @Override
+  public String getLabel() {
+    String source = getMarker().getAttribute(prefix + IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES_NAME, ""); //$NON-NLS-1$
+    String type = getMarker().getAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE, ""); //$NON-NLS-1$
+    String value = getMarker().getAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_VALUE, ""); //$NON-NLS-1$
+    return NLS.bind(Messages.LifecycleMappingProposal_sourceIgnore_label, new Object[] {source, type, value});
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.ui.internal.markers.EditorAwareMavenProblemResolution#fix(org.eclipse.core.resources.IResource, java.util.List, org.eclipse.core.runtime.IProgressMonitor)
+   */
+  @Override
+  protected void fix(IResource resource, List<IMarker> markers, IProgressMonitor monitor) {
+    fix(markers, monitor);
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.ui.internal.markers.EditorAwareMavenProblemResolution#fix(org.eclipse.jface.text.IDocument, java.util.List, org.eclipse.core.runtime.IProgressMonitor)
+   */
+  @Override
+  protected void fix(IDocument document, List<IMarker> markers, IProgressMonitor monitor) {
+    fix(markers, monitor);
+  }
+
+  private void fix(List<IMarker> markers, IProgressMonitor monitor) {
+    LifecycleMappingMetadataSource mapping = LifecycleMappingFactory.getWorkspaceMetadata(true);
+    for(IMarker marker : markers) {
+      addMapping(mapping, marker);
+    }
+    LifecycleMappingFactory.writeWorkspaceMetadata(mapping);
+
+    // must kick off an update project job since the pom isn't modified.
+    // Only update the project from where this quick fix was executed.
+    // Other projects can be updated manually
+    new UpdateMavenProjectJob(getProjects(markers.stream()).toArray(IProject[]::new)).schedule();
+  }
+
+  /**
+   * @param mapping
+   * @param marker
+   */
+  private void addMapping(LifecycleMappingMetadataSource mapping, IMarker marker) {
+    String bsn = marker.getAttribute(prefix + IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES_BSN, ""); //$NON-NLS-1$
+    String version = marker.getAttribute(prefix + IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES_VERSION, ""); //$NON-NLS-1$
+
+    String type = marker.getAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE, "");
+    String value = marker.getAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_VALUE, "");
+    if(IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE_PACKAGING.equals(type)) {
+      LifecycleMappingFactory.addLifecycleMappingPackagingFilter(mapping, bsn, version, value);
+    } else if(IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE_GOAL.equals(type)) {
+      String executionGroupId = marker.getAttribute(IMavenConstants.MARKER_ATTR_GROUP_ID, "");
+      String executionArtifactId = marker.getAttribute(IMavenConstants.MARKER_ATTR_ARTIFACT_ID, "");
+      String executionVersion = marker.getAttribute(IMavenConstants.MARKER_ATTR_VERSION, "");
+      String goal = marker.getAttribute(IMavenConstants.MARKER_ATTR_GOAL, "");
+      LifecycleMappingFactory.addLifecycleMappingExecutionFilter(mapping, bsn, version, executionGroupId,
+          executionArtifactId, executionVersion, goal);
+    }
+
+  }
+
+}

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MavenMarkerResolutionGenerator.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/markers/MavenMarkerResolutionGenerator.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.m2e.editor.internal.markers;
 
+import java.util.stream.IntStream;
+
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IMarkerResolutionGenerator;
@@ -21,6 +23,7 @@ import org.eclipse.ui.IMarkerResolutionGenerator2;
 
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.lifecyclemapping.model.PluginExecutionAction;
+import org.eclipse.m2e.editor.internal.lifecycle.ConflictingLifecycleMappingResolution;
 import org.eclipse.m2e.editor.internal.lifecycle.LifecycleMappingResolution;
 import org.eclipse.m2e.editor.internal.lifecycle.WorkspaceLifecycleMappingResolution;
 
@@ -58,6 +61,12 @@ public class MavenMarkerResolutionGenerator implements IMarkerResolutionGenerato
           new IgnoreWarningResolution(marker, IMavenConstants.MARKER_IGNORE_MANAGED),
           new OpenManagedVersionDefinitionResolution(marker)};
     }
+    if(IMavenConstants.EDITOR_HINT_CONFLICTING_LIFECYCLEMAPPING.equals(hint)) {
+      int conflicting = marker.getAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES, 0);
+      return IntStream.range(0, conflicting).mapToObj(index -> new ConflictingLifecycleMappingResolution(marker, index))
+          .toArray(IMarkerResolution[]::new);
+    }
+
     if(IMavenConstants.EDITOR_HINT_NOT_COVERED_MOJO_EXECUTION.equals(hint)) {
       return new IMarkerResolution[] {new LifecycleMappingResolution(marker, PluginExecutionAction.ignore),
           new WorkspaceLifecycleMappingResolution(marker, PluginExecutionAction.ignore),};

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/messages.properties
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/messages.properties
@@ -168,3 +168,4 @@ LifecycleMappingProposal_execute_label=Execute goal {0} as part of Eclipse build
 LifecycleMappingProposal_ignore_desc=This quickfix generates a plugin configuration snippet recognized by the m2e integration during project configuration. It marks the given goal as ignored for the purposes of the Eclipse build.
 LifecycleMappingProposal_ignore_label=Mark goal {0} as ignored in pom.xml
 LifecycleMappingProposal_workspaceIgnore_label=Mark goal {0} as ignored in eclipse preferences
+LifecycleMappingProposal_sourceIgnore_label=Ignore {0} for <{1}>{2}</{1}> in eclipse preferences

--- a/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="1.18.4",
  org.eclipse.m2e.jdt;bundle-version="1.18.3",
  org.eclipse.core.runtime;bundle-version="3.24.0",
  org.eclipse.core.resources;bundle-version="3.16.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.18.2",
+ org.eclipse.m2e.maven.runtime;bundle-version="1.18.1",
  org.eclipse.pde.core,
  org.eclipse.jdt.core
 Bundle-Activator: org.eclipse.m2e.pde.connector.Activator

--- a/org.eclipse.m2e.pde.connector/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.m2e.pde.connector/lifecycle-mapping-metadata.xml
@@ -11,8 +11,7 @@
 	<lifecycleMappings>
 		<lifecycleMapping>
 			<packagingType>bundle</packagingType>
-			<lifecycleMappingId>org.eclipse.m2e.jdt.JarLifecycleMapping
-			</lifecycleMappingId>
+			<lifecycleMappingId>org.eclipse.m2e.jdt.JarLifecycleMapping</lifecycleMappingId>
 		</lifecycleMapping>
 	</lifecycleMappings>
 
@@ -50,5 +49,16 @@
 			</action>
 		</pluginExecution>
 	</pluginExecutions>
+
+	<lifecycleMappingFilters>
+		<!-- m2e connector is a replacement for the org.sonatype.tycho.m2e bundle binding -->
+		<lifecycleMappingFilter>
+			<symbolicName>org.sonatype.tycho.m2e</symbolicName>
+			<versionRange>[0.0.1,)</versionRange>
+			<packagingTypes>
+				<packagingType>bundle</packagingType>
+			</packagingTypes>
+		</lifecycleMappingFilter>
+	</lifecycleMappingFilters>
 </lifecycleMappingMetadata>
   


### PR DESCRIPTION
This adds a quickfix that if applied filters unwanted life-cycle mapping sources based on the goal or packaging type.