### PR TITLE
[Console] generalize, clean up and speed-up ConsoleTest

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple.projectWithJUnit-5_Test/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple.projectWithJUnit-5_Test/pom.xml
@@ -2,7 +2,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.m2e.tests.projects</groupId>
+	<groupId>org.eclipse.m2e.tests</groupId>
 	<artifactId>simple.projectWithJUnit-5_Test</artifactId>
 	<version>1</version>
 	<properties>


### PR DESCRIPTION
This change generalizes and cleans-up `ConsoleTest` by leveraging super-class methods (e.g. in cleans the workspace after the test).
Furthermore the execution is speed up by merging the test cases which saves multiple project imports and build runs.