### PR TITLE
Make Eclipse-M2E launch configuration feature based

### DIFF
--- a/setup/Eclipse-M2E-IDE.launch
+++ b/setup/Eclipse-M2E-IDE.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+    <setAttribute key="additional_plugins">
+        <setEntry value="org.eclipse.m2e.logback.configuration:1.16.3.qualifier:default:true:default:true"/>
+    </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
     <booleanAttribute key="askclear" value="true"/>
     <booleanAttribute key="automaticAdd" value="true"/>
@@ -9,8 +12,10 @@
     <booleanAttribute key="clearConfig" value="true"/>
     <booleanAttribute key="clearws" value="false"/>
     <booleanAttribute key="clearwslog" value="false"/>
-    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Eclipse-IDE"/>
-    <booleanAttribute key="default" value="true"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Eclipse-M2E-IDE"/>
+    <booleanAttribute key="default" value="false"/>
+    <stringAttribute key="featureDefaultLocation" value="workspace"/>
+    <stringAttribute key="featurePluginResolution" value="workspace"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-m2e-Eclipse-IDE"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
@@ -21,10 +26,17 @@
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
+    <setAttribute key="selected_features">
+        <setEntry value="org.eclipse.m2e.feature:default"/>
+        <setEntry value="org.eclipse.m2e.lemminx.feature:default"/>
+        <setEntry value="org.eclipse.m2e.logback.feature:default"/>
+        <setEntry value="org.eclipse.m2e.pde.feature:default"/>
+        <setEntry value="org.eclipse.sdk:default"/>
+    </setAttribute>
     <booleanAttribute key="show_selected_only" value="false"/>
     <stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
     <booleanAttribute key="tracing" value="false"/>
-    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="true"/>
     <booleanAttribute key="useDefaultConfig" value="true"/>
     <booleanAttribute key="useDefaultConfigArea" value="true"/>
     <booleanAttribute key="useProduct" value="true"/>


### PR DESCRIPTION
This PR changes the Eclipse-M2E launch configuration to be based on features.

Compared to before where all workspace plug-ins were part of the launched eclipse this has the following advantages 
- test bundles are not part of the launched Eclipse
- the logback configuration plugin is activated automatically
- only the LemMinX editor feature is included and the old editor is ignored.
- other plug-ins in the workspace that are unrelated to M2E are not part of the launched Eclipse
- One recognizes immediately if a new plug-in is not added to a corresponding feature.

This improved launch-configuration relies on recent changes in PDE that were published with Eclipse 2022-03 Milestone 2.
Since  2022-03 M2 is already part of the Oomph Product Catalog I think it is acceptable to require M2E contributors to use that?

@laeubi this is a little taste of how simple you can create an M2E product/launch configuration in the future (the product part is not yet fully completed).

Site note: the bundles `org.apache.xerces` and `org.apache.xml.resolver` are only included because PDE currently fails to resolve it successfully which is why they are not added automatically.