### PR TITLE
[Console] support eclipse-plugin type projects build with Tycho

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Eclipse m2e - Release notes
 
+## 2.1.0
+
+* 📅 Release Date: _expected_ December 2022
+* All changes: https://github.com/eclipse-m2e/m2e-core/compare/2.0.2...2.1.0
+
+### Console support for polyglot Maven projects and projects without Maven nature
+
+The M2E Maven-Console now also supports tracking of so called _polyglot_ Maven-projects. Those are projects that don't have a standard `pom.xml` and whose Maven-model is instead created from another source. One prominent example in the Eclipse world are Eclipse-PDE projects that are build with Tycho(-pomless).
+
+Due to this new support, polyglot Maven projects now also benefit from the 
+[Improved links to JUnit test-reports and project file in the Console](https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#improved-links-to-junit-test-reports-and-project-pomxml-in-the-console-of-a-maven-build)
+as well as the capability to
+[Automatically launch and attach Remote-Application-Debugger when Maven plug-in starts a forked JVM that waits for a debugger](https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#automatically-launch-and-attach-remote-application-debugger-when-maven-plug-in-starts-a-forked-jvm-that-waits-for-a-debugger) introduced in previous releases.
+
 ## 2.0.2
 
 * 📅 Release Date: August 30th 2022
@@ -83,7 +97,6 @@ Further information, how to activate the debug mode of forked JVMs for the plug-
 - [Tycho-Surefire](https://www.eclipse.org/tycho/sitedocs/tycho-surefire-plugin/test-mojo.html#debugPort)
 - [Tycho-Eclipserun](https://www.eclipse.org/tycho/sitedocs/tycho-extras/tycho-eclipserun-plugin/eclipse-run-mojo.html#jvmArgs)
 
-
 #### Improved links to JUnit test-reports and project pom.xml in the Console of a Maven build
 
 Clicking on the link placed at the name of a running test-class now opens the `JUnit` view that displays the test-reports of the executed tests:
@@ -97,7 +110,6 @@ For each project build a link is now added to the project's headline, which open
 In case of a build failure another link, that opens the `pom.xml` of the failed project, is added to the line that that describes the failure at the very end of the Maven build print-out:
 
 ![grafik](https://user-images.githubusercontent.com/44067969/152247987-01ee209a-ad6c-454e-92c1-e2aa75388931.png)
-
 
 #### the m2e-pde editor now supports generation of a feature from a location:
 

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -162,6 +162,7 @@
 							-exportcontents: \
 								META-INF.plexus;-noimport:=true;x-internal:=true,\
 								META-INF.sisu;-noimport:=true;x-internal:=true,\
+								org.eclipse.m2e.internal.maven.listener;x-friends:="org.eclipse.m2e.launching",\
 								org.apache.maven.*;provider=m2e;mandatory:=provider,\
 								org.codehaus.plexus.*;provider=m2e;mandatory:=provider,\
 								org.sonatype.plexus.*;provider=m2e;mandatory:=provider,\
@@ -186,5 +187,22 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.sisu</groupId>
+				<artifactId>sisu-maven-plugin</artifactId>
+				<version>0.3.5</version>
+				<executions>
+					<execution>
+						<?m2e execute onIncremental?>
+						<id>index-plexus</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>main-index</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/java/org/eclipse/m2e/internal/maven/listener/M2EMavenBuildDataBridge.java
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/java/org/eclipse/m2e/internal/maven/listener/M2EMavenBuildDataBridge.java
@@ -1,0 +1,232 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2022 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.internal.maven.listener;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.eventspy.EventSpy;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionEvent.Type;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This {@link EventSpy} listens to certain events within a Maven build JVM and
+ * sends certain data (e.g. about projects being built) to the JVM of the
+ * Eclipse IDE that launched the Maven build JVM.
+ * 
+ * @author Hannes Wellmann
+ *
+ */
+@Named
+@Singleton
+public class M2EMavenBuildDataBridge implements EventSpy {
+
+	private static final String SOCKET_FILE_PROPERTY_NAME = "m2e.build.project.data.socket.port";
+	private static final String DATA_SET_SEPARATOR = ";;";
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(M2EMavenBuildDataBridge.class);
+
+	private SocketChannel writeChannel;
+
+	@Override
+	public void init(Context context) throws IOException {
+		String socketPort = System.getProperty(SOCKET_FILE_PROPERTY_NAME);
+		if (socketPort != null) {
+			try {
+				// TODO: replace by the following once Java-17 is required by Maven:
+				// SocketAddress address = UnixDomainSocketAddress.of(socketPort);
+				int port = Integer.parseInt(socketPort);
+				SocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
+				this.writeChannel = SocketChannel.open(address);
+			} catch (Exception e) {
+				LOGGER.warn("Failed to establish connection to Eclipse-M2E", e);
+			}
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		writeChannel.close();
+	}
+
+	@Override
+	public void onEvent(Object event) throws Exception {
+		if (writeChannel != null && event instanceof ExecutionEvent
+				&& ((ExecutionEvent) event).getType() == Type.ProjectStarted) {
+
+			String message = serializeProjectData(((ExecutionEvent) event).getProject());
+
+			ByteBuffer buffer = ByteBuffer.wrap(message.getBytes());
+			synchronized (writeChannel) {
+				while (buffer.hasRemaining()) {
+					writeChannel.write(buffer);
+				}
+			}
+		}
+	}
+
+	private static String serializeProjectData(MavenProject project) {
+		StringJoiner data = new StringJoiner(",");
+		add(data, "groupId", project.getGroupId());
+		add(data, "artifactId", project.getArtifactId());
+		add(data, "version", project.getVersion());
+		add(data, "file", project.getFile());
+		add(data, "basedir", project.getBasedir());
+		add(data, "build.directory", project.getBuild().getDirectory());
+		return data.toString() + DATA_SET_SEPARATOR;
+	}
+
+	private static void add(StringJoiner data, String key, Object value) {
+		data.add(key + "=" + value);
+	}
+
+	/**
+	 * <p>
+	 * This method is supposed to be called from M2E within the Eclipse-IDE JVM.
+	 * </p>
+	 * 
+	 * @param dataSet the data-set to parse
+	 * @return the {@link MavenProjectBuildData} parsed from the given string
+	 */
+	private static MavenProjectBuildData parseMavenBuildProject(String dataSet) {
+		Map<String, String> data = new HashMap<>(8);
+		for (String entry : dataSet.split(",")) {
+			String[] keyValue = entry.split("=");
+			if (keyValue.length != 2) {
+				throw new IllegalStateException("Invalid data-set format" + dataSet);
+			}
+			data.put(keyValue[0], keyValue[1]);
+		}
+		return new MavenProjectBuildData(data);
+	}
+
+	public static final class MavenProjectBuildData {
+		public final String groupId;
+		public final String artifactId;
+		public final String version;
+		public final Path projectBasedir;
+		public final Path projectFile;
+		public final Path projectBuildDirectory;
+
+		MavenProjectBuildData(Map<String, String> data) {
+			if (data.size() != 6) {
+				throw new IllegalArgumentException();
+			}
+			this.groupId = Objects.requireNonNull(data.get("groupId"));
+			this.artifactId = Objects.requireNonNull(data.get("artifactId"));
+			this.version = Objects.requireNonNull(data.get("version"));
+			this.projectBasedir = Path.of(data.get("basedir"));
+			this.projectFile = Path.of(data.get("file"));
+			this.projectBuildDirectory = Path.of(data.get("build.directory"));
+		}
+	}
+
+	/**
+	 * Prepares the connection to a {@code Maven build JVM} to be launched and is
+	 * intended to be called from the Eclipse IDE JVM.
+	 * 
+	 * @param label           the label of the listener thread
+	 * @param datasetListener the listener, which is notified whenever a new
+	 *                        {@link MavenProjectBuildData MavenProjectBuildDataSet}
+	 *                        has arived from the Maven VM in the Eclipse-IDE VM.
+	 * @return the preapre {@link MavenBuildConnection}
+	 * @throws IOException
+	 */
+	public static MavenBuildConnection prepareConnection(String label, Consumer<MavenProjectBuildData> datasetListener)
+			throws IOException {
+
+//	    TODO: use UNIX domain socket once Java-17 is required by Maven
+//	    Path socketFile = Files.createTempFile("m2e.maven.build.listener", ".socket");
+//	    socketFile.toFile().deleteOnExit();
+//	    Files.delete(socketFile); // file must not exist when the server-socket is bound
+
+//	    ServerSocketChannel server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+//	    server.bind(UnixDomainSocketAddress.of(socketFile));
+		ServerSocketChannel server = ServerSocketChannel.open();
+		server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+		MavenBuildConnection connection = new MavenBuildConnection(server);
+
+		Thread reader = new Thread(() -> {
+			try (ServerSocketChannel s = server; SocketChannel readChannel = server.accept()) {
+				ByteBuffer buffer = ByteBuffer.allocate(512);
+				StringBuilder message = new StringBuilder();
+				while (readChannel.read(buffer.clear()) >= 0) {
+					message.append(new String(buffer.array(), 0, buffer.position()));
+					for (int terminatorIndex; (terminatorIndex = message.indexOf(DATA_SET_SEPARATOR)) >= 0;) {
+						String dataSet = message.substring(0, terminatorIndex);
+						message.delete(0, terminatorIndex + DATA_SET_SEPARATOR.length());
+
+						MavenProjectBuildData buildData = parseMavenBuildProject(dataSet);
+						datasetListener.accept(buildData);
+					}
+				}
+			} catch (IOException ex) { // ignore, happens if Maven process is forcibly terminated
+			} finally {
+				connection.readCompleted.set(true);
+			}
+//	      try {
+//	        Files.deleteIfExists(socketFile);
+//	      } catch(IOException ex) { // ignore
+//	      }
+		}, "M2E Maven build <" + label + "> connection reader");
+		reader.setDaemon(true);
+		reader.start();
+		return connection;
+	}
+
+	public static final class MavenBuildConnection {
+		private final ServerSocketChannel server;
+		private final AtomicBoolean readCompleted = new AtomicBoolean(false);
+
+		MavenBuildConnection(ServerSocketChannel server) {
+			this.server = server;
+		}
+
+		public String getMavenVMArguments() throws IOException {
+			String port = Integer.toString(((InetSocketAddress) server.getLocalAddress()).getPort());
+			return "-D" + SOCKET_FILE_PROPERTY_NAME + "=" + port;
+		}
+
+		public boolean isReadCompleted() {
+			return readCompleted.get();
+		}
+
+		public void close() throws IOException {
+			// Close the server to ensure the reader-thread does not wait forever for a
+			// connection from the Maven-process in case something went wrong during
+			// launching or while setting up the connection.
+			server.close();
+		}
+	}
+
+}

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -26,7 +26,6 @@
 
 	<properties>
 		<jars.directory>target/jars</jars.directory>
-		<jars.sources.directory>target/jars-sources</jars.sources.directory>
 		<outputDirectory.sources>${project.build.directory}/classes-source</outputDirectory.sources>
 		<failIfMacSigningFailed>false</failIfMacSigningFailed>
 		<buildqualifier.format>%Y%m%d-%H%M</buildqualifier.format>
@@ -83,7 +82,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.10.1</version>
 					<configuration>
-						<release>1.8</release>
+						<source>1.8</source>
+						<target>1.8</target>
 						<proc>none</proc>
 					</configuration>
 				</plugin>

--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Require-Bundle: org.eclipse.m2e.tests.common,
  org.eclipse.jdt.launching,
  org.eclipse.jdt.junit,
  org.eclipse.jdt.core,
- org.eclipse.m2e.editor
+ org.eclipse.m2e.editor,
+ org.eclipse.pde.ui,
+ org.eclipse.m2e.pde.connector
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.m2e.core.tests
 Import-Package: org.apache.commons.io;version="2.0.0"

--- a/org.eclipse.m2e.core.ui.tests/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2018, 2022 Red Hat Inc. and others
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License 2.0
+	which accompanies this distribution, and is available at
+	https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+	Mickael Istria (Red Hat Inc.) - Initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.m2e</groupId>
+		<artifactId>m2e-core</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.m2e.core.ui.tests</artifactId>
+	<version>2.0.0-SNAPSHOT</version>
+	<packaging>eclipse-test-plugin</packaging>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<configuration>
+						<useUIHarness>true</useUIHarness>
+						<useUIThread>false</useUIThread>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>target-platform-configuration</artifactId>
+					<configuration>
+						<dependency-resolution>
+							<extraRequirements>
+								<requirement>
+									<id>org.eclipse.osgi.compatibility.state</id>
+									<type>p2-installable-unit</type>
+									<versionRange>0.0.0</versionRange>
+								</requirement>
+							</extraRequirements>
+						</dependency-resolution>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/.mvn/extensions.xml
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>3.0.0</version>
+  </extension>
+</extensions>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.m2e.tests</groupId>
+	<artifactId>simple-tycho</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho.version>3.0.0</tycho.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId> 
+					<artifactId>tycho-p2-director-plugin</artifactId>
+					<version>${tycho.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<target>
+						<artifact>
+							<groupId>org.eclipse.m2e.tests</groupId>
+							<artifactId>simple.target</artifactId>
+							<version>1.0.0-SNAPSHOT</version>
+						</artifact>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<modules>
+		<module>simple.target</module>
+		<module>simple.tests</module>
+	</modules>
+</project>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.target/simple.target.target
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.target/simple.target.target
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="simple-target">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/eclipse/updates/4.25/"/>
+			<unit id="org.eclipse.osgi" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.launcher" version="0.0.0"/>
+			<unit id="org.eclipse.core.runtime" version="0.0.0"/>
+			<unit id="org.junit" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/.classpath
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/.project
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.m2e.pde.connector</name>
+	<name>simple.tests</name>
 	<comment></comment>
 	<projects>
 	</projects>
@@ -17,11 +17,6 @@
 		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.pde.SchemaBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.pde.ds.core.builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests
+Bundle-SymbolicName: simple.tests
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: simple.project
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Import-Package: org.junit

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/build.properties
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/build.properties
@@ -1,5 +1,4 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               resources/,\
                .

--- a/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/src/simple/SimpleTest.java
+++ b/org.eclipse.m2e.core.ui.tests/resources/projects/simple-tycho/simple.tests/src/simple/SimpleTest.java
@@ -1,0 +1,12 @@
+package simple;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SimpleTest {
+
+	@Test
+	public void testCase() {
+		Assert.assertTrue("Intentional failure",false);
+	}
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IBuildProjectFileResolver.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IBuildProjectFileResolver.java
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2022 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.core.project;
+
+import org.eclipse.core.runtime.IPath;
+
+
+/**
+ * A service to resolve a project's real main file from a polyglot pom-model file used in a Maven build.
+ * <p>
+ * Instances have be registered as OSGi service.
+ * </p>
+ */
+public interface IBuildProjectFileResolver {
+  /**
+   * Returns the relative path to the 'real' project file as sibling of the polyglot pom file with the given name.
+   * 
+   * @param pomFilename the polyglot pom file's name
+   * @return the path to the 'real' project file, which is resolved against the polyglot pom file's parent
+   */
+  IPath resolveProjectFile(String pomFilename);
+}

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenBuildProjectDataConnection.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenBuildProjectDataConnection.java
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2022 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.internal.launch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchesListener2;
+
+import org.eclipse.m2e.core.embedder.ArtifactKey;
+import org.eclipse.m2e.core.internal.launch.MavenEmbeddedRuntime;
+import org.eclipse.m2e.internal.launch.MavenRuntimeLaunchSupport.VMArguments;
+import org.eclipse.m2e.internal.maven.listener.M2EMavenBuildDataBridge;
+import org.eclipse.m2e.internal.maven.listener.M2EMavenBuildDataBridge.MavenBuildConnection;
+import org.eclipse.m2e.internal.maven.listener.M2EMavenBuildDataBridge.MavenProjectBuildData;
+
+
+public class MavenBuildProjectDataConnection {
+
+  private static record MavenBuildConnectionData(Map<ArtifactKey, MavenProjectBuildData> projects,
+      MavenBuildConnection connection) {
+  }
+
+  private static final Map<ILaunch, MavenBuildConnectionData> LAUNCH_PROJECT_DATA = new ConcurrentHashMap<>();
+
+  static {
+    DebugPlugin.getDefault().getLaunchManager().addLaunchListener(new ILaunchesListener2() {
+      public void launchesRemoved(ILaunch[] launches) {
+        closeServers(Arrays.stream(launches).map(LAUNCH_PROJECT_DATA::remove));
+      }
+
+      public void launchesTerminated(ILaunch[] launches) {
+        closeServers(Arrays.stream(launches).map(LAUNCH_PROJECT_DATA::get));
+      }
+
+      private static void closeServers(Stream<MavenBuildConnectionData> connectionData) {
+        connectionData.filter(Objects::nonNull).forEach(c -> {
+          try {
+            c.connection().close();
+          } catch(IOException ex) { // ignore
+          }
+        });
+      }
+
+      public void launchesAdded(ILaunch[] launches) { // ignore
+      }
+
+      public void launchesChanged(ILaunch[] launches) { // ignore
+      }
+    });
+  }
+
+  static void openListenerConnection(ILaunch launch, VMArguments arguments) {
+    try {
+      if(MavenLaunchUtils.getMavenRuntime(launch.getLaunchConfiguration()) instanceof MavenEmbeddedRuntime) {
+
+        Map<ArtifactKey, MavenProjectBuildData> projects = new ConcurrentHashMap<>();
+
+        MavenBuildConnection connection = M2EMavenBuildDataBridge.prepareConnection(
+            launch.getLaunchConfiguration().getName(),
+            d -> projects.put(new ArtifactKey(d.groupId, d.artifactId, d.version, null), d));
+
+        if(LAUNCH_PROJECT_DATA.putIfAbsent(launch, new MavenBuildConnectionData(projects, connection)) != null) {
+          connection.close();
+          throw new IllegalStateException(
+              "Maven bridge already created for launch of" + launch.getLaunchConfiguration().getName());
+        }
+        arguments.append(connection.getMavenVMArguments());
+      }
+    } catch(CoreException | IOException ex) { // ignore
+    }
+  }
+
+  static MavenProjectBuildData getBuildProject(ILaunch launch, String groupId, String artifactId, String version) {
+    MavenBuildConnectionData build = LAUNCH_PROJECT_DATA.get(launch);
+    if(build == null) {
+      return null;
+    }
+    ArtifactKey key = new ArtifactKey(groupId, artifactId, version, null);
+    while(true) {
+      MavenProjectBuildData buildProject = build.projects().get(key);
+      if(buildProject != null || build.connection().isReadCompleted()) {
+        return buildProject;
+      }
+      Thread.onSpinWait(); // Await completion of project data read. It has to become available soon, since its GAV was printed on the console
+    }
+  }
+
+}

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchExtensionsSupport.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchExtensionsSupport.java
@@ -98,6 +98,7 @@ public class MavenLaunchExtensionsSupport {
     for(IMavenLaunchParticipant participant : participants) {
       arguments.append(participant.getVMArguments(configuration, launch, monitor));
     }
+    MavenBuildProjectDataConnection.openListenerConnection(launch, arguments);
   }
 
 }

--- a/org.eclipse.m2e.pde.connector/.gitignore
+++ b/org.eclipse.m2e.pde.connector/.gitignore
@@ -1,0 +1,1 @@
+OSGI-INF/org.eclipse.m2e.*.xml

--- a/org.eclipse.m2e.pde.connector/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/org.eclipse.m2e.pde.connector/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_3
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.jdt.core,
  org.eclipse.pde.ds.annotations
 Bundle-Activator: org.eclipse.m2e.pde.connector.Activator
+Service-Component: OSGI-INF/org.eclipse.m2e.pde.connector.PDEBuildProjectFileResolver.xml

--- a/org.eclipse.m2e.pde.connector/build.properties
+++ b/org.eclipse.m2e.pde.connector/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
+               OSGI-INF/,\
                lifecycle-mapping-metadata.xml

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEBuildProjectFileResolver.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEBuildProjectFileResolver.java
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2022 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.pde.connector;
+
+import java.util.Map;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.m2e.core.project.IBuildProjectFileResolver;
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = IBuildProjectFileResolver.class)
+public class PDEBuildProjectFileResolver implements IBuildProjectFileResolver {
+
+	private static final Map<String, IPath> POM_NAME_2_PROJECT_FILE = Map.of( //
+			".polyglot.META-INF", Path.forPosix("META-INF/MANIFEST.MF"), //
+			".polyglot.feature.xml", Path.forPosix("feature.xml"));
+
+	@Override
+	public IPath resolveProjectFile(String pomFilename) {
+		IPath realFile = POM_NAME_2_PROJECT_FILE.get(pomFilename);
+		if (realFile != null) {
+			return realFile;
+		}
+		if (pomFilename.startsWith(".polyglot.")
+				&& (pomFilename.endsWith(".product") || pomFilename.endsWith(".target"))) {
+			return Path.forPosix(pomFilename.substring(".polyglot.".length()));
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
With this change the `MavenConsoleLineTracker` is enhanced to support `Eclipse Plug-in` projects build with Tycho.
As a consequence all recently added/enhanced features like the test-report and project links as well as automatic debugger attachment now wok for `Eclipse Plug-in` projects too.