### PR TITLE
Fix 591: sign jnilib files

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/eclipse-sign-jnilibs.properties
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/eclipse-sign-jnilibs.properties
@@ -1,0 +1,3 @@
+# This file tells the Maven build to sign the jnilibs contained in built jar
+# see the eclipse-sign-jnilibs profile defined in the parent pom
+jars.directory = jars

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-	<version>1.18.2-SNAPSHOT</version>
+	<version>1.18.3-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>M2E Embedded Maven Runtime (includes Incubating components)</name>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -312,5 +312,78 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>eclipse-sign-jnilibs</id>
+			<activation>
+				<file>
+					<exists>eclipse-sign-jnilibs.properties</exists>
+				</file>
+			</activation>
+			<!-- 
+			To activate jnilib signing for a bundle, create a file in the project called 'eclipse-sign-jnilibs.properties' and
+			define as value of the key 'jars.directory' the directory that contains the jars whose *.jnilib files have to be signed.
+			The following ant-script then extracts all .jnilib files, sign them and repacks them into the jar file. 
+			-->
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>sign-jnilibs-files</id>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<phase>generate-resources</phase> <!-- Do this before extracting sources-->
+								<configuration>
+									<target>
+										<!-- See last answer of https://stackoverflow.com/questions/4368243/maven-antrun-with-sequential-ant-contrib-fails-to-run/45958355 -->
+										<!-- and http://ant-contrib.sourceforge.net/tasks/tasks/index.html -->
+										<taskdef resource="net/sf/antcontrib/antlib.xml" />
+										<loadproperties srcFile="${project.basedir}/eclipse-sign-jnilibs.properties" prefix="signProperties." />
+										<for param="jarFile">
+											<fileset dir="${project.basedir}/${signProperties.jars.directory}" includes="**/*.jar" />
+											<sequential>
+												<local name="jarFilename" />
+												<basename property="jarFilename" file="@{jarFile}" suffix=".jar" />
+												<local name="signingDir" />
+												<property name="signingDir" value="${project.build.directory}/jnilibs-signing/${jarFilename}" />
+
+												<unzip src="@{jarFile}" dest="${signingDir}">
+													<patternset includes="**/*.jnilib" />
+												</unzip>
+
+												<for param="jnilibFileAbsolute">
+													<fileset dir="${signingDir}" includes="**/*.jnilib" erroronmissingdir="false" />
+													<sequential>
+														<echo level="info" message="Mac-sign @{jnilibFileAbsolute}" />
+														<local name="jnilibFile" />
+														<property name="jnilibFile" value="@{jnilibFileAbsolute}" relative="true" basedir="${signingDir}" />
+														<move file="@{jnilibFileAbsolute}" tofile="@{jnilibFileAbsolute}-tosign" />
+														<exec executable="curl" dir="${signingDir}" failonerror="true">
+															<arg value="-o" />
+															<arg value="${jnilibFile}" />
+															<arg value="-F" />
+															<arg value="file=@${jnilibFile}-tosign" />
+															<arg value="https://cbi.eclipse.org/macos/codesign/sign" />
+														</exec>
+														<exec executable="jar" dir="${signingDir}" failonerror="true">
+															<arg value="--update" />
+															<arg value="--file=@{jarFile}" />
+															<arg value="${jnilibFile}" />
+														</exec>
+													</sequential>
+												</for>
+											</sequential>
+										</for>
+									</target>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
This PR has the goal to resolve issue #591 by implementing for the m2e build the steps that are performed in Orbit to sign Mac jnilibs for the m2e build, according to https://github.com/eclipse-m2e/m2e-core/issues/591#issuecomment-1050419195.

@jonahgraham, @laeubi lets see if this works.
