### PR TITLE
[Maven-Runtime] simplify source bundle preparation

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -124,28 +124,10 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>fetch-flat-dependency-sources</id> <!-- These are used to build source-plugins -->
-						<goals>
-							<goal>unpack-dependencies</goal>
-						</goals>
-						<phase>process-resources</phase>
-						<configuration>
-							<outputDirectory>${project.build.directory}/${dependency.sources.folder}</outputDirectory>
-							<classifier>sources</classifier>
-							<useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>move-java-files-to-source-bundle-root</id>
+						<id>unzip-sources-and-move-java-files-to-source-bundle-root</id>
 						<goals>
 							<goal>run</goal>
 						</goals>
@@ -153,20 +135,18 @@
 						<configuration>
 							<target>
 								<taskdef resource="net/sf/antcontrib/antlib.xml" />
-								<for param="javaFile">
-									<!--Ant-contrib tasks already defined in calling script -->
-									<dirset dir="${project.build.directory}/${dependency.sources.folder}" erroronmissingdir="false">
-										<depth min="0" max="0" />
-									</dirset>
+								<for param="jarFile">
+									<fileset dir="${project.basedir}/${dependency.sources.folder}" includes="*.jar" erroronmissingdir="false" />
 									<sequential>
 										<local name="dirName" />
-										<basename property="dirName" file="@{javaFile}" />
-										<move todir="${project.build.directory}/${dependency.sources.folder}">
-											<fileset dir="${project.build.directory}/${dependency.sources.folder}/${dirName}">
-												<include name="**/*.java" />
-											</fileset>
-										</move>
-										<!-- Delete now empty directories -->
+										<basename property="dirName" file="@{jarFile}" suffix=".jar" />
+										<unzip src="@{jarFile}" dest="${project.build.directory}/${dependency.sources.folder}">
+											<patternset includes="**/*.java" />
+										</unzip>
+										<unzip src="@{jarFile}" dest="${project.build.directory}/${dependency.sources.folder}/${dirName}-jar">
+											<patternset excludes="**/*.java" />
+										</unzip>
+										<!-- Delete empty directories -->
 										<delete includeemptydirs="true">
 											<fileset dir="${project.build.directory}/${dependency.sources.folder}">
 												<and>
@@ -175,7 +155,6 @@
 												</and>
 											</fileset>
 										</delete>
-
 									</sequential>
 								</for>
 							</target>
@@ -241,7 +220,7 @@
 								</configuration>
 							</execution>
 							<execution>
-								<id>fetch-dependency-sources</id> <!-- These are used in the workspace -->
+								<id>fetch-dependency-sources</id>
 								<goals>
 									<goal>copy-dependencies</goal>
 								</goals>


### PR DESCRIPTION
This PR simplifies the (and maybe slightly speeds up) the creation of the sources for the Maven-runtime-components.
Furthermore it simplifies the resolution of issue #591 by using the source-jars embedded into the corresponding bundle as source instead of fetching them again from the Maven-repo, which is already used in #593 .