### PR TITLE
Fix maven-runtime build qualifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
 						<phase>verify</phase>
 						<configuration>
 							<baselines>
-								<baseline>https://download.eclipse.org/technology/m2e/releases/latest/</baseline>
+								<baseline>https://download.eclipse.org/technology/m2e/releases/1.20.0/</baseline>
 							</baselines>
 							<comparator>zip</comparator>
 						</configuration>


### PR DESCRIPTION
At the moment the master build fails because the latest m2e-release 1.20.1 has a more recent build-quailifier for the `org.eclipse.m2e.maven.runtime` project than the current master (the changes were backported).
Merging the 1.20.x branch into the master makes the changes visible for the build-qualifier computation.

Alternatively a forced build-quailifier update could be done, but this would then also require a micro-version update (without an actual change) or (temporarily) the version-regression baseline repo could be set from `m2e/releases/latest` to `m2e/releases/1.20.0`.

What do the others think?
When thinking about it again I tend to prefer the fixed baseline because it keeps the git-history more clean/clear/obvious.