### PR TITLE
[Maven-Runtime] Embed Maven 3.8.5

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -19,14 +19,14 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-	<version>1.18.3-SNAPSHOT</version>
+	<version>1.18.4-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>M2E Embedded Maven Runtime (includes Incubating components)</name>
 
 	<properties>
 		<!-- maven core version -->
-		<maven-core.version>3.8.4</maven-core.version>
+		<maven-core.version>3.8.5</maven-core.version>
 		<!-- NOTE: When maven-core.version changes, this may impact the versions of the maven-resolver-*
 			jars that export the org.eclipse.aether.* packages in the org.eclipse.m2e.maven.runtime
 			bundle. So make sure the following variable has the value of the maven-resolver-* jars

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
 						<phase>verify</phase>
 						<configuration>
 							<baselines>
-								<baseline>https://download.eclipse.org/technology/m2e/releases/1.20.0/</baseline>
+								<baseline>https://download.eclipse.org/technology/m2e/releases/latest/</baseline>
 							</baselines>
 							<comparator>zip</comparator>
 						</configuration>


### PR DESCRIPTION
This embeds Maven 3.8.5.

At the moment the staged version of the mentioned released is used. As soon the final release is performed this PR has to be updated accordingly.