### PR TITLE
Force usage of newer snapshot of LemMinX-Maven

### DIFF
--- a/org.eclipse.m2e.editor.lemminx/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.editor.lemminx/forceQualifierUpdate.txt
@@ -1,3 +1,3 @@
  Edit this file to force an update to newer snapshot of lemminx-maven,
  otherwise the Git timestamp qualifier	+ Baseline replacement will ignore the change:
-Last update: 2022.01.21 ~21h10 (France)
+Last update: 2022.03.07 ~15h00 (France)


### PR DESCRIPTION
Fixes an issue regarding compatibility with Maven 3.8.5