### PR TITLE
[RelEng] Set up automatic license check

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,0 +1,31 @@
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  push:
+    branches: 
+      - 'master'
+      - 'm2e-*'
+  pull_request:
+    branches: 
+     - 'master'
+     - 'm2e-*'
+
+jobs:
+  check-licenses:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - run: mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -Dtycho.mode=maven -Pgenerate-osgi-metadata
+
+    - name: Check license vetting status
+      run: mvn -U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,10 @@
 			<id>cbi-releases</id>
 			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
 		</pluginRepository>
+		<pluginRepository>
+			<id>dash-licenses-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+		</pluginRepository>
 	</pluginRepositories>
 
 	<profiles>


### PR DESCRIPTION
This PR adds a GH workflow to automatically check the license status of all m2e (transitive) dependencies.
It is heavily inspired from [Tycho's workflows](https://github.com/eclipse/tycho/tree/master/.github/workflows) and the one of the eclipse.releng.aggregator.

What I would like to do additionally with this workflow is to add the possibility to re-trigger the license-check and to request reviews just from posting a corresponding comment (a.t.m it is `/check-licenses` respectively `/check-licenses-request-review`.
I don't want to file a review-request on every PR with new dependencies to let a committer decide if it is wanted (otherwise it could be abused by externals).

The only think left is a Token for the EFN Gitlab that is placed in this GH repositories secret store.
@mickaelistria, @laeubi, @akurtakov Do you think that would be possible?