### PR TITLE
Support contribution of Eclipse features via Maven repositories.

### DIFF
--- a/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde;singleton:=true
-Bundle-Version: 1.20.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
@@ -17,5 +17,6 @@ Bundle-Activator: org.eclipse.m2e.pde.Activator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.codec.digest;version="1.14.0",
  org.apache.commons.io;version="2.6.0",
- org.apache.commons.io.output;version="2.8.0"
+ org.apache.commons.io.output;version="2.8.0",
+ org.slf4j
 Bundle-Vendor: Eclipse.org - m2e


### PR DESCRIPTION
Convert Maven artifacts containing a feature.xml into an Eclipse feature, rather than an OSGi bundle, similar to pom-derived features. 

Supplement to eclipse/tycho#882

Note:
For some reason, I'm getting a NPE when selecting the feature in the "Open Plug-in Artifact" menu. I don't think it's directly related to this addition, as the same problem occurs for pom-derived features.
I think the problem is that the menu tries to read the location of the feature.xml file via IFeatureModel#getInstallLocation. Given that null values are allowed, I don't think it's m2e related but rather a JFace bug. Does anyone have further insights into this?
[Stacktrace.txt](https://github.com/eclipse-m2e/m2e-core/files/8481469/Stacktrace.txt)