### PR TITLE
Update m2e-core-tests submodule and m2e.core/.project

### DIFF
--- a/org.eclipse.m2e.core/.project
+++ b/org.eclipse.m2e.core/.project
@@ -21,12 +21,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.ds.core.builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.pde.ds.core.builder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>


### PR DESCRIPTION
Something in my m2e workspace constantly changes the order of the build commands in `m2e.core/.project` since it contains the `org.eclipse.pde.ds.core.builder`. I hope the pde.ds builder is consistently sorted before the m2e-builder and they wont circle forever. 
Does anybody else observed this too?