### PR TITLE
[Build] Read M2E_VERSION directly from m2e.sdk/feature.xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,8 +46,17 @@ pipeline {
 								mkdir -p ${1}"
 							scp -r org.eclipse.m2e.site/target/repository/* genie.m2e@projects-storage.eclipse.org:${1}
 						}
-						M2E_VERSION=$(<"org.eclipse.m2e.sdk.feature/target/m2e.version")
-						echo M2E_VERSION=$M2E_VERSION
+						# Read M2E branding version
+						regex='<feature id="org\.eclipse\.m2e\.sdk\.feature" version="([0-9]\.[0-9]\.[0-9])\.qualifier" '
+						content=$(echo $(<"org.eclipse.m2e.sdk.feature/feature.xml")) # replaces consecutive newline and tabs by single space
+						if [[ $content  =~ $regex ]]
+						then
+							M2E_VERSION="${BASH_REMATCH[1]}"
+							echo M2E_VERSION=$M2E_VERSION
+						else
+							echo Failed to read M2E_VERSION. Abort deployment.
+							exit 1
+						fi
 
 						deployM2ERepository /home/data/httpd/download.eclipse.org/technology/m2e/snapshots/${M2E_VERSION}
 						deployM2ERepository /home/data/httpd/download.eclipse.org/technology/m2e/snapshots/latest

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -119,6 +119,24 @@
 						</additionalFileSets>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>3.0.0</version>
+					<dependencies>
+						<dependency>
+							<groupId>ant-contrib</groupId>
+							<artifactId>ant-contrib</artifactId>
+							<version>1.0b3</version>
+							<exclusions>
+								<exclusion>
+									<groupId>ant</groupId>
+									<artifactId>ant</artifactId>
+								</exclusion>
+							</exclusions>
+						</dependency>
+					</dependencies>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.m2e.sdk.feature"
-      label="%featureName"
       version="2.0.0.qualifier"
+      label="%featureName"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -326,24 +326,6 @@
 						<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-antrun-plugin</artifactId>
-					<version>3.0.0</version>
-					<dependencies>
-						<dependency>
-							<groupId>ant-contrib</groupId>
-							<artifactId>ant-contrib</artifactId>
-							<version>1.0b3</version>
-							<exclusions>
-								<exclusion>
-									<groupId>ant</groupId>
-									<artifactId>ant</artifactId>
-								</exclusion>
-							</exclusions>
-						</dependency>
-					</dependencies>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -373,31 +355,6 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>write-m2e.version-file</id>
-								<phase>initialize</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<target> <!-- Write project.versions file read during build for the m2e-SDK feature -->
-										<taskdef resource="net/sf/antcontrib/antlib.xml" />
-										<if>
-											<equals arg1="${project.artifactId}" arg2="org.eclipse.m2e.sdk.feature" /> <!-- version-file file only required for m2e.sdk feature -->
-											<then>
-												<echo message="Write '${unqualifiedVersion}' to ${project.build.directory}/m2e.version" level="info" />
-												<echo message="${unqualifiedVersion}" file="${project.build.directory}/m2e.version" level="info" />
-											</then>
-										</if>
-									</target>
-								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
This avoids the need to create an m2e.version file using the `maven-antrun-plugin`.

The regex pattern is intentionally designed to be fragile, because I would rather fail the deployment than pushing the repo to some unintended path.