### PR TITLE
[Build] Fix escaping of M2E_VERSION regex pattern in Jenkinsfile 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
 							scp -r org.eclipse.m2e.site/target/repository/* genie.m2e@projects-storage.eclipse.org:${1}
 						}
 						# Read M2E branding version
-						regex='<feature id="org\.eclipse\.m2e\.sdk\.feature" version="([0-9]\.[0-9]\.[0-9])\.qualifier" '
+						regex='<feature id="org\\.eclipse\\.m2e\\.sdk\\.feature" version="([0-9]\\.[0-9]\\.[0-9])\\.qualifier" '
 						content=$(echo $(<"org.eclipse.m2e.sdk.feature/feature.xml")) # replaces consecutive newline and tabs by single space
 						if [[ $content  =~ $regex ]]
 						then


### PR DESCRIPTION
Second attempt to fix failure on master after #641.

But this time the PR is created from a branch in the m2e-repo.
I looks like for PR from branches from this repo Jenkins takes the Jenkinsfile from the PR and not the latest from the master.
This allows to properly test the Jenkinsfile.