### PR TITLE
[Maven-Runtime] migrate to biz.aQute.bnd:bnd-maven-plugin

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-	<version>1.18.1-SNAPSHOT</version>
+	<version>1.18.2-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>M2E Maven Archetype Common</name>
@@ -90,17 +90,18 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
 					<configuration>
-						<instructions>
-							<_exportcontents>
-								META-INF.plexus;-noimport:=true;x-internal:=true,
-								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;x-internal:=true,
-								org.codehaus.plexus.velocity;provider=m2e;mandatory:=provider;x-internal:=true,
-							</_exportcontents>
-							<Require-Bundle>org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)"</Require-Bundle>
-						</instructions>
+						<bnd>
+						<![CDATA[
+							-exportcontents: \
+								META-INF.plexus;-noimport:=true;x-internal:=true,\
+								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;x-internal:=true,\
+								org.codehaus.plexus.velocity;provider=m2e;mandatory:=provider;x-internal:=true
+							Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)"
+						]]>
+						</bnd>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -134,33 +134,32 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
 					<configuration>
-						<instructions>
-							<_exportcontents>
-								META-INF.plexus;-noimport:=true;x-internal:=true,
-								META-INF.sisu;-noimport:=true;x-internal:=true,
-								org.apache.maven.*;provider=m2e;mandatory:=provider,
-								org.codehaus.plexus.*;provider=m2e;mandatory:=provider,
-								org.sonatype.plexus.*;provider=m2e;mandatory:=provider,
-								org.eclipse.aether.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version},
-								com.google.inject.*;provider=m2e;mandatory:=provider,
+						<bnd>
+						<![CDATA[
+							-exportcontents: \
+								META-INF.plexus;-noimport:=true;x-internal:=true,\
+								META-INF.sisu;-noimport:=true;x-internal:=true,\
+								org.apache.maven.*;provider=m2e;mandatory:=provider,\
+								org.codehaus.plexus.*;provider=m2e;mandatory:=provider,\
+								org.sonatype.plexus.*;provider=m2e;mandatory:=provider,\
+								org.eclipse.aether.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version},\
+								com.google.inject.*;provider=m2e;mandatory:=provider,\
 								io.takari.*;provider=m2e;mandatory:=provider
-							</_exportcontents>
-							<Import-Package>
-								org.slf4j;resolution:=optional;version="[1.6.2,2.0.0)",
-								org.slf4j.spi;resolution:=optional;version="[1.6.2,2.0.0)",
-								org.slf4j.helpers;resolution:=optional;version="[1.6.2,2.0.0)",
+							Import-Package: \
+								org.slf4j;resolution:=optional;version="[1.6.2,2.0.0)",\
+								org.slf4j.spi;resolution:=optional;version="[1.6.2,2.0.0)",\
+								org.slf4j.helpers;resolution:=optional;version="[1.6.2,2.0.0)",\
 								javax.inject;version="1.0.0"
-							</Import-Package>
-							<Require-Bundle>
-								org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="[1.18.0,1.19.0)",
+							Require-Bundle: \
+								org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="[1.18.0,1.19.0)",\
 								com.google.guava
-							</Require-Bundle>
-							<!-- All direct dependencies specified as Require-Bundle or Import-package are added to the classpath of a launched
-								Maven-Build-JVM. See MavenEmbeddedRuntime for details. -->
-						</instructions>
+						]]>
+						<!-- All direct dependencies specified as Require-Bundle or Import-package are added to the classpath of a launched 
+							Maven-Build-JVM. See MavenEmbeddedRuntime for details. -->
+						</bnd>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -51,33 +51,28 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
-					<version>5.1.4</version>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>6.2.0</version>
 					<configuration>
-						<supportedProjectTypes>eclipse-plugin</supportedProjectTypes>
+						<packagingTypes>eclipse-plugin</packagingTypes>
 						<!-- PDE does not honor custom manifest location -->
-						<manifestLocation>META-INF</manifestLocation>
-						<instructions>
-							<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
-							<Embed-Transitive>true</Embed-Transitive>
-							<Embed-Directory>${dependency.jars.folder}</Embed-Directory>
+						<manifestPath>META-INF/MANIFEST.MF</manifestPath>
+						<bnd>
+						<![CDATA[
+							-includeresource: jars/=jars/;recursive:=false;lib:=true
 
-							<_failok>true</_failok>
-							<_nouses>true</_nouses>
-							<_nodefaultversion>true</_nodefaultversion>
-							<_snapshot>qualifier</_snapshot>
+							-failok: true
+							-nouses: true
+							-nodefaultversion: true
+							-noextraheaders
+							-snapshot: qualifier
 
-							<Bundle-SymbolicName>${project.artifactId};singleton:=false</Bundle-SymbolicName>
-							<Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
-							<Bundle-Name>${project.name}</Bundle-Name>
-							<Bundle-Vendor>Eclipse.org - m2e</Bundle-Vendor>
-							<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
-							<Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
-
-							<Import-Package>!*</Import-Package>
-							<Eclipse-BundleShape>dir</Eclipse-BundleShape>
-						</instructions>
+							Import-Package: !*
+							Automatic-Module-Name: ${bsn}
+							Eclipse-BundleShape: dir
+						]]>
+						</bnd>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -271,13 +266,14 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.apache.felix</groupId>
-						<artifactId>maven-bundle-plugin</artifactId>
+						<!-- https://github.com/bndtools/bnd/blob/master/maven/bnd-maven-plugin/README.md -->
+						<groupId>biz.aQute.bnd</groupId>
+						<artifactId>bnd-maven-plugin</artifactId>
 						<executions>
 							<execution>
 								<id>generate-manifest</id>
 								<goals>
-									<goal>manifest</goal>
+									<goal>bnd-process</goal>
 								</goals>
 								<phase>generate-sources</phase>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 	</properties>
 
 	<organization>
-		<name>Eclipse Foundation</name>
+		<name>Eclipse.org - m2e</name>
 		<url>https://eclipse.org/m2e</url>
 	</organization>
 	<licenses>


### PR DESCRIPTION
This PR migrates the generation of the MANIFEST.MF for the Maven-runtime components from Apache Felix' `maven-bundle-plugin `to the `biz.aQute.bnd:bnd-maven-plugin` as suggested by Tom Watson a while ago (about a month).

The `bnd-maven-plugin` is seen as a replacement for the `maven-bundle-plugin` and seems to be more actively maintained.
At Felix no committer reacted to any of my PRs (https://github.com/apache/felix-dev/pull/123 and https://github.com/apache/felix-dev/pull/124) yet that were already created by the end of last year even tough @laeubi asked them via mail to look at them a month ago and one committer said he would do that.

With that being said and since the maven-bundle-plugin has some flaws that make it problematic to use with M2E in the IDE (which I attempted to fix with the mentioned PR), I think we should move on. M2E supports both plug-ins in the IDE and the way dependencies are embedded with the `bnd-maven-plugin` could simplify the solution for the problem that we have in PR #466 when it comes to the question how the content of embedded jars is exported  to other Plug-ins on JDT's classpath to allow successful compilation in the IDE.