### PR TITLE
Import aQute.bnd packages and remove bnd.lib from pde-feature

### DIFF
--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -8,14 +8,15 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.pde.ui;bundle-version="3.12.0",
  org.eclipse.equinox.frameworkadmin;bundle-version="2.1.400",
- biz.aQute.bndlib;bundle-version="5.1.2",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
  org.eclipse.m2e.core,
  org.eclipse.core.resources
 Export-Package: org.eclipse.m2e.pde.target;x-friends:="org.eclipse.m2e.pde.ui"
 Bundle-Activator: org.eclipse.m2e.pde.target.Activator
 Bundle-ActivationPolicy: lazy
-Import-Package: org.apache.commons.codec.digest;version="1.14.0",
+Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)",
+ aQute.bnd.version;version="[2.2.0,3.0.0)",
+ org.apache.commons.codec.digest;version="1.14.0",
  org.apache.commons.io;version="2.6.0",
  org.apache.commons.io.output;version="2.8.0",
  org.slf4j

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.jface,
  org.eclipse.pde.ui;bundle-version="3.12.0",
  org.eclipse.equinox.frameworkadmin;bundle-version="2.1.400",
- biz.aQute.bndlib;bundle-version="5.1.2",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
  org.eclipse.m2e.core,
  org.eclipse.m2e.pde.target,
@@ -22,3 +21,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.pde.ui.Activator
 Bundle-Vendor: Eclipse.org - m2e
+Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)"


### PR DESCRIPTION
We should use Import-Package to reference the bnd.lib packages and not require the bundle. It was suggested explicitly in #445 but it is OSGi best-practice in general.

Furthermore the `bnd.lib` bundles should not be included into the `m2e.pde-feature` to simplify updates that do not require to touch that feature. P2 had the same problem with sat4j and PDE with ASM. And it is P2's job to collect dependencies not ours.
We only have to make sure the bnd.lib dependencies are contained in the m2e repo because nobody else contributes it to SimRel otherwise.
But this  is better done in the m2e.repository/category.xml, than in the feature (which I assume was the reason to include it). The category.xml is not bound to a specific version (in contrast to the feature), so this shift is a simplification.