### PR TITLE
Activate BND instruction 'noextraheaders'

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -65,7 +65,7 @@
 							-failok: true
 							-nouses: true
 							-nodefaultversion: true
-							-noextraheaders
+							-noextraheaders: true
 							-snapshot: qualifier
 
 							Import-Package: !*


### PR DESCRIPTION
This removes the following headers from the generated Manifest, which
are not functional or contain a build-timestamp which leads not of
interest changes when one compares the manifests:
- Bnd-LastModified
- Created-By
- Tool

The setting was not correctly configured and therefore did not work
before although it was intended.