### PR TITLE
Remove deprecated unused APIs in org.eclipse.m2e.core

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -110,12 +110,6 @@ public interface IMaven {
   MavenProject readProject(File pomFile, IProgressMonitor monitor) throws CoreException;
 
   /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #readMavenProject(File, IProgressMonitor)} instead.
-   */
-  @Deprecated MavenExecutionResult readProject(MavenExecutionRequest request, IProgressMonitor monitor) throws CoreException;
-
-  /**
    * @since 1.4
    * @see {@link #readMavenProjects(File, ProjectBuildingRequest)} to group requests and improve performance (RAM and
    *      CPU)
@@ -139,16 +133,6 @@ public interface IMaven {
 
   /**
    * Returns MavenProject parent project or null if no such project.
-   *
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #resolveParentProject(MavenProject, IProgressMonitor)} instead.
-   * @TODO Currently returns null in case of resolution error, consider if it should throw CoreException instead
-   */
-  @Deprecated MavenProject resolveParentProject(MavenExecutionRequest request, MavenProject project, IProgressMonitor monitor)
-      throws CoreException;
-
-  /**
-   * Returns MavenProject parent project or null if no such project.
    * 
    * @param project
    * @param monitor
@@ -166,11 +150,6 @@ public interface IMaven {
    * @deprecated this method does not properly join {@link IMavenExecutionContext}
    */
   @Deprecated MavenExecutionResult execute(MavenExecutionRequest request, IProgressMonitor monitor);
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}
-   */
-  @Deprecated MavenSession createSession(MavenExecutionRequest request, MavenProject project);
 
   /**
    * @deprecated this method does not properly join {@link IMavenExecutionContext}, use

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
@@ -175,29 +175,6 @@ public class MavenModelManager {
     }
   }
 
-  /**
-   * @deprecated use {@link #readDependencyTree(IMavenProjectFacade, MavenProject, String, IProgressMonitor)}, which
-   *             supports workspace dependency resolution
-   */
-  @Deprecated
-  public synchronized DependencyNode readDependencyTree(IFile file, String classpath, IProgressMonitor monitor)
-      throws CoreException {
-    monitor.setTaskName(Messages.MavenModelManager_monitor_reading);
-    MavenProject mavenProject = readMavenProject(file, monitor);
-
-    return readDependencyTree(mavenProject, classpath, monitor);
-  }
-
-  /**
-   * @deprecated use {@link #readDependencyTree(IMavenProjectFacade, MavenProject, String, IProgressMonitor)}, which
-   *             supports workspace dependency resolution
-   */
-  @Deprecated
-  public DependencyNode readDependencyTree(MavenProject mavenProject, String classpath, IProgressMonitor monitor)
-      throws CoreException {
-    return readDependencyTree(null, mavenProject, classpath, monitor);
-  }
-
   public synchronized DependencyNode readDependencyTree(IMavenProjectFacade context, final MavenProject mavenProject,
       final String scope, IProgressMonitor monitor) throws CoreException {
     monitor.setTaskName(Messages.MavenModelManager_monitor_building);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
@@ -30,7 +30,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 
 import org.apache.maven.model.Plugin;
@@ -40,19 +39,6 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 
 
 public class M2EUtils {
-
-  /**
-   * Helper method which creates a folder and, recursively, all its parent folders.
-   *
-   * @param folder The folder to create.
-   * @param derived true if folder should be marked as derived
-   * @throws CoreException if creating the given <code>folder</code> or any of its parents fails.
-   * @deprecated use {@link #createFolder(IFolder, boolean, IProgressMonitor)}
-   */
-  @Deprecated
-  public static void createFolder(IFolder folder, boolean derived) throws CoreException {
-    createFolder(folder, derived, new NullProgressMonitor());
-  }
 
   /**
    * Helper method which creates a folder and, recursively, all its parent folders.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -293,18 +293,6 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     return result;
   }
 
-  @Override
-  @SuppressWarnings("deprecation")
-  public MavenSession createSession(MavenExecutionRequest request, MavenProject project) {
-    RepositorySystemSession repoSession = createRepositorySession(request);
-    MavenExecutionResult result = new DefaultMavenExecutionResult();
-    MavenSession mavenSession = new MavenSession(plexus, repoSession, request, result);
-    if(project != null) {
-      mavenSession.setProjects(Collections.singletonList(project));
-    }
-    return mavenSession;
-  }
-
   /*package*/FilterRepositorySystemSession createRepositorySession(MavenExecutionRequest request) {
     try {
       DefaultRepositorySystemSession session = (DefaultRepositorySystemSession) ((DefaultMaven) lookup(Maven.class))
@@ -597,23 +585,6 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public MavenExecutionResult readProject(MavenExecutionRequest request, IProgressMonitor monitor)
-      throws CoreException {
-    final RepositorySystemSession repositorySession = createRepositorySession(request);
-    return readMavenProject(request.getPom(), repositorySession, request);
-  }
-
-  @Deprecated
-  /*package*/MavenExecutionResult readMavenProject(File pomFile, RepositorySystemSession repositorySession,
-      MavenExecutionRequest request) throws CoreException {
-    ProjectBuildingRequest configuration = request.getProjectBuildingRequest();
-    configuration.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
-    configuration.setRepositorySession(repositorySession);
-    return readMavenProject(pomFile, configuration);
-  }
-
-  @Override
   public MavenExecutionResult readMavenProject(File pomFile, ProjectBuildingRequest configuration)
       throws CoreException {
     long start = System.currentTimeMillis();
@@ -683,16 +654,6 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
   @Override
   public void detachFromSession(MavenProject project) throws CoreException {
     project.getProjectBuildingRequest().setRepositorySession(lookup(ContextRepositorySystemSession.class));
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  @Deprecated
-  public MavenProject resolveParentProject(MavenExecutionRequest request, MavenProject child, IProgressMonitor monitor)
-      throws CoreException {
-    final ProjectBuildingRequest configuration = request.getProjectBuildingRequest();
-    final RepositorySystemSession repositorySession = createRepositorySession(request);
-    return resolveParentProject(repositorySession, child, configuration);
   }
 
   /*package*/MavenProject resolveParentProject(RepositorySystemSession repositorySession, MavenProject child,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/AbstractMavenRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/AbstractMavenRuntime.java
@@ -69,11 +69,6 @@ public abstract class AbstractMavenRuntime implements MavenRuntime {
 
   private List<ClasspathEntry> extensions;
 
-  @Deprecated
-  protected AbstractMavenRuntime() {
-    this.name = null;
-  }
-
   protected AbstractMavenRuntime(String name) {
     this.name = name;
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
@@ -56,6 +56,7 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
   private transient String version;
 
   public MavenExternalRuntime(String location) {
+    super(MavenRuntimeManagerImpl.EXTERNAL);
     this.location = location;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/NotCoveredMojoExecution.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/NotCoveredMojoExecution.java
@@ -26,14 +26,6 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 public class NotCoveredMojoExecution extends MojoExecutionProblemInfo {
 
   /**
-   * @deprecated use {@link #NotCoveredMojoExecution(MojoExecutionKey, int, SourceLocation)}
-   */
-  @Deprecated
-  public NotCoveredMojoExecution(MojoExecutionKey mojoExecutionKey, SourceLocation markerLocation) {
-    this(mojoExecutionKey, IMarker.SEVERITY_ERROR, markerLocation);
-  }
-
-  /**
    * @since 1.5
    */
   public NotCoveredMojoExecution(MojoExecutionKey mojoExecutionKey, int severity, SourceLocation markerLocation) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
@@ -98,22 +98,6 @@ public interface MavenPreferenceConstants {
   String P_DEFAULT_POM_EDITOR_PAGE = "eclipse.m2.defaultPomEditorPage"; //$NON-NLS-1$
 
   /**
-   * boolean
-   *
-   * @deprecated Use {@link MavenPreferenceConstants#P_DUP_OF_PARENT_GROUPID_PB} instead
-   */
-  @Deprecated String P_DISABLE_GROUPID_DUP_OF_PARENT_WARNING = PREFIX
-      + ".disableGroupIdDuplicateOfParentWarning"; //$NON-NLS-1$
-
-  /**
-   * boolean
-   *
-   * @deprecated Use {@link MavenPreferenceConstants#P_DISABLE_VERSION_DUP_OF_PARENT_WARNING} instead
-   */
-  @Deprecated String P_DISABLE_VERSION_DUP_OF_PARENT_WARNING = PREFIX
-      + ".disableVersionDuplicateOfParentWarning"; //$NON-NLS-1$
-
-  /**
    * @since 1.5
    **/
   String PROBLEM_PREFIX = PREFIX + "problem.";

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/conversion/ProjectConversionManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/conversion/ProjectConversionManager.java
@@ -151,12 +151,6 @@ public class ProjectConversionManager implements IProjectConversionManager {
   }
 
   @Override
-  @Deprecated
-  public List<AbstractProjectConversionParticipant> getConversionParticipants(IProject project) throws CoreException {
-    return getConversionParticipants(project, null);
-  }
-
-  @Override
   public List<AbstractProjectConversionParticipant> getConversionParticipants(IProject project, String packaging)
       throws CoreException {
     List<AbstractProjectConversionParticipant> allParticipants = lookupConversionParticipants(project);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-import org.apache.maven.execution.MavenExecutionRequest;
-
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
@@ -47,16 +45,6 @@ public abstract class AbstractMavenDependencyResolver {
 
   protected ProjectRegistryManager getManager() {
     return manager;
-  }
-
-  /**
-   * @deprecated implement {@link #resolveProjectDependencies(IMavenProjectFacade, Set, Set, IProgressMonitor)} instead
-   */
-  @Deprecated
-  public void resolveProjectDependencies(IMavenProjectFacade facade, MavenExecutionRequest mavenRequest,
-      Set<Capability> capabilities, Set<RequiredCapability> requirements, IProgressMonitor monitor)
-      throws CoreException {
-    resolveProjectDependencies(facade, capabilities, requirements, monitor);
   }
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenProjectInfo.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenProjectInfo.java
@@ -83,18 +83,6 @@ public class MavenProjectInfo {
     this.pomFile = pomFile;
   }
 
-  /** @deprecated use set/get BasedirRename */
-  @Deprecated
-  public void setNeedsRename(boolean needsRename) {
-    setBasedirRename(needsRename ? RENAME_REQUIRED : RENAME_NO);
-  }
-
-  /** @deprecated use set/get BasedirRenamePolicy */
-  @Deprecated
-  public boolean isNeedsRename() {
-    return getBasedirRename() == RENAME_REQUIRED;
-  }
-
   /**
    * See {@link #RENAME_NO}, {@link #RENAME_REQUIRED}
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
@@ -50,14 +50,6 @@ public class ResolverConfiguration implements Serializable {
     return this.resolveWorkspaceProjects;
   }
 
-  /**
-   * @deprecated use {@link #getSelectedProfiles()} instead.
-   */
-  @Deprecated
-  public String getActiveProfiles() {
-    return getSelectedProfiles();
-  }
-
   public String getSelectedProfiles() {
     return this.selectedProfiles;
   }
@@ -72,14 +64,6 @@ public class ResolverConfiguration implements Serializable {
 
   public void setResolveWorkspaceProjects(boolean resolveWorkspaceProjects) {
     this.resolveWorkspaceProjects = resolveWorkspaceProjects;
-  }
-
-  /**
-   * @deprecated use {@link #setSelectedProfiles(String)} instead.
-   */
-  @Deprecated
-  public void setActiveProfiles(String activeProfiles) {
-    setSelectedProfiles(activeProfiles);
   }
 
   public void setSelectedProfiles(String profiles) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
@@ -35,9 +35,6 @@ import org.eclipse.core.runtime.Status;
 
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.ConfigurationContainer;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -45,7 +42,6 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
-import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
@@ -180,20 +176,6 @@ public abstract class AbstractProjectConfigurator implements IExecutableExtensio
       description.setNatureIds(newNatures);
       project.setDescription(description, updateFlags, monitor);
     }
-  }
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String)} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("deprecation")
-  protected <T> T getParameterValue(String parameter, Class<T> asType, MavenSession session, MojoExecution mojoExecution)
-      throws CoreException {
-    PluginExecution execution = new PluginExecution();
-    execution.setConfiguration(mojoExecution.getConfiguration());
-    return maven.getMojoParameterValue(parameter, asType, session, mojoExecution.getPlugin(), execution,
-        mojoExecution.getGoal());
   }
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/IProjectConversionManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/IProjectConversionManager.java
@@ -36,15 +36,6 @@ public interface IProjectConversionManager {
   void convert(IProject project, Model model, IProgressMonitor monitor) throws CoreException;
 
   /**
-   * Returns an unmodifiable list of all {@link AbstractProjectConversionParticipant}s applying to the given project.
-   * Packaging restrictions on {@link AbstractProjectConversionParticipant}s will be ignored.
-   *
-   * @deprecated since 1.3 Use {@link #getConversionParticipants(IProject, String)} instead.
-   */
-  @Deprecated
-  List<AbstractProjectConversionParticipant> getConversionParticipants(IProject project) throws CoreException;
-
-  /**
    * Returns an unmodifiable list of all {@link AbstractProjectConversionParticipant}s applying to the given project and
    * packaging.
    *


### PR DESCRIPTION
This PRs applies the simple removals of API in o.e.m2e.core, those API that is not used.