### PR TITLE
Remove extensions referring to the removed UpdateMavenProjectAction

### DIFF
--- a/org.eclipse.m2e.core.ui/plugin.properties
+++ b/org.eclipse.m2e.core.ui/plugin.properties
@@ -30,7 +30,6 @@ m2.popup.project.update-sources.label=Update Source Folders
 m2.popup.ModuleProjectWizardAction=New &Maven Module Project
 m2.popup.AddPluginAction=Add &Plugin
 m2.popup.AddDependencyAction=Add &Dependency
-m2.popup.UpdateMavenProjectAction=&Update Project...
 m2.popup.OpenUrlAction.openCiPage=Open Continuous Integration
 m2.popup.OpenUrlAction.openScmPage=Open Source Control
 m2.popup.OpenUrlAction.openIssuesPage=Open Issue Tracker

--- a/org.eclipse.m2e.core.ui/plugin.xml
+++ b/org.eclipse.m2e.core.ui/plugin.xml
@@ -123,24 +123,6 @@
            </and>
          </visibility>
       </objectContribution>
-      <objectContribution id="org.eclipse.m2e.updateConfigurationAction"
-                          objectClass="org.eclipse.core.resources.IProject"
-                          adaptable="true">
-         <action id="org.eclipse.m2e.updateProjectAction"
-         		 definitionId="org.eclipse.m2e.core.ui.command.updateProject"
-                 class="org.eclipse.m2e.core.ui.internal.actions.UpdateMavenProjectAction"
-                 label="%m2.popup.UpdateMavenProjectAction"
-                 style="push"
-                 icon="icons/update_dependencies.png"
-                 menubarPath="org.eclipse.m2e.core.mavenMenu/update"
-                 enablesFor="+"/>
-         <visibility>
-           <and>
-             <objectState name="open" value="true"/>
-             <objectState name="nature" value="org.eclipse.m2e.core.maven2Nature"/>
-           </and>
-         </visibility>
-      </objectContribution>
 
       <objectContribution id="org.eclipse.m2e.disableAction"
                           objectClass="org.eclipse.core.resources.IProject"
@@ -216,22 +198,6 @@
             <objectState name="name" value="pom.xml"/>
          </visibility>
       </objectContribution>
-	  <objectContribution id="org.eclipse.m2e.core.fileMenu.updateProjectAction"
-                          objectClass="org.eclipse.core.resources.IFile"
-                          adaptable="true">
-         <action id="org.eclipse.m2e.updateProjectAction"
-                 class="org.eclipse.m2e.core.ui.internal.actions.UpdateMavenProjectAction"
-                 label="%m2.popup.UpdateMavenProjectAction"
-                 style="push"
-                 icon="icons/update_dependencies.png"
-                 menubarPath="org.eclipse.m2e.core.fileMenu/update"
-                 enablesFor="1"/>
-         <visibility>
-           <and>
-              <objectState name="name" value="pom.xml"/>
-           </and>
-         </visibility>
-      </objectContribution>
       <!-- MNGECLIPSE-2564 -for *not* maven project, add the Convert to Maven Project action -->
       <objectContribution id="org.eclipse.m2e.enableNatureAction"
                           objectClass="org.eclipse.core.resources.IProject"
@@ -274,18 +240,6 @@
          </menu>
       </objectContribution>
 
-      <objectContribution id="org.eclipse.m2e.workingSet.updateConfigurationAction"
-      	     adaptable="true"
-             objectClass="org.eclipse.ui.IWorkingSet">
-         <action id="org.eclipse.m2e.updateConfigurationAction"
-         		 definitionId="org.eclipse.m2e.core.ui.command.updateProject"
-                 class="org.eclipse.m2e.core.ui.internal.actions.UpdateMavenProjectAction"
-                 label="%m2.popup.UpdateMavenProjectAction"
-                 style="push"
-                 icon="icons/update_dependencies.png"
-                 menubarPath="org.eclipse.m2e.core.workingSetMenu/update"
-                 enablesFor="+"/>
-      </objectContribution>
 
       <objectContribution id="org.eclipse.m2e.core.openPomArtifact"
           objectClass="org.apache.maven.artifact.Artifact"


### PR DESCRIPTION
The class UpdateMavenProjectAction was deprecated and finally removed in PR #671.
But it was forgotten to remove the extensions referring that class were not removed in that process.