### PR TITLE
Ensure non-null IProgressMonitor in MavenExecutionContext execution

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/AbstractTransferListenerAdapter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/AbstractTransferListenerAdapter.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.osgi.util.NLS;
 
@@ -49,7 +48,7 @@ abstract class AbstractTransferListenerAdapter {
 
   protected AbstractTransferListenerAdapter(MavenImpl maven, IProgressMonitor monitor) {
     this.maven = maven;
-    this.monitor = monitor == null ? new NullProgressMonitor() : monitor;
+    this.monitor = IProgressMonitor.nullSafe(monitor);
   }
 
   protected void formatBytes(long n, StringBuilder sb) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -179,7 +179,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
         mavenSession.setCurrentProject(project);
         mavenSession.setProjects(Collections.singletonList(project));
       }
-      return callable.call(this, monitor);
+      return callable.call(this, IProgressMonitor.nullSafe(monitor));
     } finally {
       Thread.currentThread().setContextClassLoader(origTCCL);
       repositorySession.setTransferListener(origTransferListener);


### PR DESCRIPTION
This change ensure a non-null IProgressMonitor is passed to the ICallable even when any of the IMaven(-ExecutionContext).execute() methods is called with an null monitor argument.