### PR TITLE
Remove deprecated IMaven API

### DIFF
--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
@@ -363,8 +363,9 @@ public abstract class AbstractAptConfiguratorDelegate implements AptConfigurator
       MojoExecution mojoExecution) throws CoreException {
     PluginExecution execution = new PluginExecution();
     execution.setConfiguration(mojoExecution.getConfiguration());
-    return maven.getMojoParameterValue(parameter, asType, session, mojoExecution.getPlugin(), execution,
-        mojoExecution.getGoal());
+    MavenProject mavenProject = mavenFacade.getMavenProject();
+    return maven.getMojoParameterValue(mavenProject, parameter, asType, mojoExecution.getPlugin(), execution,
+        mojoExecution.getGoal(), null);
   }
 
 }

--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerBuildParticipant.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerBuildParticipant.java
@@ -25,6 +25,7 @@ import org.codehaus.plexus.util.Scanner;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
 
 import org.sonatype.plexus.build.incremental.BuildContext;
 
@@ -57,20 +58,18 @@ public class MavenCompilerBuildParticipant extends MojoExecutionBuildParticipant
     monitor.setTaskName("Executing " + mojoExecution.getArtifactId() + ":" + mojoExecution.getGoal());
 
     //TODO check delta / scan source for *.java
-
-    String compilerArgument = maven.getMojoParameterValue(getSession(), mojoExecution, "compilerArgument",
-        String.class);
+    IMavenProjectFacade mavenProjectFacade = getMavenProjectFacade();
+    MavenProject project = mavenProjectFacade.getMavenProject();
+    String compilerArgument = maven.getMojoParameterValue(project, mojoExecution, "compilerArgument", String.class,
+        null);
     boolean isAnnotationProcessingEnabled = (compilerArgument == null) || !compilerArgument.contains("-proc:none");
     if(isAnnotationProcessingEnabled) {
-      String proc = maven.getMojoParameterValue(getSession(), mojoExecution, PROC, String.class);
+      String proc = maven.getMojoParameterValue(project, mojoExecution, PROC, String.class, null);
       isAnnotationProcessingEnabled = !"none".equals(proc);
     }
     if(!isAnnotationProcessingEnabled) {
       return Collections.emptySet();
     }
-
-    IMavenProjectFacade mavenProjectFacade = getMavenProjectFacade();
-
     if(!buildContext.hasDelta(mavenProjectFacade.getPomFile())) {
 
       IPath[] sources = "compile".equals(mojoExecution.getGoal()) ? mavenProjectFacade.getCompileSourceLocations()
@@ -108,8 +107,8 @@ public class MavenCompilerBuildParticipant extends MojoExecutionBuildParticipant
     }
 
     // tell m2e builder to refresh generated files
-    File generated = maven.getMojoParameterValue(getSession(), getMojoExecution(),
-        MavenCompilerJdtAptDelegate.OUTPUT_DIRECTORY_PARAMETER, File.class);
+    File generated = maven.getMojoParameterValue(project, getMojoExecution(),
+        MavenCompilerJdtAptDelegate.OUTPUT_DIRECTORY_PARAMETER, File.class, null);
     if(generated != null) {
       buildContext.refresh(generated);
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/ParentGatherer.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/util/ParentGatherer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Sonatype, Inc.
+ * Copyright (c) 2010, 2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.M2EUtils;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
@@ -64,7 +65,7 @@ public class ParentGatherer {
         if(monitor1.isCanceled()) {
           return null;
         }
-        project = maven.resolveParentProject(project, monitor1);
+        project = ((MavenImpl) maven).resolveParentProject(project, monitor1);
         IFile resource = M2EUtils.getPomFile(project); // resource is null if parent is not coming from workspace
         IMavenProjectFacade facade = resource != null ? MavenPlugin.getMavenProjectRegistry().getProject(
             resource.getProject()) : null;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,9 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import org.apache.maven.artifact.Artifact;
@@ -41,7 +39,6 @@ import org.apache.maven.settings.Mirror;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsProblem;
-import org.apache.maven.wagon.events.TransferListener;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 
 
@@ -57,26 +54,9 @@ import org.apache.maven.wagon.proxy.ProxyInfo;
  */
 public interface IMaven {
 
-  /**
-   * Creates new Maven execution request. This method is not long running, but created execution request is configured
-   * to report progress to provided progress monitor. Monitor can be null.
-   *
-   * @deprecated see {@link IMavenExecutionContext}.
-   */
-  @Deprecated MavenExecutionRequest createExecutionRequest(IProgressMonitor monitor) throws CoreException;
-
   // POM Model read/write operations
 
   Model readModel(InputStream in) throws CoreException;
-
-  /**
-   * Using {@link File} representations in Eclipse workspaces is prone to errors, since remote filesystems must be
-   * cached via {@link IFileStore#toLocalFile}. Simple transformations via {@link IPath#toFile()} do not work for remote
-   * files.
-   *
-   * @deprecated use {@link #readModel(InputStream)} instead.
-   */
-  @Deprecated Model readModel(File pomFile) throws CoreException;
 
   void writeModel(Model model, OutputStream out) throws CoreException;
 
@@ -131,43 +111,12 @@ public interface IMaven {
    */
   void detachFromSession(MavenProject project) throws CoreException;
 
-  /**
-   * Returns MavenProject parent project or null if no such project.
-   * 
-   * @param project
-   * @param monitor
-   * @return
-   * @throws CoreException
-   * @deprecated directly use <code>project.getParent()</code> whenever possible, and if parent needs to be re-resolved,
-   *             it's a responsibility of the consumer to do it in its code.
-   */
-  @Deprecated
-  MavenProject resolveParentProject(MavenProject project, IProgressMonitor monitor) throws CoreException;
-
   // execution
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}
-   */
-  @Deprecated MavenExecutionResult execute(MavenExecutionRequest request, IProgressMonitor monitor);
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #execute(MojoExecution, IProgressMonitor)} instead.
-   */
-  @Deprecated void execute(MavenSession session, MojoExecution execution, IProgressMonitor monitor);
 
   /**
    * @since 1.4
    */
   void execute(MavenProject project, MojoExecution execution, IProgressMonitor monitor) throws CoreException;
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #calculateExecutionPlan(MavenProject, List, boolean, IProgressMonitor)} instead.
-   */
-  @Deprecated MavenExecutionPlan calculateExecutionPlan(MavenSession session, MavenProject project, List<String> goals,
-      boolean setup, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @since 1.4
@@ -176,37 +125,16 @@ public interface IMaven {
       IProgressMonitor monitor) throws CoreException;
 
   /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #setupMojoExecution(MavenProject, MojoExecution)} instead.
-   */
-  @Deprecated MojoExecution setupMojoExecution(MavenSession session, MavenProject project, MojoExecution execution)
-      throws CoreException;
-
-  /**
    * @since 1.4
    */
   MojoExecution setupMojoExecution(MavenProject project, MojoExecution execution, IProgressMonitor monitor)
       throws CoreException;
 
   /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #getMojoParameterValue(MojoExecution, String, Class)} instead.
-   */
-  @Deprecated <T> T getMojoParameterValue(MavenSession session, MojoExecution mojoExecution, String parameter,
-      Class<T> asType) throws CoreException;
-
-  /**
    * @since 1.4
    */
   <T> T getMojoParameterValue(MavenProject project, MojoExecution mojoExecution, String parameter,
       Class<T> asType, IProgressMonitor monitor) throws CoreException;
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String)} instead.
-   */
-  @Deprecated <T> T getMojoParameterValue(String parameter, Class<T> type, MavenSession session, Plugin plugin,
-      ConfigurationContainer configuration, String goal) throws CoreException;
 
   /**
    * @since 1.4
@@ -268,15 +196,6 @@ public interface IMaven {
 
   /** @provisional */
   void removeLocalRepositoryListener(ILocalRepositoryListener listener);
-
-  /**
-   * Creates wagon TransferListener that can be used with Archetype, NexusIndexer and other components that use wagon
-   * API directly. The listener will adopt wagon transfer events to corresponding calls to IProgressMonitor and all
-   * registered ILocalRepositoryListeners.
-   *
-   * @deprecated IMaven API should not expose maven.repository.ArtifactTransferListener
-   */
-  @Deprecated TransferListener createTransferListener(IProgressMonitor monitor);
 
   ProxyInfo getProxyInfo(String protocol) throws CoreException;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2014 Sonatype, Inc. and others.
+ * Copyright (c) 2008-2022 Sonatype, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,6 +82,7 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.embedder.AbstractRunnable;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
 import org.eclipse.m2e.core.internal.markers.IMavenMarkerManager;
 import org.eclipse.m2e.core.internal.preferences.ProblemSeverity;
@@ -764,21 +765,6 @@ public class ProjectConfigurationManager implements IProjectConfigurationManager
   /**
    * Creates project structure using Archetype and then imports created project(s)
    *
-   * @deprecated use
-   *             {@link #createArchetypeProjects(IPath, Archetype, String, String, String, String, Properties, ProjectImportConfiguration, IProgressMonitor)}
-   */
-  @Override
-  @Deprecated
-  public void createArchetypeProject(IProject project, IPath location, Archetype archetype, String groupId,
-      String artifactId, String version, String javaPackage, Properties properties,
-      ProjectImportConfiguration configuration, IProgressMonitor monitor) throws CoreException {
-    createArchetypeProjects(location, archetype, groupId, artifactId, version, javaPackage, properties, configuration,
-        monitor);
-  }
-
-  /**
-   * Creates project structure using Archetype and then imports created project(s)
-   *
    * @return an unmodifiable list of created projects.
    * @since 1.1
    */
@@ -828,7 +814,7 @@ public class ProjectConfigurationManager implements IProjectConfigurationManager
 
       ArchetypeGenerationRequest request = new ArchetypeGenerationRequest()
           //
-          .setTransferListener(maven.createTransferListener(monitor))
+          .setTransferListener(((MavenImpl) maven).createTransferListener(monitor))
           //
           .setArchetypeGroupId(artifact.getGroupId())
           //

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -110,7 +110,6 @@ import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
-import org.eclipse.m2e.core.project.MavenUpdateRequest;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.core.project.configurator.ILifecycleMapping;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -288,18 +287,6 @@ public class ProjectRegistryManager implements ISaveParticipant {
     pomSet.remove(pom);
 
     return pomSet;
-  }
-
-  /**
-   * @deprecated this method does not properly join {@link IMavenExecutionContext}, use
-   *             {@link #refresh(Set, IProgressMonitor)} instead.
-   */
-  @Deprecated
-  public void refresh(final MavenUpdateRequest request, final IProgressMonitor monitor) throws CoreException {
-    getMaven().execute(request.isOffline(), request.isForceDependencyUpdate(), (context, pm) -> {
-      refresh(request.getPomFiles(), monitor);
-      return null;
-    }, monitor);
   }
 
   private boolean isForceDependencyUpdate() throws CoreException {
@@ -905,18 +892,6 @@ public class ProjectRegistryManager implements ISaveParticipant {
       this.resolverConfiguration = resolverConfiguration;
       this.pom = pom;
     }
-  }
-
-  /**
-   * @deprecated This method does not properly join {@link IMavenExecutionContext}
-   */
-  @Deprecated
-  public MavenExecutionRequest createExecutionRequest(IFile pom, ResolverConfiguration resolverConfiguration,
-      IProgressMonitor monitor) throws CoreException {
-    MavenExecutionRequest request = getMaven().createExecutionRequest(monitor);
-    configureExecutionRequest(request, projectRegistry, pom, resolverConfiguration);
-    MavenExecutionContext.populateSystemProperties(request);
-    return request;
   }
 
   /*package*/MavenExecutionRequest configureExecutionRequest(MavenExecutionRequest request, IProjectRegistry state,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,15 +54,6 @@ public interface IProjectConfigurationManager {
   void createSimpleProject(IProject project, IPath location, Model model, String[] folders,
       ProjectImportConfiguration configuration, IProjectCreationListener importListener, IProgressMonitor monitor)
           throws CoreException;
-
-  /**
-   * @deprecated use
-   *             {@link #createArchetypeProjects(IPath, Archetype, String, String, String, String, Properties, ProjectImportConfiguration, IProgressMonitor)}
-   */
-  @Deprecated
-  void createArchetypeProject(IProject project, IPath location, Archetype archetype, //
-      String groupId, String artifactId, String version, String javaPackage, Properties properties, //
-      ProjectImportConfiguration configuration, IProgressMonitor monitor) throws CoreException;
 
   /**
    * Creates project structure using Archetype and then imports the created project(s)

--- a/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
+++ b/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
@@ -47,6 +47,7 @@ import org.apache.maven.shared.utils.StringUtils;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.NoSuchComponentException;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
@@ -367,7 +368,6 @@ public class ProfileManager implements IProfileManager {
     if(file == null) {
       return null;
     }
-
-    return maven.readModel(file);
+    return ((MavenImpl) maven).readModel(file);
   }
 }

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/AbstractPomRefactoring.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/AbstractPomRefactoring.java
@@ -52,6 +52,7 @@ import org.eclipse.osgi.util.NLS;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.model.edit.pom.Model;
@@ -281,7 +282,7 @@ public abstract class AbstractPomRefactoring extends Refactoring {
       throws CoreException {
     IMavenProjectRegistry projectManager = MavenPlugin.getMavenProjectRegistry();
     return projectManager.execute(project,
-        (context, monitor1) -> MavenPlugin.getMaven().resolveParentProject(current, monitor1), monitor);
+        (c, m) -> ((MavenImpl) MavenPlugin.getMaven()).resolveParentProject(current, m), monitor);
   }
 
   // title for a composite change

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
@@ -42,6 +42,7 @@ import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.Messages;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.AbstractProjectScanner;
 
 
@@ -216,7 +217,7 @@ public class MavenProjectPomScanner<T> extends AbstractProjectScanner<MavenProje
     // MavenProject project = embedder.readProject(file);
 
     monitor.subTask(NLS.bind(Messages.MavenProjectPomScanner_23, new Object[] {groupId, artifactId, version}));
-    return maven.readModel(file);
+    return ((MavenImpl) maven).readModel(file);
   }
 
 }


### PR DESCRIPTION
Remove the deprecated API of `org.eclipse.m2e.core.embedder.IMaven`.

This requires adjustments in the m2e-core tests which should be tested first:
https://github.com/tesla/m2e-core-tests/pull/149