### PR TITLE
Replace uses of deprecated methods in MavenJRETab and WorkingSetGroup

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/WorkingSetGroup.java
@@ -101,8 +101,8 @@ public class WorkingSetGroup {
 
     workingsetComboViewer = new ComboViewer(workingsetCombo);
     workingsetComboViewer.setContentProvider(new IStructuredContentProvider() {
-        @Override
-        public Object[] getElements(Object input) {
+      @Override
+      public Object[] getElements(Object input) {
         if(input instanceof IWorkingSet[]) {
           return (IWorkingSet[]) input;
         } else if(input instanceof List<?>) {
@@ -113,22 +113,22 @@ public class WorkingSetGroup {
         return new IWorkingSet[0];
       }
 
-        @Override
-        public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+      @Override
+      public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
       }
 
-        @Override
-        public void dispose() {
+      @Override
+      public void dispose() {
       }
     });
     workingsetComboViewer.setLabelProvider(new LabelProvider() {
       private final ResourceManager images = new LocalResourceManager(JFaceResources.getResources());
 
-        @Override
-        @SuppressWarnings("deprecation")
+      @Override
       public Image getImage(Object element) {
         if(element instanceof IWorkingSet) {
-          ImageDescriptor imageDescriptor = ((IWorkingSet) element).getImage();
+
+          ImageDescriptor imageDescriptor = ((IWorkingSet) element).getImageDescriptor();
           if(imageDescriptor != null) {
             try {
               return (Image) images.create(imageDescriptor);
@@ -140,8 +140,8 @@ public class WorkingSetGroup {
         return super.getImage(element);
       }
 
-        @Override
-        public String getText(Object element) {
+      @Override
+      public String getText(Object element) {
         if(element instanceof IWorkingSet) {
           return ((IWorkingSet) element).getLabel();
         } else if(element instanceof List<?>) {
@@ -159,8 +159,8 @@ public class WorkingSetGroup {
         return super.getText(element);
       }
 
-        @Override
-        public void dispose() {
+      @Override
+      public void dispose() {
         images.dispose();
         super.dispose();
       }

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenJRETab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenJRETab.java
@@ -13,15 +13,11 @@
 
 package org.eclipse.m2e.ui.internal.launch;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.jdt.debug.ui.launchConfigurations.JavaJRETab;
 import org.eclipse.jdt.internal.debug.ui.launcher.VMArgumentsBlock;
-import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
-import org.eclipse.jdt.launching.IVMInstall;
-import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
@@ -32,9 +28,7 @@ public class MavenJRETab extends JavaJRETab {
 
   private final VMArgumentsBlock vmArgumentsBlock = new VMArgumentsBlock();
 
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#createControl(org.eclipse.swt.widgets.Composite)
-   */
+  @Override
   public void createControl(Composite parent) {
     super.createControl(parent);
 
@@ -46,9 +40,7 @@ public class MavenJRETab extends JavaJRETab {
     ((GridData) vmArgumentsBlock.getControl().getLayoutData()).horizontalSpan = 2;
   }
 
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#performApply(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-   */
+  @Override
   public void performApply(ILaunchConfigurationWorkingCopy configuration) {
     super.performApply(configuration);
     vmArgumentsBlock.performApply(configuration);
@@ -86,64 +78,25 @@ public class MavenJRETab extends JavaJRETab {
 //    return deflt;
 //  }
 
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#initializeFrom(org.eclipse.debug.core.ILaunchConfiguration)
-   */
+  @Override
   public void initializeFrom(ILaunchConfiguration configuration) {
     super.initializeFrom(configuration);
     vmArgumentsBlock.initializeFrom(configuration);
     // fVMArgumentsBlock.setEnabled(!fJREBlock.isDefaultJRE());
   }
 
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#setLaunchConfigurationDialog(org.eclipse.debug.ui.ILaunchConfigurationDialog)
-   */
+  @Override
   public void setLaunchConfigurationDialog(ILaunchConfigurationDialog dialog) {
     super.setLaunchConfigurationDialog(dialog);
     vmArgumentsBlock.setLaunchConfigurationDialog(dialog);
   }
 
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#activated(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-   */
+  @Override
   public void activated(ILaunchConfigurationWorkingCopy workingCopy) {
     setLaunchConfigurationWorkingCopy(workingCopy);
   }
 
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#setDefaults(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-   */
-  public void setDefaults(ILaunchConfigurationWorkingCopy config) {
-    super.setDefaults(config);
-    IVMInstall defaultVMInstall = getDefaultVMInstall(config);
-    if(defaultVMInstall != null) {
-      setDefaultVMInstallAttributes(defaultVMInstall, config);
-    }
-
-  }
-
-  private IVMInstall getDefaultVMInstall(ILaunchConfiguration config) {
-    IVMInstall defaultVMInstall;
-    try {
-      defaultVMInstall = JavaRuntime.computeVMInstall(config);
-    } catch(CoreException e) {
-      //core exception thrown for non-Java project
-      defaultVMInstall = JavaRuntime.getDefaultVMInstall();
-    }
-    return defaultVMInstall;
-  }
-
-  @SuppressWarnings("deprecation")
-  private void setDefaultVMInstallAttributes(IVMInstall defaultVMInstall, ILaunchConfigurationWorkingCopy config) {
-    String vmName = defaultVMInstall.getName();
-    String vmTypeID = defaultVMInstall.getVMInstallType().getId();
-    config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_INSTALL_NAME, vmName);
-    config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_INSTALL_TYPE, vmTypeID);
-  }
-
-  /* (non-Javadoc)
-   * @see org.eclipse.debug.ui.ILaunchConfigurationTab#deactivated(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-   */
+  @Override
   public void deactivated(ILaunchConfigurationWorkingCopy workingCopy) {
   }
 }


### PR DESCRIPTION
... and perform minor clean ups and formatting.

Not setting `IJavaLaunchConfigurationConstants.ATTR_VM_INSTALL_NAME` and `IJavaLaunchConfigurationConstants.ATTR_VM_INSTALL_TYPE` to the config and simply letting the `JREsComboBlock` of the `MavenJRETab` handle the JREs also fixes the quirk that when one creates a new maven launch-config `Alternate JRE` is selected by default instead of Workspace default:

![grafik](https://user-images.githubusercontent.com/44067969/167499670-d8bcc6d1-0c89-4e6f-aadc-e11561512cc4.png)

