### PR TITLE
Remove remaining deprecated APIs from org.eclipse.m2e.core

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenImportWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenImportWizardPage.java
@@ -73,6 +73,7 @@ import org.apache.maven.model.Parent;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.MavenModelManager;
+import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
 import org.eclipse.m2e.core.project.AbstractProjectScanner;
 import org.eclipse.m2e.core.project.LocalProjectScanner;
 import org.eclipse.m2e.core.project.MavenProjectInfo;
@@ -465,7 +466,7 @@ public class MavenImportWizardPage extends AbstractMavenWizardPage {
 
     // derive working set name from project name
     if(rootProject != null) {
-      updateWorkingSet(getImportConfiguration().getProjectName(rootProject.getModel()), //
+      updateWorkingSet(ProjectConfigurationManager.getProjectName(getImportConfiguration(), rootProject.getModel()), //
           !rootProject.getProjects().isEmpty());
     } else {
       updateWorkingSet(null, false);
@@ -536,7 +537,7 @@ public class MavenImportWizardPage extends AbstractMavenWizardPage {
   boolean isAlreadyExists(MavenProjectInfo info) {
     if(info != null) {
       IWorkspace workspace = ResourcesPlugin.getWorkspace();
-      String name = getImportConfiguration().getProjectName(info.getModel());
+      String name = ProjectConfigurationManager.getProjectName(getImportConfiguration(), info.getModel());
       if(name != null && name.length() > 0) {
         IProject project = workspace.getRoot().getProject(name);
         return project.exists();
@@ -634,13 +635,13 @@ public class MavenImportWizardPage extends AbstractMavenWizardPage {
   protected String validateProjectInfo(MavenProjectInfo info) {
     if(info != null) {
       if(isWorkspaceFolder(info)) {
-        String projectName = getImportConfiguration().getProjectName(info.getModel());
+        String projectName = ProjectConfigurationManager.getProjectName(getImportConfiguration(), info.getModel());
         return NLS.bind(Messages.wizardImportValidatorWorkspaceFolder, projectName);
       } else if(isAlreadyImported(info)) {
-        String projectName = getImportConfiguration().getProjectName(info.getModel());
+        String projectName = ProjectConfigurationManager.getProjectName(getImportConfiguration(), info.getModel());
         return NLS.bind(Messages.wizardImportValidatorProjectImported, projectName);
       } else if(isAlreadyExists(info)) {
-        String projectName = getImportConfiguration().getProjectName(info.getModel());
+        String projectName = ProjectConfigurationManager.getProjectName(getImportConfiguration(), info.getModel());
         return NLS.bind(Messages.wizardImportValidatorProjectExists, projectName);
       }
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizard.java
@@ -52,6 +52,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
 import org.eclipse.m2e.core.ui.internal.MavenImages;
 import org.eclipse.m2e.core.ui.internal.Messages;
 import org.eclipse.m2e.core.ui.internal.actions.OpenMavenConsoleAction;
@@ -215,8 +216,8 @@ public class MavenModuleWizard extends AbstractMavenProjectWizard implements INe
         @Override
         protected List<IProject> doCreateMavenProjects(IProgressMonitor monitor) throws CoreException {
           setProperty(IProgressConstants.ACTION_PROPERTY, new OpenMavenConsoleAction());
-          String projectName = importConfiguration.getProjectName(model);
-          IProject project = importConfiguration.getProject(ResourcesPlugin.getWorkspace().getRoot(), model);
+          String projectName = ProjectConfigurationManager.getProjectName(importConfiguration, model);
+          IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 
           // XXX respect parent's setting for separate projects for modules
           // XXX should run update sources on parent instead of creating new module project

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypeParametersPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypeParametersPage.java
@@ -268,8 +268,7 @@ public class MavenProjectWizardArchetypeParametersPage extends AbstractMavenWiza
     }));
 
     propertiesTable.addSelectionListener(
-        SelectionListener.widgetSelectedAdapter(e -> removeButton.setEnabled(propertiesTable.getSelectionCount() > 0)
-      ));
+        SelectionListener.widgetSelectedAdapter(e -> removeButton.setEnabled(propertiesTable.getSelectionCount() > 0)));
   }
 
   /**
@@ -325,7 +324,7 @@ public class MavenProjectWizardArchetypeParametersPage extends AbstractMavenWiza
     }
 
     // validate project name
-    IStatus nameStatus = getImportConfiguration().validateProjectName(getModel());
+    IStatus nameStatus = MavenProjectWizard.validateProjectName(getImportConfiguration(), getModel());
     if(!nameStatus.isOK()) {
       return NLS.bind(Messages.wizardProjectPageMaven2ValidatorProjectNameInvalid, nameStatus.getMessage());
     }
@@ -424,9 +423,9 @@ public class MavenProjectWizardArchetypeParametersPage extends AbstractMavenWiza
     @Override
     public void run(IProgressMonitor monitor) {
       String archetypeName = getName(archetype);
-      monitor.beginTask(NLS.bind(
-          org.eclipse.m2e.core.ui.internal.Messages.MavenProjectWizardArchetypeParametersPage_task, archetypeName),
-          IProgressMonitor.UNKNOWN);
+      monitor
+          .beginTask(NLS.bind(org.eclipse.m2e.core.ui.internal.Messages.MavenProjectWizardArchetypeParametersPage_task,
+              archetypeName), IProgressMonitor.UNKNOWN);
 
       try {
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArtifactPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArtifactPage.java
@@ -270,7 +270,7 @@ public class MavenProjectWizardArtifactPage extends AbstractMavenWizardPage {
     }
 
     // validate project name
-    IStatus nameStatus = getImportConfiguration().validateProjectName(artifactComponent.getModel());
+    IStatus nameStatus = MavenProjectWizard.validateProjectName(getImportConfiguration(), artifactComponent.getModel());
     if(!nameStatus.isOK()) {
       return nameStatus.getMessage();
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardLocationPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardLocationPage.java
@@ -295,7 +295,9 @@ public class MavenProjectWizardLocationPage extends AbstractMavenWizardPage {
       // the other wizard don't seem to have any getModel() methods.
       //see MNGECLIPSE-1252 for more.
       if(getWizard() instanceof MavenProjectWizard) {
-        String projectName = getImportConfiguration().getProjectName(((MavenProjectWizard) getWizard()).getModel());
+        @SuppressWarnings("restriction")
+        String projectName = org.eclipse.m2e.core.internal.project.ProjectConfigurationManager
+            .getProjectName(getImportConfiguration(), ((MavenProjectWizard) getWizard()).getModel());
         if(projectName.length() > 0) {
           final IStatus locationStatus = workspace.validateProjectLocation(workspace.getRoot().getProject(projectName),
               projectPath);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/AbstractEclipseBuildContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/AbstractEclipseBuildContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
@@ -134,13 +133,5 @@ public abstract class AbstractEclipseBuildContext implements BuildContext, IIncr
   @Override
   public void release() {
     ThreadBuildContext.setThreadBuildContext(null);
-  }
-
-  /**
-   * @deprecated BuildContext consumers should not care which files were modified during a build.
-   */
-  @Deprecated
-  public Set<File> getFiles() {
-    return results.getFiles();
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractLifecycleMapping.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractLifecycleMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2010 Sonatype, Inc.
+ * Copyright (c) 2008-2022 Sonatype, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -39,6 +40,7 @@ import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.M2EUtils;
 import org.eclipse.m2e.core.internal.Messages;
+import org.eclipse.m2e.core.internal.builder.InternalBuildParticipant;
 import org.eclipse.m2e.core.internal.builder.MavenBuilderImpl;
 import org.eclipse.m2e.core.internal.embedder.MavenProjectMutableState;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -59,10 +61,9 @@ public abstract class AbstractLifecycleMapping implements ILifecycleMapping {
 
   private static final MavenBuilderImpl builder = new MavenBuilderImpl() {
     @Override
-    protected boolean isApplicable(org.eclipse.m2e.core.internal.builder.InternalBuildParticipant participant,
-        int kind, org.eclipse.core.resources.IResourceDelta delta) {
+    protected boolean isApplicable(InternalBuildParticipant participant, int kind, IResourceDelta delta) {
       return true;
-    };
+    }
   };
 
   /**
@@ -112,8 +113,8 @@ public abstract class AbstractLifecycleMapping implements ILifecycleMapping {
             participants.put(entry.getKey(), participants2);
           }
         }
-        builder.build(request.getMavenSession(), projectFacade, AbstractBuildParticipant2.PRECONFIGURE_BUILD,
-            Collections.<String, String> emptyMap(), participants, monitor);
+        projectFacade.getMaven().execute((c, m) -> builder.build(c.getSession(), projectFacade,
+            AbstractBuildParticipant2.PRECONFIGURE_BUILD, Collections.emptyMap(), participants, m), monitor);
 
         //perform configuration
         for(AbstractProjectConfigurator configurator : getProjectConfigurators(projectFacade, monitor.newChild(1))) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/ProjectConfigurationRequest.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/ProjectConfigurationRequest.java
@@ -16,11 +16,8 @@ package org.eclipse.m2e.core.project.configurator;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
-import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
 
@@ -45,18 +42,6 @@ public class ProjectConfigurationRequest {
 
   public MavenProject getMavenProject() {
     return mavenProject;
-  }
-
-  /**
-   * @deprecated see {@link IMavenExecutionContext}.
-   */
-  @Deprecated
-  public MavenSession getMavenSession() {
-    final IMavenExecutionContext context = MavenPlugin.getMaven().getExecutionContext();
-    if(context == null) {
-      throw new IllegalStateException();
-    }
-    return context.getSession();
   }
 
   public IFile getPom() {

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/internal/wizards/MavenProjectCheckoutJob.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/internal/wizards/MavenProjectCheckoutJob.java
@@ -54,12 +54,14 @@ import org.apache.maven.model.Model;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.MavenModelManager;
+import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
 import org.eclipse.m2e.core.project.LocalProjectScanner;
 import org.eclipse.m2e.core.project.MavenProjectInfo;
 import org.eclipse.m2e.core.project.ProjectImportConfiguration;
 import org.eclipse.m2e.core.ui.internal.actions.OpenMavenConsoleAction;
 import org.eclipse.m2e.core.ui.internal.wizards.ImportMavenProjectsJob;
 import org.eclipse.m2e.core.ui.internal.wizards.MavenImportWizard;
+import org.eclipse.m2e.core.ui.internal.wizards.MavenProjectWizard;
 import org.eclipse.m2e.scm.MavenCheckoutOperation;
 import org.eclipse.m2e.scm.MavenProjectScmInfo;
 import org.eclipse.m2e.scm.internal.Messages;
@@ -128,7 +130,7 @@ public abstract class MavenProjectCheckoutJob extends WorkspaceJob {
             projectInfo.setModel(model);
           }
 
-          String projectName = configuration.getProjectName(model);
+          String projectName = ProjectConfigurationManager.getProjectName(configuration, model);
           IProject project = workspace.getProject(projectName);
           if(project.exists()) {
             checkoutAllProjects = false;

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -78,6 +78,7 @@ import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
 import org.eclipse.m2e.core.internal.preferences.MavenConfigurationImpl;
+import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
 import org.eclipse.m2e.core.internal.project.registry.MavenProjectFacade;
 import org.eclipse.m2e.core.internal.project.registry.ProjectRegistryRefreshJob;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -465,7 +466,8 @@ public abstract class AbstractMavenProjectTestCase {
     workspace.run((IWorkspaceRunnable) monitor -> {
       MavenPlugin.getProjectConfigurationManager().importProjects(Collections.singleton(projectInfo),
           importConfiguration, monitor);
-      IProject project = workspace.getRoot().getProject(importConfiguration.getProjectName(projectInfo.getModel()));
+      IProject project = workspace.getRoot()
+          .getProject(ProjectConfigurationManager.getProjectName(importConfiguration, projectInfo.getModel()));
       assertNotNull("Failed to import project " + projectInfo, project);
     }, MavenPlugin.getProjectConfigurationManager().getRule(), IWorkspace.AVOID_UPDATE, monitor);
 


### PR DESCRIPTION
This PR replaces the use and removes the remaining deprecated API from m2e.core.

The only problem that is not yet resolved is how to properly replace `ProjectImportConfiguration.getProjectName()` respectivly `ProjectImportConfiguration.getProject()`.