### PR TITLE
Add a dev target that includes the current eclipse isntallation

### DIFF
--- a/target-platform/dev.target
+++ b/target-platform/dev.target
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="dev">
+	<locations>
+		<location path="${eclipse_home}" type="Profile"/>
+		<location type="Target" uri="file:${project_loc:/target-platform}/target-platform.target"/>
+	</locations>
+</target>


### PR DESCRIPTION
I sometimes use the current eclipse installation so I don't need to import all bundles (especially the runtime ones).
With the new target reference in PDE one could easily create such a target without modify the original one.