### PR TITLE
Let IMaven implement Maven

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -252,6 +252,15 @@ public interface IMaven {
   <V> V execute(ICallable<V> callable, IProgressMonitor monitor) throws CoreException;
 
   /**
+   * Execute the given {@link MavenExecutionRequest} in the context of m2eclipse and return the result, this could be
+   * seen as an embedded run of the maven cli, at least it tries to replicate as much as possible from that.
+   * 
+   * @param request a {@link MavenExecutionRequest}
+   * @return the result of the execution
+   */
+  MavenExecutionResult execute(MavenExecutionRequest request);
+
+  /**
    * Creates and returns new, possibly nested, maven execution context.
    *
    * @since 1.4
@@ -282,4 +291,5 @@ public interface IMaven {
    * @return
    */
   <T> T lookupComponent(Class<T> clazz);
+
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MonitorExecutionListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MonitorExecutionListener.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.embedder;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionListener;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.internal.LifecycleTaskSegmentCalculator;
+import org.apache.maven.lifecycle.internal.TaskSegment;
+
+
+/**
+ * This is a wrapper from an {@link IProgressMonitor} to an {@link ExecutionListener} that could be used to report
+ * progress
+ */
+public class MonitorExecutionListener implements ExecutionListener {
+
+  private IProgressMonitor monitor;
+
+  public MonitorExecutionListener(IProgressMonitor monitor) {
+    this.monitor = IProgressMonitor.nullSafe(monitor);
+  }
+
+  @Override
+  public void mojoStarted(ExecutionEvent event) {
+    String id = event.getMojoExecution().getPlugin().getId();
+    monitor.subTask("Executing " + id + "...");
+  }
+
+  void mojoFinished(ExecutionEvent event) {
+    if(monitor.isCanceled()) {
+      //this might not be the nicest approach here, but from the maven code the EventCatapult
+      //is passing exceptions occurring in the ExecutionListener and there is no other way to stop maven
+      throw new CancellationException();
+    }
+    monitor.worked(1);
+    monitor.subTask("");
+  }
+
+  @Override
+  public void mojoFailed(ExecutionEvent event) {
+    mojoFinished(event);
+  }
+
+  @Override
+  public void mojoSkipped(ExecutionEvent event) {
+    mojoFinished(event);
+  }
+
+  @Override
+  public void mojoSucceeded(ExecutionEvent event) {
+    mojoFinished(event);
+
+  }
+
+  @Override
+  public void projectStarted(ExecutionEvent event) {
+    monitor.setTaskName("Building " + event.getProject().getName() + "...");
+  }
+
+  void projectFinished(ExecutionEvent event) {
+    monitor.setTaskName("Building...");
+  }
+
+  @Override
+  public void projectFailed(ExecutionEvent event) {
+    projectFinished(event);
+  }
+
+  @Override
+  public void projectSkipped(ExecutionEvent event) {
+    projectFinished(event);
+  }
+
+  @Override
+  public void projectSucceeded(ExecutionEvent event) {
+    projectFinished(event);
+  }
+
+  @Override
+  public void sessionEnded(ExecutionEvent event) {
+    monitor.done();
+  }
+
+  @Override
+  public void sessionStarted(ExecutionEvent event) {
+    int totalWork;
+    try {
+      MavenSession session = event.getSession();
+      LifecycleTaskSegmentCalculator calculator = (LifecycleTaskSegmentCalculator) session
+          .lookup(LifecycleTaskSegmentCalculator.class.getName());
+      List<TaskSegment> segments = calculator.calculateTaskSegments(session);
+      totalWork = (int) (segments.stream().flatMap(seg -> seg.getTasks().stream()).count()
+          * session.getProjects().size());
+    } catch(Exception ex) {
+      totalWork = IProgressMonitor.UNKNOWN;
+    }
+    monitor.beginTask("Building ...", totalWork);
+  }
+
+  //not used currently ...
+  @Override
+  public void projectDiscoveryStarted(ExecutionEvent event) {
+
+  }
+
+  @Override
+  public void forkFailed(ExecutionEvent event) {
+  }
+
+  @Override
+  public void forkStarted(ExecutionEvent event) {
+  }
+
+  @Override
+  public void forkSucceeded(ExecutionEvent event) {
+  }
+
+  @Override
+  public void forkedProjectFailed(ExecutionEvent event) {
+  }
+
+  @Override
+  public void forkedProjectStarted(ExecutionEvent event) {
+  }
+
+  @Override
+  public void forkedProjectSucceeded(ExecutionEvent event) {
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -70,6 +70,11 @@ public class MavenExecutionContext implements IMavenExecutionContext {
     this.maven = maven;
   }
 
+  MavenExecutionContext(MavenImpl maven, MavenExecutionRequest request) {
+    this.maven = maven;
+    this.request = request;
+  }
+
   @Override
   public MavenExecutionRequest getExecutionRequest() throws CoreException {
     if(request != null && context != null) {


### PR DESCRIPTION
Actually m2e is some kind of "maven" and like the "DefaultMaven" of
maven cli should handle the loading of extensions and alike.

This let IMaven implement Maven and perform some task like the maven CLI does.
Beside this, a wrapper around a monitor is added that redirects ExecutionEvents to the monitor.
