### PR TITLE
Add setting for explicit project encoding UTF-8

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.binaryproject.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.binaryproject.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.binaryproject.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.binaryproject.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.binaryproject/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.binaryproject/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.core.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.core.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.core.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.core.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.discovery/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.discovery/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.editor.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.editor.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.editor/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.editor/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.jdt.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.jdt.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.jdt.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.jdt.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.jdt/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.jdt/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.launching/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.launching/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.lemminx.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.lemminx.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.logback.appender/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.logback.appender/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.logback.configuration/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.logback.configuration/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.logback.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.logback.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.pde.connector/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.pde.connector/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.pde.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.pde.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.pde.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.pde.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.pde/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.pde/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.profiles.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.profiles.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.profiles.core/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.profiles.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.profiles.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.profiles.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.refactoring/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.refactoring/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.sdk.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.sdk.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.sourcelookup.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.sourcelookup.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.sourcelookup/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.sourcelookup/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.tests.common/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.tests.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/target-platform/.settings/org.eclipse.core.resources.prefs
+++ b/target-platform/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Without that a warning is emitted for recent Eclipse-IDEs.