### PR TITLE
Disable concurrent builds, as building older commits do not help much.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
 	options {
 		timeout(time: 180, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'10'))
+		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {
 		label "centos-latest"


### PR DESCRIPTION
Currently a PR is build multiple times if before the build finished there is a new commit in the meantime.