### PR TITLE
[Logback] reduce rolling log file limit

### DIFF
--- a/org.eclipse.m2e.logback.configuration/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback.configuration/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2E Logback Configuration
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-SymbolicName: org.eclipse.m2e.logback.configuration;singleton:=true
-Bundle-Version: 1.16.3.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.m2e.logback.configuration.LogPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  ch.qos.logback.classic;bundle-version="1.0.0",

--- a/org.eclipse.m2e.logback.configuration/defaultLogbackConfiguration/logback.xml
+++ b/org.eclipse.m2e.logback.configuration/defaultLogbackConfiguration/logback.xml
@@ -16,7 +16,7 @@
       <MaxIndex>10</MaxIndex>
     </rollingPolicy>
     <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-      <MaxFileSize>100MB</MaxFileSize>
+      <MaxFileSize>10MB</MaxFileSize>
     </triggeringPolicy>
     <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
       <pattern>%date [%thread] %-5level %logger{35} - %msg%n</pattern>


### PR DESCRIPTION
In order to reduce the disk-space occupation by m2e I want to propose the reduce the max-size of each log-file from 100MB to 10MB. Given that the rolling file-appender creates up to 10 files, this reduces the total log-file size from 1GB to 100MB per workspace!
I think this is more than sufficient. Who want's to know what exactly happens in its workspace 3months ago?
Personally I never look into the logs and given that the MavenConsole shows the log content in the IDE, from my standpoint, the rolling file appender can be removed completely.