### PR TITLE
Prevent NPE on m2.pde.ui bundle stop

### DIFF
--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/Activator.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/Activator.java
@@ -12,16 +12,21 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui;
 
-import org.eclipse.m2e.pde.ui.target.adapter.DependencyNodeAdapterFactory;
-import org.eclipse.m2e.pde.ui.target.adapter.MavenTargetAdapterFactory;
-import org.eclipse.m2e.pde.ui.target.adapter.MavenTargetBundleAdapterFactory;
-import org.eclipse.m2e.pde.ui.target.adapter.MavenTargetDependencyAdapterFactory;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 public class Activator implements BundleActivator {
 
 	public static final String ID = "org.eclipse.m2e.pde.ui";
+
+	private static final Set<Runnable> STOP_ACTIONS = new HashSet<>();
+
+	public static void runOnBundleStop(Runnable action) {
+		STOP_ACTIONS.add(action);
+	}
 
 	@Override
 	public void start(BundleContext context) throws Exception {
@@ -30,12 +35,6 @@ public class Activator implements BundleActivator {
 
 	@Override
 	public void stop(BundleContext context) throws Exception {
-		DependencyNodeAdapterFactory.LABEL_PROVIDER.dispose();
-		DependencyNodeAdapterFactory.TREE_CONTENT_PROVIDER.dispose();
-		MavenTargetAdapterFactory.LABEL_PROVIDER.dispose();
-		MavenTargetAdapterFactory.TREE_CONTENT_PROVIDER.dispose();
-		MavenTargetBundleAdapterFactory.LABEL_PROVIDER.dispose();
-		MavenTargetDependencyAdapterFactory.LABEL_PROVIDER.dispose();
+		STOP_ACTIONS.forEach(Runnable::run);
 	}
-
 }

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/DependencyNodeAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/DependencyNodeAdapterFactory.java
@@ -16,6 +16,7 @@ import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.m2e.pde.ui.Activator;
 import org.eclipse.m2e.pde.ui.target.editor.MavenTargetLocationEditor;
 import org.eclipse.m2e.pde.ui.target.provider.DependencyNodeLabelProvider;
 import org.eclipse.m2e.pde.ui.target.provider.MavenTargetTreeContentProvider;
@@ -26,6 +27,10 @@ public class DependencyNodeAdapterFactory implements IAdapterFactory {
 	public static final ITreeContentProvider TREE_CONTENT_PROVIDER = new MavenTargetTreeContentProvider();
 	public static final ILabelProvider LABEL_PROVIDER = new DependencyNodeLabelProvider();
 	private static final MavenTargetLocationEditor LOCATION_EDITOR = new MavenTargetLocationEditor();
+	static {
+		Activator.runOnBundleStop(TREE_CONTENT_PROVIDER::dispose);
+		Activator.runOnBundleStop(LABEL_PROVIDER::dispose);
+	}
 
 	@Override
 	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetAdapterFactory.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.m2e.pde.target.MavenTargetLocation;
+import org.eclipse.m2e.pde.ui.Activator;
 import org.eclipse.m2e.pde.ui.target.editor.MavenTargetLocationEditor;
 import org.eclipse.m2e.pde.ui.target.provider.MavenTargetLocationLabelProvider;
 import org.eclipse.m2e.pde.ui.target.provider.MavenTargetTreeContentProvider;
@@ -26,7 +27,10 @@ public class MavenTargetAdapterFactory implements IAdapterFactory {
 	public static final ILabelProvider LABEL_PROVIDER = new MavenTargetLocationLabelProvider();
 	public static final ITreeContentProvider TREE_CONTENT_PROVIDER = new MavenTargetTreeContentProvider();
 	private static final MavenTargetLocationEditor LOCATION_EDITOR = new MavenTargetLocationEditor();
-
+	static {
+		Activator.runOnBundleStop(LABEL_PROVIDER::dispose);
+		Activator.runOnBundleStop(TREE_CONTENT_PROVIDER::dispose);
+	}
 	@Override
 	public Class<?>[] getAdapterList() {
 		return new Class[] { ILabelProvider.class, ITreeContentProvider.class, ITargetLocationHandler.class };

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetBundleAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetBundleAdapterFactory.java
@@ -15,12 +15,15 @@ package org.eclipse.m2e.pde.ui.target.adapter;
 import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.m2e.pde.target.MavenTargetBundle;
+import org.eclipse.m2e.pde.ui.Activator;
 import org.eclipse.m2e.pde.ui.target.provider.MavenTargetBundleLabelProvider;
 
 public class MavenTargetBundleAdapterFactory implements IAdapterFactory {
 
 	public static final ILabelProvider LABEL_PROVIDER = new MavenTargetBundleLabelProvider();
-
+	static {
+		Activator.runOnBundleStop(LABEL_PROVIDER::dispose);
+	}
 	@Override
 	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
 		if (adaptableObject instanceof MavenTargetBundle) {

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetDependencyAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetDependencyAdapterFactory.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.m2e.pde.target.MavenTargetDependency;
+import org.eclipse.m2e.pde.ui.Activator;
 import org.eclipse.m2e.pde.ui.target.editor.MavenTargetLocationEditor;
 import org.eclipse.m2e.pde.ui.target.provider.MavenTargetDependencyLabelProvider;
 import org.eclipse.m2e.pde.ui.target.provider.MavenTargetTreeContentProvider;
@@ -26,7 +27,10 @@ public class MavenTargetDependencyAdapterFactory implements IAdapterFactory {
 	public static final ILabelProvider LABEL_PROVIDER = new MavenTargetDependencyLabelProvider();
 	public static final ITreeContentProvider TREE_CONTENT_PROVIDER = new MavenTargetTreeContentProvider();
 	private static final MavenTargetLocationEditor LOCATION_EDITOR = new MavenTargetLocationEditor();
-
+	static {
+		Activator.runOnBundleStop(LABEL_PROVIDER::dispose);
+		Activator.runOnBundleStop(TREE_CONTENT_PROVIDER::dispose);
+	}
 	@Override
 	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
 		if (adaptableObject instanceof MavenTargetDependency) {


### PR DESCRIPTION
It can happen that not all classes referenced in the m2e.pde.ui bundle's activator are initialized when the bundle is stopped. I think this happens when a user has not opened all tabs of the target-editor.

If m2e.pde.ui is stopped, e.g. when the application shuts down those classes are initialized during Bundle-stop. The initialization requires a Display instance that is null then this causing an NPE and finally a InitializationException.
This seems not to be harmful but can be disturbing for users as this shows up on the Error-log at the next start.