### PR TITLE
Move the basedir entirely into the IMavenExecutionContext

### DIFF
--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
@@ -52,6 +52,7 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.apt.internal.utils.ProjectUtils;
+import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
@@ -356,8 +357,11 @@ public abstract class AbstractAptConfiguratorDelegate implements AptConfigurator
     PluginExecution execution = new PluginExecution();
     execution.setConfiguration(mojoExecution.getConfiguration());
     MavenProject mavenProject = mavenFacade.getMavenProject();
-    return mavenFacade.getMaven().getMojoParameterValue(mavenProject, parameter, asType, mojoExecution.getPlugin(),
-        execution, mojoExecution.getGoal(), null);
+    return mavenFacade.createExecutionContext().execute(mavenProject, (context, monitor) -> {
+      //TODO provide as part of the execution context? We then probably won't need the project parameter at all?
+      return MavenPlugin.getMaven().getMojoParameterValue(mavenProject, parameter, asType, mojoExecution.getPlugin(),
+          execution, mojoExecution.getGoal(), null);
+    }, null);
   }
 
 }

--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptProjectConfigurator.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptProjectConfigurator.java
@@ -82,7 +82,7 @@ public abstract class AbstractAptProjectConfigurator extends AbstractProjectConf
 
     AnnotationProcessingMode mode = getAnnotationProcessorMode(mavenProjectFacade);
 
-    mavenProjectFacade.getMaven().createExecutionContext().execute((c, m) -> {
+    mavenProjectFacade.createExecutionContext().execute((c, m) -> {
       AptConfiguratorDelegate configuratorDelegate = getDelegate(mode);
       configuratorDelegate.setSession(c.getSession());
       configuratorDelegate.setFacade(mavenProjectFacade);
@@ -144,7 +144,7 @@ public abstract class AbstractAptProjectConfigurator extends AbstractProjectConf
       return;
     }
 
-    request.getMavenProjectFacade().getMaven().execute((c, m) -> {
+    request.getMavenProjectFacade().createExecutionContext().execute((c, m) -> {
       AptConfiguratorDelegate delegate = getDelegate(request.getMavenProjectFacade());
       delegate.setFacade(request.getMavenProjectFacade());
       delegate.setSession(c.getSession());

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/MavenBugsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/MavenBugsTest.java
@@ -90,7 +90,7 @@ public class MavenBugsTest extends AbstractMavenProjectTestCase {
 			true, monitor);
 		Assert.assertNotNull(facade);
 		File[] multiModuleDirectory = new File[] { null }; 
-		facade.getMaven().execute((context, monitor) -> multiModuleDirectory[0] = context.getExecutionRequest().getMultiModuleProjectDirectory(), null);
+		facade.createExecutionContext().execute((context, monitor) -> multiModuleDirectory[0] = context.getExecutionRequest().getMultiModuleProjectDirectory(), null);
 		assertEquals(project.getLocation().toFile(), multiModuleDirectory[0]);
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/MavenPlugin.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/MavenPlugin.java
@@ -32,7 +32,7 @@ public final class MavenPlugin {
   }
 
   /**
-   * Use {@link IMavenProjectFacade#getMaven()} instead whenever possible
+   * Use {@link IMavenProjectFacade#createExecutionContext()} instead whenever possible
    * 
    * @return a generic Maven instance (not customized by project).
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -42,6 +42,8 @@ import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsProblem;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+
 
 /**
  * Entry point for all Maven functionality in m2e. Note that this component does not directly support workspace artifact
@@ -258,7 +260,10 @@ public interface IMaven {
   MavenExecutionResult execute(MavenExecutionRequest request);
 
   /**
-   * Creates and returns new, possibly nested, maven execution context.
+   * Creates and returns new global maven execution context. such a context is suitable if one likes to perform some
+   * action without a project, this is similar to calling maven but without a pom.xml If you want to execute in the
+   * context of a project (e.g. to support project scoped extensions) you should use
+   * {@link IMavenProjectFacade#createExecutionContext()} instead.
    *
    * @since 1.4
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -177,7 +177,7 @@ import org.eclipse.m2e.core.internal.preferences.MavenPreferenceConstants;
 
 
 @Component(service = {IMaven.class, IMavenConfigurationChangeListener.class})
-public class MavenImpl implements IMaven, IMavenConfigurationChangeListener, Cloneable {
+public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
   private static final Logger log = LoggerFactory.getLogger(MavenImpl.class);
 
   /**
@@ -207,8 +207,6 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener, Clo
 
   /** Last modified timestamp of cached user settings */
   private long settingsTimestamp;
-
-  private File basedir;
 
   @Override
   public String getLocalRepositoryPath() {
@@ -1212,7 +1210,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener, Clo
 
   @Override
   public MavenExecutionContext createExecutionContext() {
-    return new MavenExecutionContext(this, basedir);
+    return new MavenExecutionContext(this, (File) null);
   }
 
   @Override
@@ -1265,17 +1263,4 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener, Clo
     return basedir;
   }
 
-  public MavenImpl cloneForBasedir(File basedir) {
-    try {
-      MavenImpl res = (MavenImpl) clone();
-      res.basedir = basedir;
-      // TODO: more customization may be needed, more fields cleared, maybe in the end no
-      // need to start from a clone at all...
-      // TODO? What about getExecutionContext() that's tied to the thread and not to this?
-      return res;
-    } catch(CloneNotSupportedException ex) {
-      // unexpected, let's just crash
-      throw new RuntimeException(ex);
-    }
-  }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -36,11 +36,12 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
-import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.embedder.ArtifactRef;
 import org.eclipse.m2e.core.embedder.ArtifactRepositoryRef;
 import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
+import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -108,8 +109,6 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
   private Map<MojoExecutionKey, List<IPluginExecutionMetadata>> mojoExecutionMapping;
 
   private transient Map<String, Object> sessionProperties;
-
-  private IMaven maven;
 
   public MavenProjectFacade(ProjectRegistryManager manager, IFile pom, MavenProject mavenProject,
       ResolverConfiguration resolverConfiguration) {
@@ -534,11 +533,12 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
   }
 
   @Override
+  public IMavenExecutionContext createExecutionContext() {
+    return new MavenExecutionContext((MavenImpl) getMaven(), getPomFile());
+  }
+
+  @Override
   public IMaven getMaven() {
-    if(maven == null) {
-      File basedir = pomFile != null ? (pomFile.isDirectory() ? pomFile : pomFile.getParentFile()) : null;
-      maven = ((MavenImpl) MavenPlugin.getMaven()).cloneForBasedir(basedir);
-    }
-    return maven;
+    return manager.getMaven();
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -31,6 +31,7 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.embedder.ArtifactRef;
 import org.eclipse.m2e.core.embedder.ArtifactRepositoryRef;
 import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 
@@ -139,7 +140,17 @@ public interface IMavenProjectFacade {
   Set<ArtifactRepositoryRef> getPluginArtifactRepositoryRefs();
 
   /**
-   * Gets an access to a Maven instance, configured according to this project.
+   * Creates a new execution context that is one suitable to execute in the context of this facade, that is it might
+   * include project specific extensions.
+   * 
+   * @return a new execution context for this facade
+   */
+  IMavenExecutionContext createExecutionContext();
+
+  /**
+   * Gets an access to a (possibly project specific) {@link IMaven} instance,
+   * this is the same instance that is used to create new {@link IMavenExecutionContext}s
+   * see {@link #createExecutionContext()}
    * 
    * @return a Maven instance, configured according to this project
    */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractLifecycleMapping.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractLifecycleMapping.java
@@ -113,7 +113,7 @@ public abstract class AbstractLifecycleMapping implements ILifecycleMapping {
             participants.put(entry.getKey(), participants2);
           }
         }
-        projectFacade.getMaven().execute((c, m) -> builder.build(c.getSession(), projectFacade,
+        projectFacade.createExecutionContext().execute((c, m) -> builder.build(c.getSession(), projectFacade,
             AbstractBuildParticipant2.PRECONFIGURE_BUILD, Collections.emptyMap(), participants, m), monitor);
 
         //perform configuration


### PR DESCRIPTION
This scopes the basedir inside a unique IMavenExecutionContext, instead
of trying to provide a project specific IMaven, the IMavenProjectFacade
now allows of creation of a project scoped IMavenExecutionContext to be
used, see https://github.com/eclipse-m2e/m2e-core/discussions/710 for
further context.

@mickaelistria WDYT?