### PR TITLE
Move execution part out of IMaven

### DIFF
--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/RegistryTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/RegistryTest.java
@@ -31,7 +31,9 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
+import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
 import org.eclipse.m2e.core.project.ProjectImportConfiguration;
@@ -81,7 +83,8 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
     pomFiles.add(dependencyProject.getFile("pom.xml"));
     MutableProjectRegistry state = MavenPluginActivator.getDefault().getMavenProjectManagerImpl().newMutableProjectRegistry();
     state.clear();
-    registryManager.getMaven().execute(false, false, (context, aMonitor) -> {
+    IMaven maven = registryManager.getMaven();
+	MavenImpl.execute(maven, false, false, (context, aMonitor) -> {
       registryManager.refresh(state, pomFiles, aMonitor);
       return null;
     }, monitor);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenInstallFileWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenInstallFileWizard.java
@@ -102,7 +102,7 @@ public class MavenInstallFileWizard extends Wizard implements IImportWizard {
         request.setGoals(Arrays.asList("install:install-file")); //$NON-NLS-1$
         request.setUserProperties(properties);
         request.setExecutionListener(new MonitorExecutionListener(monitor));
-        MavenExecutionResult executionResult = maven.execute(request);
+        MavenExecutionResult executionResult = executionContext.execute(request);
 
         for(Throwable exception : executionResult.getExceptions()) {
           log.error(Messages.MavenInstallFileWizard_error + "; " + exception, exception);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -42,6 +42,7 @@ import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsProblem;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 
@@ -55,7 +56,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
  * @author igor
  * @noimplement This interface is not intended to be implemented by clients.
  */
-public interface IMaven {
+public interface IMaven extends IMavenExecutionContextFactory {
 
   // POM Model read/write operations
 
@@ -117,9 +118,14 @@ public interface IMaven {
   // execution
 
   /**
+   * @deprecated replaced with direct usage of {@link IMavenExecutionContext} see for example
+   *             {@link IMavenExecutionContext#join()}
    * @since 1.4
    */
-  void execute(MavenProject project, MojoExecution execution, IProgressMonitor monitor) throws CoreException;
+  @Deprecated(forRemoval = true)
+  default void execute(MavenProject project, MojoExecution execution, IProgressMonitor monitor) throws CoreException {
+    IMavenExecutionContext.join(this).execute(project, execution, monitor);
+  }
 
   /**
    * @since 1.4
@@ -237,27 +243,28 @@ public interface IMaven {
    * return context.execute(callable, monitor);
    * </pre>
    *
+   * @deprecated should be replaced with the fully equivalent code mentioned in this javadoc, e.g. inside a private
+   *             util method
    * @since 1.4
    */
-  <V> V execute(boolean offline, boolean forceDependencyUpdate, ICallable<V> callable, IProgressMonitor monitor)
-      throws CoreException;
+  @Deprecated(forRemoval = true)
+  default <V> V execute(boolean offline, boolean forceDependencyUpdate, ICallable<V> callable, IProgressMonitor monitor)
+      throws CoreException {
+    return MavenImpl.execute(this, offline, forceDependencyUpdate, callable, monitor);
+  }
 
   /**
    * Either joins existing session or starts new session with default configuration and executes the callable in the
    * context of the session.
    *
+   * @deprecated replaced with direct usage of {@link IMavenExecutionContext} see for example
+   *             {@link IMavenExecutionContext#join()}
    * @since 1.4
    */
-  <V> V execute(ICallable<V> callable, IProgressMonitor monitor) throws CoreException;
-
-  /**
-   * Execute the given {@link MavenExecutionRequest} in the context of m2eclipse and return the result, this could be
-   * seen as an embedded run of the maven cli, at least it tries to replicate as much as possible from that.
-   * 
-   * @param request a {@link MavenExecutionRequest}
-   * @return the result of the execution
-   */
-  MavenExecutionResult execute(MavenExecutionRequest request);
+  @Deprecated(forRemoval = true)
+  default <V> V execute(ICallable<V> callable, IProgressMonitor monitor) throws CoreException {
+    return IMavenExecutionContext.join(this).execute(callable, monitor);
+  }
 
   /**
    * Creates and returns new global maven execution context. such a context is suitable if one likes to perform some

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContextFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContextFactory.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.embedder;
+
+import org.eclipse.core.runtime.CoreException;
+
+
+/**
+ * a {@link IMavenExecutionContextFactory} is a supplier for new {@link IMavenExecutionContext}s
+ *
+ */
+public interface IMavenExecutionContextFactory {
+
+  /**
+   * @return a fresh {@link IMavenExecutionContext}
+   * @throws CoreException
+   */
+  IMavenExecutionContext createExecutionContext() throws CoreException;
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -139,7 +139,7 @@ public class ProjectConfigurationManager
       throws CoreException {
 
     // overall execution context to share repository session data and cache for all projects
-    return maven.execute((context, m) -> {
+    return IMavenExecutionContext.join(maven).execute((context, m) -> {
       SubMonitor progress = SubMonitor.convert(m, Messages.ProjectConfigurationManager_task_importing, 100);
       long t1 = System.currentTimeMillis();
       List<IMavenProjectImportResult> result = new ArrayList<>();
@@ -336,7 +336,7 @@ public class ProjectConfigurationManager
   public Map<String, IStatus> updateProjectConfiguration(MavenUpdateRequest request, boolean updateConfiguration,
       boolean cleanProjects, boolean refreshFromLocal, IProgressMonitor monitor) {
     try {
-      return maven.execute(request.isOffline(), request.isForceDependencyUpdate(),
+      return MavenImpl.execute(maven, request.isOffline(), request.isForceDependencyUpdate(),
           (context, m) -> updateProjectConfiguration0(request.getPomFiles(), updateConfiguration, cleanProjects,
               refreshFromLocal, m),
           monitor);
@@ -489,7 +489,7 @@ public class ProjectConfigurationManager
   public void enableMavenNature(IProject project, ResolverConfiguration configuration, IProgressMonitor monitor)
       throws CoreException {
     monitor.subTask(Messages.ProjectConfigurationManager_task_enable_nature);
-    maven.execute(new AbstractRunnable() {
+    IMavenExecutionContext.join(maven).execute(new AbstractRunnable() {
       @Override
       protected void run(IMavenExecutionContext context, IProgressMonitor monitor) throws CoreException {
         enableBasicMavenNature(project, configuration, monitor);
@@ -747,7 +747,9 @@ public class ProjectConfigurationManager
   public List<IProject> createArchetypeProjects(IPath location, Archetype archetype, String groupId, String artifactId,
       String version, String javaPackage, Properties properties, ProjectImportConfiguration configuration,
       IProjectCreationListener listener, IProgressMonitor monitor) throws CoreException {
-    return maven.execute((context, m) -> createArchetypeProjects0(location, archetype, groupId, artifactId, version,
+    return IMavenExecutionContext.join(maven)
+        .execute((context, m) -> createArchetypeProjects0(location, archetype, groupId,
+        artifactId, version,
         javaPackage, properties, configuration, listener, m), monitor);
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryRefreshJob.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryRefreshJob.java
@@ -41,9 +41,11 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 
+import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.Messages;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.internal.jobs.IBackgroundProcessingQueue;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
 
@@ -63,6 +65,9 @@ public class ProjectRegistryRefreshJob extends Job implements IResourceChangeLis
 
   @Reference
   private IMavenConfiguration mavenConfiguration;
+
+  @Reference
+  private IMaven maven;
 
   public ProjectRegistryRefreshJob() {
     super(Messages.ProjectRegistryRefreshJob_title);
@@ -96,7 +101,7 @@ public class ProjectRegistryRefreshJob extends Job implements IResourceChangeLis
     }
 
     try (MutableProjectRegistry newState = manager.newMutableProjectRegistry()) {
-      manager.getMaven().execute((context, theMonitor) -> {
+      maven.createExecutionContext().execute((context, theMonitor) -> {
         // group requests
         Set<IFile> offlineForceDependencyUpdate = new HashSet<>();
         Set<IFile> offlineNotForceDependencyUpdate = new HashSet<>();
@@ -121,8 +126,9 @@ public class ProjectRegistryRefreshJob extends Job implements IResourceChangeLis
         if(theMonitor.isCanceled()) {
           throw new OperationCanceledException();
         }
+        IMaven maven = manager.getMaven();
         if(!offlineForceDependencyUpdate.isEmpty()) {
-          manager.getMaven().execute(true, true, (aContext, aMonitor) -> {
+          MavenImpl.execute(maven, true, true, (aContext, aMonitor) -> {
             manager.refresh(newState, offlineForceDependencyUpdate, aMonitor);
             return null;
           }, theMonitor);
@@ -132,7 +138,7 @@ public class ProjectRegistryRefreshJob extends Job implements IResourceChangeLis
           throw new OperationCanceledException();
         }
         if(!offlineNotForceDependencyUpdate.isEmpty()) {
-          manager.getMaven().execute(true, false, (aContext, aMonitor) -> {
+          MavenImpl.execute(maven, true, false, (aContext, aMonitor) -> {
             manager.refresh(newState, offlineNotForceDependencyUpdate, aMonitor);
             return null;
           }, theMonitor);
@@ -142,7 +148,7 @@ public class ProjectRegistryRefreshJob extends Job implements IResourceChangeLis
           throw new OperationCanceledException();
         }
         if(!notOfflineForceDependencyUpdate.isEmpty()) {
-          manager.getMaven().execute(false, true, (aContext, aMonitor) -> {
+          MavenImpl.execute(maven, false, true, (aContext, aMonitor) -> {
             manager.refresh(newState, notOfflineForceDependencyUpdate, aMonitor);
             return null;
           }, theMonitor);
@@ -152,7 +158,7 @@ public class ProjectRegistryRefreshJob extends Job implements IResourceChangeLis
           throw new OperationCanceledException();
         }
         if(!notOfflineNotForceDependencyUpdate.isEmpty()) {
-          manager.getMaven().execute(false, false, (aContext, aMonitor) -> {
+          MavenImpl.execute(maven, false, false, (aContext, aMonitor) -> {
             manager.refresh(newState, notOfflineNotForceDependencyUpdate, aMonitor);
             return null;
           }, theMonitor);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -32,6 +32,7 @@ import org.eclipse.m2e.core.embedder.ArtifactRef;
 import org.eclipse.m2e.core.embedder.ArtifactRepositoryRef;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContextFactory;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 
@@ -42,7 +43,7 @@ import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
  * @noimplement This interface is not intended to be implemented by clients.
  * @author Igor Fedorenko
  */
-public interface IMavenProjectFacade {
+public interface IMavenProjectFacade extends IMavenExecutionContextFactory {
 
   /**
    * Returns project relative paths of resource directories

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/MojoExecutionBuildParticipant.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/MojoExecutionBuildParticipant.java
@@ -20,8 +20,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 import org.apache.maven.plugin.MojoExecution;
 
-import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 
 /**
@@ -50,9 +49,8 @@ public class MojoExecutionBuildParticipant extends AbstractBuildParticipant2 {
   @Override
   public Set<IProject> build(int kind, IProgressMonitor monitor) throws Exception {
     if(appliesToBuildKind(kind)) {
-      IMaven maven = MavenPlugin.getMaven();
-
-      maven.execute(getMavenProjectFacade().getMavenProject(), getMojoExecution(), monitor);
+      IMavenProjectFacade projectFacade = getMavenProjectFacade();
+      projectFacade.createExecutionContext().execute(projectFacade.getMavenProject(), getMojoExecution(), monitor);
     }
     return null;
   }

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/MavenDiscoveryService.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/MavenDiscoveryService.java
@@ -55,6 +55,7 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingResult;
 import org.eclipse.m2e.core.internal.lifecyclemapping.MappingMetadataSource;

--- a/org.eclipse.m2e.editor.lemminx/.classpath
+++ b/org.eclipse.m2e.editor.lemminx/.classpath
@@ -7,5 +7,5 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -52,6 +53,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
@@ -158,8 +160,15 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
   public IRuntimeClasspathEntry[] resolveClasspath(final IRuntimeClasspathEntry[] entries,
       final ILaunchConfiguration configuration) throws CoreException {
     IProgressMonitor monitor = new NullProgressMonitor(); // XXX
-    return MavenPlugin.getMaven().execute((context, monitor1) -> resolveClasspath0(entries, configuration, monitor1),
-        monitor);
+    IJavaProject javaProject = JavaRuntime.getJavaProject(configuration);
+    IMavenProjectFacade projectFacade = Adapters.adapt(javaProject.getProject(), IMavenProjectFacade.class);
+    IMavenExecutionContext context;
+    if(projectFacade == null) {
+      context = IMavenExecutionContext.join(MavenPlugin.getMaven());
+    } else {
+      context = projectFacade.createExecutionContext();
+    }
+    return context.execute((ctx, monitor1) -> resolveClasspath0(entries, configuration, monitor1), monitor);
   }
 
   IRuntimeClasspathEntry[] resolveClasspath0(IRuntimeClasspathEntry[] entries, ILaunchConfiguration configuration,

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/ExcludeArtifactRefactoring.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/exclude/ExcludeArtifactRefactoring.java
@@ -46,6 +46,7 @@ import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.ui.internal.editing.AddDependencyOperation;
 import org.eclipse.m2e.core.ui.internal.editing.AddExclusionOperation;

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/MavenRunner.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/MavenRunner.java
@@ -37,7 +37,7 @@ public class MavenRunner extends BlockJUnit4ClassRunner {
     return new Statement() {
       @SuppressWarnings("synthetic-access")
       public void evaluate() throws Throwable {
-        Throwable catchedThrowable = MavenPlugin.getMaven().execute((c, m) -> {
+        Throwable catchedThrowable = MavenPlugin.getMaven().createExecutionContext().execute((c, m) -> {
           try {
             MavenRunner.super.methodInvoker(method, test);
           } catch(Throwable ex) {


### PR DESCRIPTION
This is archived by two ways:

1) IMavenProjectFacade now has a method to create an execution from it
2) IMavenExecutionContext now has a method join/canJoin

That way we don't need IMaven to perform what
IMavenExecutionContext#join now offers and we can execute without
reference IMaven as it actually only delegates to the
IMavenExecutionContext.

Existing methods are now marked for removal as they are probably widely
used.

See also https://github.com/eclipse-m2e/m2e-core/discussions/710

this replaces https://github.com/eclipse-m2e/m2e-core/pull/719