### PR TITLE
Remove IMavenExecutionContext.join()

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -43,7 +43,6 @@ import org.apache.maven.settings.building.SettingsProblem;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
-import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 
 /**
@@ -124,7 +123,8 @@ public interface IMaven extends IMavenExecutionContextFactory {
    */
   @Deprecated(forRemoval = true)
   default void execute(MavenProject project, MojoExecution execution, IProgressMonitor monitor) throws CoreException {
-    IMavenExecutionContext.join(this).execute(project, execution, monitor);
+    IMavenExecutionContext.getThreadContext().orElseGet(this::createExecutionContext).execute(project, execution,
+        monitor);
   }
 
   /**
@@ -261,18 +261,8 @@ public interface IMaven extends IMavenExecutionContextFactory {
    */
   @Deprecated(forRemoval = true)
   default <V> V execute(ICallable<V> callable, IProgressMonitor monitor) throws CoreException {
-    return IMavenExecutionContext.join(this).execute(callable, monitor);
+    return IMavenExecutionContext.getThreadContext().orElseGet(this::createExecutionContext).execute(callable, monitor);
   }
-
-  /**
-   * Creates and returns new global maven execution context. such a context is suitable if one likes to perform some
-   * action without a project, this is similar to calling maven but without a pom.xml If you want to execute in the
-   * context of a project (e.g. to support project scoped extensions) you should use
-   * {@link IMavenProjectFacade#createExecutionContext()} instead.
-   *
-   * @since 1.4
-   */
-  IMavenExecutionContext createExecutionContext() throws CoreException;
 
   /**
    * Lookup a component from the embedded PlexusContainer.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
@@ -14,11 +14,11 @@
 package org.eclipse.m2e.core.embedder;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Status;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -29,7 +29,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 
 import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
-import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
 
@@ -138,23 +137,12 @@ public interface IMavenExecutionContext {
   ProjectBuildingRequest newProjectBuildingRequest();
 
   /**
-   * Either join the currents thread {@link IMavenExecutionContext} or creates a fresh one from the supplied factory if
-   * this thread is currently not executing anything. Be aware that because of this might return an already executing
-   * context, this context should not be configured in any way, use {@link IMaven#createExecutionContext()} or
-   * {@link IMavenProjectFacade#createExecutionContext()} to create a specific context that could be configured.
-   * 
-   * @return a {@link IMavenExecutionContext} that could be used for execution
-   * @throws CoreException
+   * @return the IMavenExecutionContext already in use for current thread, or {@link Optional#empty()} if absent.
+   * @since 2.0
    */
-  static IMavenExecutionContext join(IMavenExecutionContextFactory factory) throws CoreException {
-    IMavenExecutionContext context = MavenExecutionContext.getThreadContext();
-    if(context == null) {
-      if(factory == null) {
-        throw new CoreException(Status.error("Nothing to join and no factory given!"));
-      }
-      return factory.createExecutionContext();
-    }
-    return context;
+  static Optional<IMavenExecutionContext> getThreadContext() {
+    return Optional.ofNullable(MavenExecutionContext.getThreadContext());
   }
+
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContextFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContextFactory.java
@@ -10,19 +10,16 @@
  *******************************************************************************/
 package org.eclipse.m2e.core.embedder;
 
-import org.eclipse.core.runtime.CoreException;
-
-
 /**
  * a {@link IMavenExecutionContextFactory} is a supplier for new {@link IMavenExecutionContext}s
- *
+ * 
+ * @since 2.0
  */
 public interface IMavenExecutionContextFactory {
 
   /**
    * @return a fresh {@link IMavenExecutionContext}
-   * @throws CoreException
    */
-  IMavenExecutionContext createExecutionContext() throws CoreException;
+  IMavenExecutionContext createExecutionContext();
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -139,7 +139,7 @@ public class ProjectConfigurationManager
       throws CoreException {
 
     // overall execution context to share repository session data and cache for all projects
-    return IMavenExecutionContext.join(maven).execute((context, m) -> {
+    return IMavenExecutionContext.getThreadContext().orElseGet(maven::createExecutionContext).execute((context, m) -> {
       SubMonitor progress = SubMonitor.convert(m, Messages.ProjectConfigurationManager_task_importing, 100);
       long t1 = System.currentTimeMillis();
       List<IMavenProjectImportResult> result = new ArrayList<>();
@@ -489,7 +489,7 @@ public class ProjectConfigurationManager
   public void enableMavenNature(IProject project, ResolverConfiguration configuration, IProgressMonitor monitor)
       throws CoreException {
     monitor.subTask(Messages.ProjectConfigurationManager_task_enable_nature);
-    IMavenExecutionContext.join(maven).execute(new AbstractRunnable() {
+    IMavenExecutionContext.getThreadContext().orElseGet(maven::createExecutionContext).execute(new AbstractRunnable() {
       @Override
       protected void run(IMavenExecutionContext context, IProgressMonitor monitor) throws CoreException {
         enableBasicMavenNature(project, configuration, monitor);
@@ -747,7 +747,7 @@ public class ProjectConfigurationManager
   public List<IProject> createArchetypeProjects(IPath location, Archetype archetype, String groupId, String artifactId,
       String version, String javaPackage, Properties properties, ProjectImportConfiguration configuration,
       IProjectCreationListener listener, IProgressMonitor monitor) throws CoreException {
-    return IMavenExecutionContext.join(maven)
+    return IMavenExecutionContext.getThreadContext().orElseGet(maven::createExecutionContext)
         .execute((context, m) -> createArchetypeProjects0(location, archetype, groupId,
         artifactId, version,
         javaPackage, properties, configuration, listener, m), monitor);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -141,14 +141,6 @@ public interface IMavenProjectFacade extends IMavenExecutionContextFactory {
   Set<ArtifactRepositoryRef> getPluginArtifactRepositoryRefs();
 
   /**
-   * Creates a new execution context that is one suitable to execute in the context of this facade, that is it might
-   * include project specific extensions.
-   * 
-   * @return a new execution context for this facade
-   */
-  IMavenExecutionContext createExecutionContext();
-
-  /**
    * Gets an access to a (possibly project specific) {@link IMaven} instance,
    * this is the same instance that is used to create new {@link IMavenExecutionContext}s
    * see {@link #createExecutionContext()}

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.launching,
  org.eclipse.core.resources,
  org.eclipse.m2e.maven.runtime;bundle-version="1.16.0",
- org.eclipse.m2e.core;bundle-version="1.16.0"
+ org.eclipse.m2e.core;bundle-version="2.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.jdt.MavenJdtPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -164,7 +164,7 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
     IMavenProjectFacade projectFacade = Adapters.adapt(javaProject.getProject(), IMavenProjectFacade.class);
     IMavenExecutionContext context;
     if(projectFacade == null) {
-      context = IMavenExecutionContext.join(MavenPlugin.getMaven());
+      context = IMavenExecutionContext.getThreadContext().orElseGet(MavenPlugin.getMaven()::createExecutionContext);
     } else {
       context = projectFacade.createExecutionContext();
     }


### PR DESCRIPTION
It seems better to let consumers take responsibility of which context to
use on their hand, so let's not give too much help in avoiding to deal
with this responsibility.