### PR TITLE
Reduce dependency to maven archetype runtime from m2e.core

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -97,8 +97,8 @@
 						<![CDATA[
 							-exportcontents: \
 								META-INF.plexus;-noimport:=true;x-internal:=true,\
-								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;x-internal:=true,\
-								org.codehaus.plexus.velocity;provider=m2e;mandatory:=provider;x-internal:=true
+								org.apache.maven.archetype.*,\
+								org.codehaus.plexus.velocity
 							Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)"
 						]]>
 						</bnd>

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.osgi;bundle-version="3.10.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.16.0",
- org.eclipse.m2e.archetype.common;bundle-version="1.16.0",
  org.eclipse.m2e.workspace.cli;bundle-version="0.1.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources;bundle-version="3.9.0",
@@ -53,6 +52,13 @@ Export-Package: org.eclipse.m2e.core,
 MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.core
 Import-Package: javax.inject;version="1.0.0",
+ org.apache.maven.archetype,
+ org.apache.maven.archetype.catalog,
+ org.apache.maven.archetype.catalog.io.xpp3,
+ org.apache.maven.archetype.common,
+ org.apache.maven.archetype.exception,
+ org.apache.maven.archetype.metadata,
+ org.apache.maven.archetype.source,
  org.slf4j;version="1.6.2"
 Automatic-Module-Name: org.eclipse.m2e.core
 Service-Component: OSGI-INF/org.eclipse.m2e.core.embedder.MavenModelManager.xml,


### PR DESCRIPTION
Use Import-Package to allow multiple providers.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>