### PR TITLE
Remove IMavenProjectFacade.getMaven()

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -537,8 +537,14 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     return new MavenExecutionContext((MavenImpl) getMaven(), this);
   }
 
-  @Override
-  public IMaven getMaven() {
+  /**
+   * Gets an access to a (possibly project specific) {@link IMaven} instance,
+   * this is the same instance that is used to create new {@link IMavenExecutionContext}s
+   * see {@link #createExecutionContext()}
+   * 
+   * @return a Maven instance, configured according to this project
+   */
+  private IMaven getMaven() {
     return manager.getMaven();
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -30,8 +30,6 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.embedder.ArtifactRef;
 import org.eclipse.m2e.core.embedder.ArtifactRepositoryRef;
-import org.eclipse.m2e.core.embedder.IMaven;
-import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContextFactory;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -139,15 +137,6 @@ public interface IMavenProjectFacade extends IMavenExecutionContextFactory {
   Set<ArtifactRepositoryRef> getArtifactRepositoryRefs();
 
   Set<ArtifactRepositoryRef> getPluginArtifactRepositoryRefs();
-
-  /**
-   * Gets an access to a (possibly project specific) {@link IMaven} instance,
-   * this is the same instance that is used to create new {@link IMavenExecutionContext}s
-   * see {@link #createExecutionContext()}
-   * 
-   * @return a Maven instance, configured according to this project
-   */
-  IMaven getMaven();
 
   /**
    * Returns fully setup MojoExecution instance bound to project build lifecycle that matches provided mojoExecutionKey.


### PR DESCRIPTION
This method is not useful in API at the moment, and it seems like the
getExecuutionContext would be a better entry point to retrieve the
underlying IMaven instance/installation which can be shared across
multiple contexts.