### PR TITLE
Update to Maven Archetype 3.2.1

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -19,15 +19,13 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-	<version>1.18.2-SNAPSHOT</version>
+	<version>3.2.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>M2E Maven Archetype Common</name>
 
 	<properties>
-		<archetype-common.version>2.4</archetype-common.version>
-		<dom4j.version>2.1.3</dom4j.version>
-		<commons-collections.version>3.2.2</commons-collections.version>
+		<archetype-common.version>3.2.1</archetype-common.version>
 	</properties>
 
 	<dependencies>
@@ -39,50 +37,42 @@
 				<!-- Excluded dependencies are fulfilled via the OSGi requirements specified below as Import-Package/Require-Bundle and
 					therefore don't have to be embedded. -->
 				<exclusion>
-					<!-- there is newer velocity with different groupId that we want -->
-					<artifactId>velocity</artifactId>
-					<groupId>velocity</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>plexus-container-default</artifactId>
-					<groupId>org.codehaus.plexus</groupId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.sonatype.sisu</groupId>
-					<artifactId>sisu-inject-plexus</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>dom4j</groupId>
-					<artifactId>dom4j</artifactId>
+					<groupId>com.ibm.icu</groupId>
+					<artifactId>icu4j</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-project</artifactId>
+					<artifactId>maven-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.maven</groupId>
+					<artifactId>maven-artifact</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.maven</groupId>
 					<artifactId>maven-model</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>org.apache.maven</groupId>
+					<artifactId>maven-plugin-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.maven.shared</groupId>
+					<artifactId>maven-shared-utils</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
-					<artifactId>plexus-component-annotations</artifactId>
+					<artifactId>plexus-classworlds</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
 					<artifactId>plexus-utils</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.plexus</groupId>
+					<artifactId>plexus-component-annotations</artifactId>
+				</exclusion>
 			</exclusions>
-		</dependency>
-		<!-- Transitive dependencies that are replaced with more recent version -->
-		<dependency>
-			<groupId>org.dom4j</groupId>
-			<artifactId>dom4j</artifactId>
-			<version>${dom4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
-			<version>${commons-collections.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -97,9 +87,10 @@
 						<![CDATA[
 							-exportcontents: \
 								META-INF.plexus;-noimport:=true;x-internal:=true,\
-								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;x-internal:=true,\
-								org.codehaus.plexus.velocity;provider=m2e;mandatory:=provider;x-internal:=true
-							Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)"
+								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;version="${archetype-common.version}";x-friends:="org.eclipse.m2e.core.ui"
+							Require-Bundle: \
+								org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)",\
+								com.ibm.icu
 						]]>
 						</bnd>
 					</configuration>

--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -18,7 +18,7 @@
 		<version>1.16.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>org.eclipse.m2e.archetype.common</artifactId>
+	<artifactId>org.eclipse.m2e.archetype.common</artifactId><!-- TODO: rename to org.eclipse.m2e.archetype -->
 	<version>3.2.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
@@ -31,46 +31,23 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven.archetype</groupId>
-			<artifactId>archetype-common</artifactId>
+			<artifactId>archetype-catalog</artifactId>
 			<version>${archetype-common.version}</version>
 			<exclusions>
-				<!-- Excluded dependencies are fulfilled via the OSGi requirements specified below as Import-Package/Require-Bundle and
-					therefore don't have to be embedded. -->
-				<exclusion>
-					<groupId>com.ibm.icu</groupId>
-					<artifactId>icu4j</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-artifact</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-model</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-plugin-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven.shared</groupId>
-					<artifactId>maven-shared-utils</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.plexus</groupId>
-					<artifactId>plexus-classworlds</artifactId>
-				</exclusion>
 				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
 					<artifactId>plexus-utils</artifactId>
 				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.archetype</groupId>
+			<artifactId>archetype-descriptor</artifactId>
+			<version>${archetype-common.version}</version>
+			<exclusions>
 				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
-					<artifactId>plexus-component-annotations</artifactId>
+					<artifactId>plexus-utils</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -84,9 +61,8 @@
 					<artifactId>bnd-maven-plugin</artifactId>
 					<configuration>
 						<bnd>
-						<![CDATA[
+							<![CDATA[
 							-exportcontents: \
-								META-INF.plexus;-noimport:=true;x-internal:=true,\
 								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;version="${archetype-common.version}";x-friends:="org.eclipse.m2e.core.ui"
 							Require-Bundle: \
 								org.eclipse.m2e.maven.runtime;bundle-version="[1.18.0,1.19.0)",\

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/archetype/ArchetypeManager.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/archetype/ArchetypeManager.java
@@ -181,11 +181,12 @@ public class ArchetypeManager {
 
     return maven.createExecutionContext().execute((context, monitor1) -> {
       ArtifactRepository localRepository = context.getLocalRepository();
-      if(aaMgr.isFileSetArchetype(groupId, artifactId, version, null, localRepository, repositories)) {
+      if(aaMgr.isFileSetArchetype(groupId, artifactId, version, null, localRepository, repositories,
+          context.newProjectBuildingRequest())) {
         ArchetypeDescriptor descriptor;
         try {
           descriptor = aaMgr.getFileSetArchetypeDescriptor(groupId, artifactId, version, null, localRepository,
-              repositories);
+              repositories, context.newProjectBuildingRequest());
         } catch(UnknownArchetype ex) {
           throw new CoreException(Status.error("UnknownArchetype", ex));
         }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArchetypePage.java
@@ -84,6 +84,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.project.ProjectBuildingRequest;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
@@ -760,7 +761,13 @@ public class MavenProjectWizardArchetypePage extends AbstractMavenWizardPage {
             archetype.setRepository(repositoryUrl);
             org.apache.maven.archetype.ArchetypeManager archetyper = M2EUIPluginActivator.getDefault()
                 .getArchetypeManager().getArchetyper();
-            archetyper.updateLocalCatalog(archetype);
+            maven.createExecutionContext().execute((ctx, m) -> {
+              ProjectBuildingRequest request = ctx.newProjectBuildingRequest();
+              archetyper.updateLocalCatalog(request, archetype);
+              return null;
+            }, monitor);
+
+
 
             archetypesCache.clear();
 


### PR DESCRIPTION
This draft provides an intermediate state of the migration to Archetype 3.2.1.
The dependencies are updated and the code compiles.
I also tested remote archtype catalogs and they worked well. The defaultLocal catalog failed in my test and arbitrary local catalog is not yet tested.

I pushed this branch into the m2e-core repo directly. So @laeubi if you want to use this and it is suitable, you can directly work on this branch.

This also includes some parts of https://github.com/eclipse-m2e/m2e-core/pull/735 and fixes restriction warnings in m2e.core and m2e.core.ui.