### PR TITLE
Add support for maven-rooted PlexusContainer

### DIFF
--- a/org.eclipse.m2e.core.tests/.classpath
+++ b/org.eclipse.m2e.core.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless/.mvn/extensions.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>2.7.3</version>
+<!-- 		<version>${tycho.version}</version> -->
+	</extension>
+</extensions>

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless/bundle/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless/bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle
+Bundle-SymbolicName: my.bundle
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: my.bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless/bundle/build.properties
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless/bundle/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless/pom.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>tycho-pomless</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>2.7.3</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package org.eclipse.m2e.core;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -18,6 +19,7 @@ import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,9 +33,21 @@ public class ExtensionsTest extends AbstractMavenProjectTestCase {
 		Assert.assertNotNull(facade);
 		Collection<AbstractMavenLifecycleParticipant> buildParticipants = facade.createExecutionContext()
 				.execute((context, monitor) -> {
-			assertNotNull("context has no project!", context.getSession().getCurrentProject());
-			return context.lookupExtensions(AbstractMavenLifecycleParticipant.class);
-		}, monitor);
+					assertNotNull("context has no project!", context.getSession().getCurrentProject());
+					return context.getComponentLookup().lookupCollection(AbstractMavenLifecycleParticipant.class);
+				}, monitor);
 		assertTrue("the must be at laest one build participant!", buildParticipants.size() > 0);
+	}
+
+	@Test
+	public void testCoreExtension() throws Exception {
+		boolean skipSanityCheck = true; // TODO this should also work! But not part of this change
+		IProject[] projects = importProjects("resources/projects/pomless/", new String[] { "bundle/pom.xml" },
+				new ResolverConfiguration(), skipSanityCheck);
+		waitForJobsToComplete(monitor);
+		assertEquals(1, projects.length);
+		IProject project = projects[0];
+		assertEquals("my.bundle", project.getName());
+		assertNotNull(project.getNature("org.eclipse.m2e.core.maven2Nature"));
 	}
 }

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -55,7 +55,9 @@ Import-Package: javax.inject;version="1.0.0",
  org.slf4j;version="1.6.2"
 Automatic-Module-Name: org.eclipse.m2e.core
 Service-Component: OSGI-INF/org.eclipse.m2e.core.embedder.MavenModelManager.xml,
+ OSGI-INF/org.eclipse.m2e.core.internal.embedder.EclipseLoggerManager.xml,
  OSGI-INF/org.eclipse.m2e.core.internal.embedder.MavenImpl.xml,
+ OSGI-INF/org.eclipse.m2e.core.internal.embedder.PlexusContainerManager.xml,
  OSGI-INF/org.eclipse.m2e.core.internal.index.filter.ArtifactFilterManager.xml,
  OSGI-INF/org.eclipse.m2e.core.internal.launch.MavenRuntimeManagerImpl.xml,
  OSGI-INF/org.eclipse.m2e.core.internal.markers.MavenMarkerManager.xml,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IComponentLookup.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IComponentLookup.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.embedder;
+
+import java.util.Collection;
+
+import org.eclipse.core.runtime.CoreException;
+
+
+/**
+ * A {@link IComponentLookup} looks up a component in a given context
+ * 
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @since 2.0
+ */
+public interface IComponentLookup {
+
+  /**
+   * Lookup a single component from this context.
+   * 
+   * @param clazz the requested role
+   * @return The component instance requested.
+   * @throws CoreException if the requested component is not available
+   */
+  <C> C lookup(Class<C> type) throws CoreException;
+
+  /**
+   * Look up a list of components in a given context
+   * 
+   * @param <C>
+   * @param extensionType
+   * @return a (possibly empty) list of the requested components
+   * @throws CoreException
+   */
+  <C> Collection<C> lookupCollection(Class<C> type) throws CoreException;
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -56,7 +56,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
  * @author igor
  * @noimplement This interface is not intended to be implemented by clients.
  */
-public interface IMaven {
+public interface IMaven extends IComponentLookup {
 
   // POM Model read/write operations
 
@@ -229,8 +229,6 @@ public interface IMaven {
    */
   ClassLoader getProjectRealm(MavenProject project);
 
-  // execution context
-
   /**
    * This is convenience method fully equivalent to
    *
@@ -241,8 +239,8 @@ public interface IMaven {
    * return context.execute(callable, monitor);
    * </pre>
    *
-   * @deprecated should be replaced with the fully equivalent code mentioned in this javadoc, e.g. inside a private
-   *             util method
+   * @deprecated should be replaced with the fully equivalent code mentioned in this javadoc, e.g. inside a private util
+   *             method
    * @since 1.4
    */
   @Deprecated(forRemoval = true)
@@ -262,17 +260,6 @@ public interface IMaven {
   default <V> V execute(ICallable<V> callable, IProgressMonitor monitor) throws CoreException {
     return IMavenExecutionContext.getThreadContext().orElseGet(this::createExecutionContext).execute(callable, monitor);
   }
-
-  /**
-   * Lookup a component from the embedded PlexusContainer.
-   * @param clazz the requested role
-   * @return The component instance requested.
-   * @throws CoreException if the requested component is not available
-   *
-   * @since 1.10
-   */
-  <T> T lookup(Class<T> clazz) throws CoreException;
-
 
   /**
    * Creates and returns new, possibly nested, maven execution context for this Maven embedder.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.m2e.core.embedder;
 
-import java.util.Collection;
 import java.util.Optional;
 
 import org.eclipse.aether.RepositorySystemSession;
@@ -104,16 +103,6 @@ public interface IMavenExecutionContext {
   MavenExecutionResult execute(MavenExecutionRequest request);
 
   /**
-   * Look up the given extension type, this requires an active execution
-   * 
-   * @param <Extension>
-   * @param extensionType
-   * @throws IllegalStateException if called outside of any execute call
-   * @return
-   */
-  <Extension> Collection<Extension> lookupExtensions(Class<Extension> extensionType) throws CoreException;
-
-  /**
    * @throws IllegalStateException if called outside of {@link #execute(MavenProject,ICallable, IProgressMonitor)}
    * @since 1.4
    */
@@ -135,6 +124,12 @@ public interface IMavenExecutionContext {
    * @since 1.4
    */
   ProjectBuildingRequest newProjectBuildingRequest();
+
+  /**
+   * @return the {@link IComponentLookup} to use for this context
+   * @throws IllegalStateException if called outside of any execute call
+   */
+  IComponentLookup getComponentLookup();
 
   /**
    * Get the current thread context.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -65,15 +67,20 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 
+import org.codehaus.plexus.PlexusContainer;
+
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.building.FileModelSource;
+import org.apache.maven.model.building.ModelProcessor;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.Messages;
+import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
@@ -91,20 +98,52 @@ public class MavenModelManager {
   private IMavenProjectRegistry projectManager;
 
   @Reference
+  private PlexusContainerManager containerManager;
+
+  @Reference
   private IMaven maven;
 
   public org.apache.maven.model.Model readMavenModel(InputStream reader) throws CoreException {
     return maven.readModel(reader);
   }
 
+  /**
+   * Read the model from the provided pom file (might not exits) pointer
+   * 
+   * @param pomFile the file pointer
+   * @return a maven model, or <code>null</code> if the pointer do not point to any valid maven directory
+   * @throws CoreException if the file points to a valid maven directory but the pom could not be read
+   */
   public org.apache.maven.model.Model readMavenModel(File pomFile) throws CoreException {
-    try (FileInputStream stream = new FileInputStream(pomFile)) {
-      Model model = readMavenModel(stream);
-      model.setPomFile(pomFile);
-      return model;
-    } catch(IOException ex) {
-      throw new CoreException(new Status(IStatus.ERROR, IMavenConstants.PLUGIN_ID, ex.getMessage(), ex));
+
+    if(pomFile.isFile()) {
+      try (FileInputStream stream = new FileInputStream(pomFile)) {
+        Model model = readMavenModel(stream);
+        model.setPomFile(pomFile);
+        return model;
+      } catch(IOException ex) {
+        throw new CoreException(Status.error(ex.getMessage(), ex));
+      }
     }
+    //this might be a polyglot model...
+    File baseDir = pomFile.isDirectory() ? pomFile : pomFile.getParentFile();
+    ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+    try {
+      PlexusContainer plexusContainer = containerManager.aquire(baseDir);
+      Thread.currentThread().setContextClassLoader(plexusContainer.getContainerRealm());
+      ModelProcessor modelProcessor = plexusContainer.lookup(ModelProcessor.class);
+      File pom = modelProcessor.locatePom(baseDir);
+      if(pom != null && pom.isFile()) {
+        Model model = modelProcessor.read(pom, new HashMap<>(Map.of(ModelProcessor.SOURCE, new FileModelSource(pom))));
+        model.setPomFile(pom);
+        return model;
+      }
+    } catch(Exception ex) {
+      throw new CoreException(Status.error(ex.getMessage(), ex));
+    } finally {
+      Thread.currentThread().setContextClassLoader(ccl);
+    }
+    return null;
   }
 
   public org.apache.maven.model.Model readMavenModel(IFile pomFile) throws CoreException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseLoggerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/EclipseLoggerManager.java
@@ -13,8 +13,13 @@
 
 package org.eclipse.m2e.core.internal.embedder;
 
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 import org.codehaus.plexus.logging.AbstractLoggerManager;
 import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
 
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 
@@ -24,12 +29,17 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
  *
  * @author igor
  */
+@Component(service = LoggerManager.class)
 public class EclipseLoggerManager extends AbstractLoggerManager {
 
-  private final EclipseLogger logger;
+  @Reference
+  IMavenConfiguration mavenConfiguration;
 
-  public EclipseLoggerManager(IMavenConfiguration mavenConfiguration) {
-    this.logger = new EclipseLogger(mavenConfiguration);
+  private EclipseLogger logger;
+
+  @Activate
+  void activate() {
+    logger = new EclipseLogger(mavenConfiguration);
   }
 
   @Override

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,10 +36,11 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 
 import org.apache.maven.Maven;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.InvalidRepositoryException;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.cli.configuration.SettingsXmlConfigurationProcessor;
 import org.apache.maven.eventspy.internal.EventSpyDispatcher;
@@ -60,9 +60,13 @@ import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.properties.internal.EnvironmentUtils;
+import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.session.scope.internal.SessionScope;
+import org.apache.maven.settings.Settings;
 
 import org.eclipse.m2e.core.embedder.ICallable;
+import org.eclipse.m2e.core.embedder.IComponentLookup;
+import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
@@ -135,21 +139,23 @@ public class MavenExecutionContext implements IMavenExecutionContext {
       request = DefaultMavenExecutionRequest.copy(parent);
     }
     if(request == null) {
-      request = createExecutionRequest();
+      request = createExecutionRequest(maven.getMavenConfiguration(), maven, maven);
+      request.setBaseDirectory(basedir);
     }
-    request.setMultiModuleProjectDirectory(MavenImpl.computeMultiModuleProjectDirectory(basedir));
+    request.setMultiModuleProjectDirectory(PlexusContainerManager.computeMultiModuleProjectDirectory(basedir));
 
     return request;
   }
 
-  private MavenExecutionRequest createExecutionRequest() throws CoreException {
+  static MavenExecutionRequest createExecutionRequest(IMavenConfiguration mavenConfiguration,
+      IComponentLookup lookup, IMaven maven)
+      throws CoreException {
     MavenExecutionRequest request = new DefaultMavenExecutionRequest();
 
     // this causes problems with unexpected "stale project configuration" error markers
     // need to think how to manage ${maven.build.timestamp} properly inside workspace
     //request.setStartTime( new Date() );
 
-    IMavenConfiguration mavenConfiguration = maven.getMavenConfiguration();
     if(mavenConfiguration.getGlobalSettingsFile() != null) {
       request.setGlobalSettingsFile(new File(mavenConfiguration.getGlobalSettingsFile()));
     }
@@ -159,13 +165,25 @@ public class MavenExecutionContext implements IMavenExecutionContext {
     }
     request.setUserSettingsFile(userSettingsFile);
 
+    Settings settings = maven.getSettings(); //TODO if we could adapt IMavenConfiguration -> Settings we could save the IMaven reference here 
+    //and settings are actually derived from IMavenConfiguration
     try {
-      maven.lookup(MavenExecutionRequestPopulator.class).populateFromSettings(request, maven.getSettings());
+      request = lookup.lookup(MavenExecutionRequestPopulator.class).populateFromSettings(request, settings);
     } catch(MavenExecutionRequestPopulationException ex) {
       throw new CoreException(Status.error(Messages.MavenImpl_error_no_exec_req, ex));
     }
 
-    ArtifactRepository localRepository = maven.getLocalRepository();
+    String localRepositoryPath = settings.getLocalRepository();
+    if(localRepositoryPath == null) {
+      localRepositoryPath = RepositorySystem.defaultUserLocalRepository.getAbsolutePath();
+    }
+
+    ArtifactRepository localRepository;
+    try {
+      localRepository = lookup.lookup(RepositorySystem.class).createLocalRepository(new File(localRepositoryPath));
+    } catch(InvalidRepositoryException ex) {
+      throw new AssertionError("Should never happen!", ex);
+    }
     request.setLocalRepository(localRepository);
     request.setLocalRepositoryPath(localRepository.getBasedir());
     request.setOffline(mavenConfiguration.isOffline());
@@ -179,12 +197,6 @@ public class MavenExecutionContext implements IMavenExecutionContext {
     request.setCacheTransferError(true);
 
     request.setGlobalChecksumPolicy(mavenConfiguration.getGlobalChecksumPolicy());
-    // the right way to disable snapshot update
-    // request.setUpdateSnapshots(false);
-    if(basedir != null) {
-      request.setBaseDirectory(basedir);
-      request.setMultiModuleProjectDirectory(MavenImpl.computeMultiModuleProjectDirectory(basedir));
-    }
     return request;
   }
 
@@ -459,46 +471,52 @@ public class MavenExecutionContext implements IMavenExecutionContext {
   }
 
   @Override
-  public <Extension> Collection<Extension> lookupExtensions(Class<Extension> extensionType) {
-    MavenSession session = getSession();
-    List<MavenProject> projects = session.getProjects();
-    Collection<Extension> extensions = new LinkedHashSet<>();
-    extensions.addAll(lookupList(extensionType));
-    if(projects != null && !projects.isEmpty()) {
-      extensions.addAll(getProjectScopedExtensionComponents(projects, extensionType));
+  public IComponentLookup getComponentLookup() {
+    if(context == null) {
+      throw new IllegalStateException();
     }
-    return extensions;
-  }
-
-  private <Extension> List<Extension> lookupList(Class<Extension> extensionType) {
-    try {
-      return maven.getPlexusContainer().lookupList(extensionType);
-    } catch(CoreException | ComponentLookupException e) {
-      e.printStackTrace();
-      return List.of();
+    if(projectFacade == null) {
+      return maven;
     }
-  }
-
-  private <T> Collection<T> getProjectScopedExtensionComponents(Collection<MavenProject> projects,
-      Class<T> extensionType) {
-
-    Collection<T> result = new LinkedHashSet<>();
-    Collection<ClassLoader> realms = new HashSet<>();
-
-    Thread thread = Thread.currentThread();
-    ClassLoader ccl = thread.getContextClassLoader();
-    try {
-      for(MavenProject project : projects) {
-        ClassLoader projectRealm = project.getClassRealm();
-
-        if(projectRealm != null && realms.add(projectRealm)) {
-          thread.setContextClassLoader(projectRealm);
-          result.addAll(lookupList(extensionType));
+    IComponentLookup projectComponentLookup = projectFacade.getComponentLookup();
+    MavenProject mavenProject = projectFacade.getMavenProject();
+    if(mavenProject == null) {
+      return projectComponentLookup;
+    }
+    //project scoped lookup...
+    return new IComponentLookup() {
+      @Override
+      public <T> T lookup(Class<T> clazz) throws CoreException {
+        Thread thread = Thread.currentThread();
+        ClassLoader ccl = thread.getContextClassLoader();
+        try {
+          ClassLoader projectRealm = mavenProject.getClassRealm();
+          if(projectRealm != null) {
+            thread.setContextClassLoader(projectRealm);
+          }
+          return projectComponentLookup.lookup(clazz);
+        } finally {
+          thread.setContextClassLoader(ccl);
         }
       }
-      return result;
-    } finally {
-      thread.setContextClassLoader(ccl);
-    }
+
+      @Override
+      public <C> Collection<C> lookupCollection(Class<C> type) throws CoreException {
+        Thread thread = Thread.currentThread();
+        ClassLoader ccl = thread.getContextClassLoader();
+        try {
+          ClassRealm projectRealm = mavenProject.getClassRealm();
+          if(projectRealm != null) {
+            thread.setContextClassLoader(projectRealm);
+          }
+          return projectComponentLookup.lookupCollection(type);
+        } finally {
+          thread.setContextClassLoader(ccl);
+        }
+      }
+
+    };
   }
+
+
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -1,0 +1,334 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal.embedder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.logging.LoggerManager;
+
+import org.apache.maven.cli.internal.BootstrapCoreExtensionManager;
+import org.apache.maven.cli.internal.ExtensionResolutionException;
+import org.apache.maven.cli.internal.extension.model.CoreExtension;
+import org.apache.maven.cli.internal.extension.model.io.xpp3.CoreExtensionsXpp3Reader;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.scope.internal.MojoExecutionScopeModule;
+import org.apache.maven.extension.internal.CoreExports;
+import org.apache.maven.extension.internal.CoreExtensionEntry;
+import org.apache.maven.session.scope.internal.SessionScopeModule;
+
+import org.eclipse.m2e.core.embedder.IComponentLookup;
+import org.eclipse.m2e.core.embedder.IMavenConfiguration;
+import org.eclipse.m2e.core.internal.MavenPluginActivator;
+import org.eclipse.m2e.core.internal.Messages;
+
+
+/**
+ * The {@link PlexusContainerManager} takes care about creating and caching {@link PlexusContainer}, code should always
+ * ask the manager instead of caching container instances as if file-system change containers can also change without
+ * notice.
+ */
+@Component(service = PlexusContainerManager.class)
+public class PlexusContainerManager {
+
+  static final String MVN_FOLDER = ".mvn";
+
+  private static final String EXTENSIONS_FILENAME = MVN_FOLDER + "/extensions.xml";
+
+  private static final String CONTAINER_CONFIGURATION_NAME = "maven";
+
+  private static final String MAVEN_EXTENSION_REALM_PREFIX = "maven.ext.";
+
+  private static final String PLEXUS_CORE_REALM = "plexus.core";
+
+  private static final ClassWorld CLASS_WORLD = new ClassWorld(PLEXUS_CORE_REALM, ClassWorld.class.getClassLoader());
+
+  private static final ClassRealm CORE_REALM;
+
+  private static final CoreExtensionEntry CORE_ENTRY;
+
+  private static final AtomicLong REALM_ID_SEQUENCE = new AtomicLong();
+
+  static {
+    try {
+      CORE_REALM = CLASS_WORLD.getRealm(PLEXUS_CORE_REALM);
+      CORE_ENTRY = CoreExtensionEntry.discoverFrom(CORE_REALM);
+    } catch(NoSuchRealmException ex) {
+      throw new AssertionError("Should never happen", ex);
+    }
+  }
+
+  private PlexusContainer nonRootedContainer;
+
+  private final Map<File, PlexusContainer> containerMap = new HashMap<>();
+
+  @Reference
+  private LoggerManager loggerManager;
+
+  @Reference
+  private IMavenConfiguration mavenConfiguration;
+
+  @Deactivate
+  void dispose() {
+    synchronized(containerMap) {
+      containerMap.values().forEach(PlexusContainer::dispose);
+      containerMap.clear();
+      if(nonRootedContainer != null) {
+        nonRootedContainer.dispose();
+        nonRootedContainer = null;
+      }
+    }
+  }
+
+  /**
+   * Performs a cleanup cycle by disposing (and removing) container that are no longer referencing a valid maven root
+   */
+  void cleanup() {
+    synchronized(containerMap) {
+      containerMap.entrySet().removeIf(entry -> {
+        if(!new File(entry.getKey(), MVN_FOLDER).isDirectory()) {
+          entry.getValue().dispose();
+          return true;
+        }
+        return false;
+      });
+    }
+  }
+
+  public PlexusContainer aquire() throws Exception {
+    synchronized(containerMap) {
+      cleanup();
+      if(nonRootedContainer == null) {
+        nonRootedContainer = newPlexusContainer(null, loggerManager, mavenConfiguration);
+      }
+      return nonRootedContainer;
+    }
+  }
+
+  public PlexusContainer aquire(File basedir) throws Exception {
+    File directory = computeMultiModuleProjectDirectory(basedir);
+    if(directory == null) {
+      return aquire();
+    }
+    File canonicalDirectory = directory.getCanonicalFile();
+    synchronized(containerMap) {
+      cleanup();
+      PlexusContainer plexusContainer = containerMap.get(canonicalDirectory);
+      if(plexusContainer == null) {
+        try {
+        containerMap.put(canonicalDirectory,
+            plexusContainer = newPlexusContainer(canonicalDirectory, loggerManager, mavenConfiguration));
+        } catch(ExtensionResolutionException e) {
+          //TODO should we fail or should we return the standard container then and for example create an error marker on the project?
+          CoreExtension extension = e.getExtension();
+          throw new PlexusContainerException("can't create plexus container for basedir = " + basedir.getAbsolutePath()
+              + " because one the extensions " + extension.getGroupId() + ":" + extension.getArtifactId() + ":"
+              + extension.getVersion() + " can't be loaded.", e);
+        }
+      }
+      return plexusContainer;
+    }
+  }
+
+  private static DefaultPlexusContainer newPlexusContainer(File multiModuleProjectDirectory,
+      LoggerManager loggerManager, IMavenConfiguration mavenConfiguration) throws Exception {
+    List<CoreExtensionEntry> extensions = loadCoreExtensions(multiModuleProjectDirectory, loggerManager,
+        mavenConfiguration);
+    List<File> extClassPath = List.of(); //TODO should we allow to set an ext-class path for m2e?
+    ClassRealm containerRealm = setupContainerRealm(extClassPath, extensions);
+
+    ContainerConfiguration cc = new DefaultContainerConfiguration().setClassWorld(CLASS_WORLD).setRealm(containerRealm)
+        .setClassPathScanning(PlexusConstants.SCANNING_INDEX).setAutoWiring(true).setJSR250Lifecycle(true)
+        .setName(CONTAINER_CONFIGURATION_NAME);
+
+    Set<String> exportedArtifacts = new HashSet<>(CORE_ENTRY.getExportedArtifacts());
+    Set<String> exportedPackages = new HashSet<>(CORE_ENTRY.getExportedPackages());
+    for(CoreExtensionEntry extension : extensions) {
+      exportedArtifacts.addAll(extension.getExportedArtifacts());
+      exportedPackages.addAll(extension.getExportedPackages());
+    }
+
+    final CoreExports exports = new CoreExports(containerRealm, exportedArtifacts, exportedPackages);
+
+    DefaultPlexusContainer container = new DefaultPlexusContainer(cc, new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(ILoggerFactory.class).toInstance(LoggerFactory.getILoggerFactory());
+        bind(CoreExports.class).toInstance(exports);
+      }
+    }, new ExtensionModule());
+    container.setLookupRealm(null);
+    Thread thread = Thread.currentThread();
+    ClassLoader ccl = thread.getContextClassLoader();
+    try {
+      thread.setContextClassLoader(container.getContainerRealm());
+      container.setLoggerManager(loggerManager);
+      for(CoreExtensionEntry extension : extensions) {
+        container.discoverComponents(extension.getClassRealm(), new SessionScopeModule(container),
+            new MojoExecutionScopeModule(container));
+      }
+    } finally {
+      thread.setContextClassLoader(ccl);
+    }
+    return container;
+  }
+
+  private static ClassRealm setupContainerRealm(List<File> extClassPath, List<CoreExtensionEntry> extensions)
+      throws Exception {
+    if(extClassPath.isEmpty() && extensions.isEmpty()) {
+      return CORE_REALM;
+    }
+    ClassRealm extRealm = CLASS_WORLD.newRealm(MAVEN_EXTENSION_REALM_PREFIX + REALM_ID_SEQUENCE.getAndIncrement(),
+        null);
+    extRealm.setParentRealm(CORE_REALM);
+    for(File file : extClassPath) {
+      extRealm.addURL(file.toURI().toURL());
+    }
+    for(int i = extensions.size() - 1; i >= 0; i-- ) {
+      CoreExtensionEntry entry = extensions.get(i);
+      Set<String> exportedPackages = entry.getExportedPackages();
+      ClassRealm realm = entry.getClassRealm();
+      for(String exportedPackage : exportedPackages) {
+        extRealm.importFrom(realm, exportedPackage);
+      }
+      if(exportedPackages.isEmpty()) {
+        extRealm.importFrom(realm, realm.getId());
+      }
+    }
+
+    return extRealm;
+  }
+
+  private static List<CoreExtensionEntry> loadCoreExtensions(File multiModuleProjectDirectory,
+      LoggerManager loggerManager, IMavenConfiguration mavenConfiguration) throws Exception {
+    if(multiModuleProjectDirectory == null) {
+      return Collections.emptyList();
+    }
+    File extensionsXml = new File(multiModuleProjectDirectory, EXTENSIONS_FILENAME);
+    if(!extensionsXml.isFile()) {
+      return Collections.emptyList();
+    }
+    List<CoreExtension> extensions;
+    try (InputStream is = new FileInputStream(extensionsXml)) {
+      extensions = new CoreExtensionsXpp3Reader().read(is).getExtensions();
+    }
+    if(extensions.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    ContainerConfiguration cc = new DefaultContainerConfiguration().setClassWorld(CLASS_WORLD).setRealm(CORE_REALM)
+        .setClassPathScanning(PlexusConstants.SCANNING_INDEX).setAutoWiring(true).setJSR250Lifecycle(true)
+        .setName(CONTAINER_CONFIGURATION_NAME);
+
+    DefaultPlexusContainer container = new DefaultPlexusContainer(cc, new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(ILoggerFactory.class).toInstance(LoggerFactory.getILoggerFactory());
+      }
+    });
+
+    Thread thread = Thread.currentThread();
+    ClassLoader ccl = thread.getContextClassLoader();
+    try {
+      container.setLookupRealm(null);
+      container.setLoggerManager(loggerManager);
+      thread.setContextClassLoader(container.getContainerRealm());
+      MavenExecutionRequest request = MavenExecutionContext.createExecutionRequest(mavenConfiguration,
+          new PlexusComponentLookup(container), MavenPluginActivator.getDefault().getMaven());
+      request.setBaseDirectory(multiModuleProjectDirectory);
+      request.setMultiModuleProjectDirectory(multiModuleProjectDirectory);
+      BootstrapCoreExtensionManager resolver = container.lookup(BootstrapCoreExtensionManager.class);
+      return resolver.loadCoreExtensions(request, CORE_ENTRY.getExportedArtifacts(), extensions);
+    } finally {
+      thread.setContextClassLoader(ccl);
+      container.dispose();
+    }
+  }
+
+  private static final class PlexusComponentLookup implements IComponentLookup {
+
+    private PlexusContainer container;
+
+    public PlexusComponentLookup(PlexusContainer container) {
+      this.container = container;
+    }
+
+    @Override
+    public <C> C lookup(Class<C> type) throws CoreException {
+      try {
+        return container.lookup(type);
+      } catch(ComponentLookupException ex) {
+        throw new CoreException(Status.error(Messages.MavenImpl_error_lookup, ex));
+      }
+    }
+
+    @Override
+    public <C> Collection<C> lookupCollection(Class<C> type) {
+      try {
+        return container.lookupList(type);
+      } catch(ComponentLookupException ex) {
+        return List.of();
+      }
+    }
+
+  }
+
+  /**
+   * @param file a base file or directory, may be <code>null</code>
+   * @return the value for `maven.multiModuleProjectDirectory` as defined in Maven launcher
+   */
+  public static File computeMultiModuleProjectDirectory(File file) {
+    if(file == null) {
+      return null;
+    }
+    final File basedir = file.isDirectory() ? file : file.getParentFile();
+    File current = basedir;
+    while(current != null) {
+      if(new File(current, MVN_FOLDER).isDirectory()) {
+        return current;
+      }
+      current = current.getParentFile();
+    }
+    return null;
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -98,6 +98,7 @@ import org.eclipse.m2e.core.internal.URLConnectionCaches;
 import org.eclipse.m2e.core.internal.builder.MavenBuilder;
 import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
+import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingResult;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
@@ -158,6 +159,9 @@ public class ProjectRegistryManager implements ISaveParticipant {
 
   @Reference
   private IMavenConfiguration configuration;
+
+  @Reference
+  private PlexusContainerManager containerManager;
 
   @Reference
   private ProjectRegistryReader stateReader;
@@ -919,7 +923,8 @@ public class ProjectRegistryManager implements ISaveParticipant {
     request.setLocalRepository(getMaven().getLocalRepository());
     request.setWorkspaceReader(getWorkspaceReader(state, pom, resolverConfiguration));
     if(pom != null && pom.getLocation() != null) {
-      request.setMultiModuleProjectDirectory(MavenImpl.computeMultiModuleProjectDirectory(pom.getLocation().toFile()));
+      request.setMultiModuleProjectDirectory(
+          PlexusContainerManager.computeMultiModuleProjectDirectory(pom.getLocation().toFile()));
     }
 
     return request;
@@ -978,6 +983,10 @@ public class ProjectRegistryManager implements ISaveParticipant {
 
   IMaven getMaven() {
     return maven;
+  }
+
+  PlexusContainerManager getContainerManager() {
+    return this.containerManager;
   }
 
   /*package*/MojoExecution setupMojoExecution(MavenProjectFacade projectFacade, MojoExecution mojoExecution,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -30,6 +30,7 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.embedder.ArtifactRef;
 import org.eclipse.m2e.core.embedder.ArtifactRepositoryRef;
+import org.eclipse.m2e.core.embedder.IComponentLookup;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -163,5 +164,12 @@ public interface IMavenProjectFacade {
    * @since 2.0
    */
   IMavenExecutionContext createExecutionContext();
+
+  /**
+   * Returns the component lookup for this projects context. This will include potentially defined
+   * <b>core</b>-extensions, but not <b>project</b>-scoped extensions! If you need project-scoped extensions as well use
+   * {@link #createExecutionContext()};
+   */
+  IComponentLookup getComponentLookup();
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/LocalProjectScanner.java
@@ -123,20 +123,17 @@ public class LocalProjectScanner extends AbstractProjectScanner<MavenProjectInfo
         return null; // we already know this project
         //mkleint: well, if the project is first scanned standalone and later scanned via parent reference, the parent ref gets thrown away??
       }
-
-      File pomFile = new File(baseDir, IMavenConstants.POM_FILE_NAME);
-      if(!pomFile.exists()) {
+      Model model = modelManager.readMavenModel(new File(baseDir, IMavenConstants.POM_FILE_NAME));
+      if(model == null) {
         return null;
       }
-      Model model = modelManager.readMavenModel(pomFile);
-      String pomName = modulePath + "/" + IMavenConstants.POM_FILE_NAME; //$NON-NLS-1$
-
+      String pomName = modulePath + "/" + model.getPomFile().getName(); //$NON-NLS-1$
       if(model.getArtifactId() == null) {
         throw new CoreException(new Status(IStatus.ERROR, IMavenConstants.PLUGIN_ID,
             NLS.bind(Messages.LocalProjectScanner_missingArtifactId, pomName)));
       }
 
-      MavenProjectInfo projectInfo = newMavenProjectInfo(pomName, pomFile, model, parentInfo);
+      MavenProjectInfo projectInfo = newMavenProjectInfo(pomName, model.getPomFile(), model, parentInfo);
       //We only want to optionally rename the base directory not any sub directory
       if(parentInfo == null) {
         projectInfo.setBasedirRename(getBasedirRename(projectInfo));

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/OverviewPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/OverviewPage.java
@@ -164,8 +164,6 @@ public class OverviewPage extends MavenPomEditorPage {
   private static final int RELOAD_ALL = RELOAD_MODULES + RELOAD_BASE + RELOAD_CI + RELOAD_SCM + RELOAD_IM
       + RELOAD_PROPERTIES + RELOAD_ORG + RELOAD_PARENT;
 
-  private static final String COMPONENTS_PATH = "META-INF/plexus/components.xml";
-
   //controls
   Text artifactIdText;
 
@@ -357,8 +355,9 @@ public class OverviewPage extends MavenPomEditorPage {
     if(projectFacade != null) {
       try {
         List<String> list = projectFacade.createExecutionContext().execute((context, monitor) -> {
-          return context.lookupExtensions(ArtifactHandler.class).stream().map(ArtifactHandler::getPackaging)
-              .filter(Objects::nonNull).distinct().sorted().collect(Collectors.toList());
+          return context.getComponentLookup().lookupCollection(ArtifactHandler.class).stream()
+              .map(ArtifactHandler::getPackaging).filter(Objects::nonNull).distinct().sorted()
+              .collect(Collectors.toList());
         }, null);
         packagingTypes.addAll(list);
       } catch(CoreException ex) {


### PR DESCRIPTION
This adds support for PlexuContainers rooted as the "mvn" folder and
lookup of components in three different context:

- IMaven lookup in the default maven context not containing any
extensions
- IMavenProjectFacade lookup in the projects maven context containing
core extensions
- IMavenExecutionContext lookup in the executions maven context
containing core and project scoped extensions