### PR TITLE
[Target] Ensure that invalid Maven bundles are removed from the cache.

### DIFF
--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)",
  aQute.bnd.version;version="[2.2.0,3.0.0)",
  org.apache.commons.codec.digest;version="1.14.0",
  org.apache.commons.io;version="2.6.0",
+ org.apache.commons.io.filefilter;version="2.8.0",
  org.apache.commons.io.output;version="2.8.0",
  org.slf4j
 Bundle-Vendor: Eclipse.org - m2e


### PR DESCRIPTION
The Manifest files of wrapped Maven bundles are updated, whenever they
become out-of-sync with their original artifact. If this update ever
corrupts the jar, then m2e is unable to recover from this and fails to
load the bundle, until either the Eclipse is restarted or the cache
cleared manually.

Those files should instead be deleted automatically, such that a fresh
file can be generated in its stead.

Should fix #743 