### PR TITLE
Use eclipse/dash-licenses' reusable licenses-check workflow

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -11,21 +11,15 @@ on:
     branches: 
      - 'master'
      - 'm2e-*'
+  issue_comment:
+    types: [created]
 
 jobs:
-  check-licenses:
-    runs-on: ubuntu-latest
-
-    steps:
-
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
-
-    - run: mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -Dtycho.mode=maven -Pgenerate-osgi-metadata
-
-    - name: Check license vetting status
-      run: mvn -U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true
+  call-license-check:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: technology.m2e
+      setupScript: |
+        mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -Dtycho.mode=maven -Pgenerate-osgi-metadata
+    secrets:
+      gitlabAPIToken: ${{ secrets.M2E_GITLAB_API_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -337,10 +337,6 @@
 			<id>cbi-releases</id>
 			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
 		</pluginRepository>
-		<pluginRepository>
-			<id>dash-licenses-snapshots</id>
-			<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
-		</pluginRepository>
 	</pluginRepositories>
 
 	<profiles>


### PR DESCRIPTION
The [`mavenLicenseCheck`](https://github.com/eclipse/dash-licenses/blob/master/.github/workflows/mavenLicenseCheck.yml) workflow provided by `eclipse/dash-licenses`
- avoids the need to add the `dash-licenses snapshots` repository to this project's pom.xml 
- allows committers to request license reviews for unvetted licenses by simply adding a comment `/request-license-review` to a PR
  - While the PR is open the PR's head is checked, if it is closed the master-branch is checked allowing delayed review requests

The license-state check is already functional (like before).
The feature to request a license review requires an authentication token for the Eclipse-Foundation Gitlab API and was already requested: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1137
But this can be added later. Review-request will just fail until the token is available.