### PR TITLE
Exceptions when failing to wrap Maven artifacts should be logged.

### DIFF
--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
@@ -22,7 +22,9 @@ import java.util.jar.Manifest;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.pde.core.target.TargetBundle;
@@ -32,6 +34,7 @@ import aQute.bnd.osgi.Jar;
 
 public class MavenTargetBundle extends TargetBundle {
 
+	private static final ILog LOGGER = Platform.getLog(MavenTargetBundle.class);
 	private TargetBundle bundle;
 	private IStatus status;
 	private final BundleInfo bundleInfo;
@@ -90,6 +93,7 @@ public class MavenTargetBundle extends TargetBundle {
 			if (metadataMode == MissingMetadataMode.ERROR) {
 				status = new Status(Status.ERROR, MavenTargetBundle.class.getPackage().getName(),
 						artifact + " is not a bundle", ex);
+				LOGGER.log(status);
 			} else if (metadataMode == MissingMetadataMode.GENERATE) {
 				try {
 					bundle = cacheManager.accessArtifactFile(artifact,
@@ -102,9 +106,11 @@ public class MavenTargetBundle extends TargetBundle {
 						message += " (" + e.getMessage() + ")";
 					}
 					status = new Status(Status.ERROR, MavenTargetBundle.class.getPackage().getName(), message, e);
+					LOGGER.log(status);
 				}
 			} else {
 				status = Status.CANCEL_STATUS;
+				LOGGER.log(status);
 			}
 		}
 	}


### PR DESCRIPTION
Errors are only shown in the target editor. However, this is a volatile
medium and messages may disappear, when reloading the target platform or
after closing and re-opening the editor.

Writing the error also to the Error Log gives access to the stack trace,
making it easier to find the cause of the problem, in case something
goes wrong.

As suggested in #756 , any exceptions that are thrown when trying to
resolve Maven dependencies are also written to the Error Log.