### PR TITLE
[RelEng] Update to Eclipse 2022-06 and other dependencies

### DIFF
--- a/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
+++ b/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
@@ -30,7 +30,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.util.NLS;
 
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
@@ -70,7 +69,8 @@ import org.eclipse.m2e.profiles.core.internal.ProfileState;
 @Component(service = IProfileManager.class)
 public class ProfileManager implements IProfileManager {
 
-  private static final ILog log = Platform.getLog(ProfileManager.class);
+  @Reference
+  private ILog log;
 
   @Reference
   IProjectConfigurationManager configurationManager;

--- a/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/actions/ProfileSelectionHandler.java
+++ b/org.eclipse.m2e.profiles.ui/src/org/eclipse/m2e/profiles/ui/internal/actions/ProfileSelectionHandler.java
@@ -24,8 +24,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,8 +80,7 @@ public class ProfileSelectionHandler extends AbstractHandler {
   private IProfileManager profileManager;
 
   public ProfileSelectionHandler() {
-    BundleContext context = FrameworkUtil.getBundle(ProfileSelectionHandler.class).getBundleContext();
-    IEclipseContext serviceContext = EclipseContextFactory.getServiceContext(context);
+    IEclipseContext serviceContext = EclipseContextFactory.getServiceContext(ProfileSelectionHandler.class);
     ContextInjectionFactory.inject(this, serviceContext);
   }
 

--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -19,7 +19,7 @@
       <category name="m2e"/>
    </feature>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
-   <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.3/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.20.2/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/eclipse/updates/4.23/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.5/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.20.5/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/eclipse/updates/4.24/" enabled="true" />
 </site>

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -414,6 +414,7 @@ public abstract class AbstractMavenProjectTestCase {
       } else {
         project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
       }
+      ensureDefaultCharset(project, monitor);
     }, null);
 
     // emulate behavior when autobuild was not honored by ProjectRegistryRefreshJob
@@ -519,6 +520,7 @@ public abstract class AbstractMavenProjectTestCase {
       IMavenProjectImportResult importResult = importResults.get(i);
       assertSame(projectInfos.get(i), importResult.getMavenProjectInfo());
       projects[i] = importResult.getProject();
+      ensureDefaultCharset(projects[i], monitor);
       assertNotNull("Failed to import project " + projectInfos, projects[i]);
 
       /*
@@ -544,6 +546,12 @@ public abstract class AbstractMavenProjectTestCase {
 
     projectInfo.setBasedirRename(
         basedir.getParentFile().equals(workspaceRoot) ? MavenProjectInfo.RENAME_REQUIRED : MavenProjectInfo.RENAME_NO);
+  }
+
+  private static void ensureDefaultCharset(IProject project, IProgressMonitor monitor) throws CoreException {
+    if(project.getDefaultCharset(false) == null) {
+      project.setDefaultCharset("UTF-8", monitor);
+    }
   }
 
   protected IProject importProject(String projectName, String projectLocation, ResolverConfiguration configuration)

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -4,29 +4,29 @@
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.23/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/eclipse/updates/4.24/R-4.24-202206070700/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 			<unit id="org.mockito.mockito-core" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/egit/updates-6.1/"/>
+			<repository location="https://download.eclipse.org/egit/updates-6.2/"/>
 			<unit id="org.eclipse.jgit" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.29/"/>
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.30"/>
 			<unit id="org.eclipse.emf.edit.ui.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.ecore.edit.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.25.0/R-3.25.0-20220224093948/repository/"/>
+			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.26.0/R-3.26.0-20220526191850/repository/"/>
 			<unit id="org.eclipse.wst.common.uriresolver" version="0.0.0"/>
 			<unit id="org.eclipse.wst.common.emf" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-03/"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-06/"/>
 			<unit id="com.google.gson" version="0.0.0"/>
 			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="ch.qos.logback.core" version="0.0.0"/>
@@ -34,11 +34,11 @@
 			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.3/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.5/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.2/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.20.5/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
The repository for Eclipse 4.24 should become available today so we can already start using it.

@laeubi are there more possible changes due to recent enhancements in platform?