### PR TITLE
[PDE] update biz.aQute.bndlib and -util to version 6.3.1

### DIFF
--- a/org.eclipse.m2e.pde.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.pde.feature/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+# To force a version qualifier update add the bug here
+[PDE] update biz.aQute.bndlib and -util to version 6.3.1 - https://github.com/eclipse-m2e/m2e-core/pull/772

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -50,13 +50,13 @@
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bnd.util</artifactId>
-					<version>6.3.0</version>
+					<version>6.3.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
-					<version>6.3.0</version>
+					<version>6.3.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
Looks like I oversaw the recent service-release in #445.
But if it's available lets use it.