### PR TITLE
Mark src-folders as 'test' and migrate affected test-plugins to Java-17

### DIFF
--- a/org.eclipse.m2e.binaryproject.tests/.classpath
+++ b/org.eclipse.m2e.binaryproject.tests/.classpath
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.m2e.binaryproject.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.m2e.binaryproject.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=17
-org.eclipse.jdt.core.compiler.debug.lineNumber=generate
-org.eclipse.jdt.core.compiler.debug.localVariable=generate
-org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error

--- a/org.eclipse.m2e.binaryproject.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.tests/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="1.16.0",
  org.eclipse.jdt.core;bundle-version="3.8.1",
  org.eclipse.core.runtime;bundle-version="3.8.0"
 Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.m2e.binaryproject.tests

--- a/org.eclipse.m2e.core.tests/.classpath
+++ b/org.eclipse.m2e.core.tests/.classpath
@@ -6,6 +6,10 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.m2e.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Integration for Eclipse Core Tests
 Bundle-SymbolicName: org.eclipse.m2e.core.tests
 Bundle-Version: 1.16.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e
 Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="1.16.0",
  org.junit;bundle-version="4.12.0",

--- a/org.eclipse.m2e.core.ui.tests/.classpath
+++ b/org.eclipse.m2e.core.ui.tests/.classpath
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Integration for Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.m2e.core.ui.tests
 Bundle-Version: 1.19.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e
 Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="1.16.0",
  org.junit;bundle-version="4.12.0",


### PR DESCRIPTION
Since PR #773 the src-folder of m2e.tests.common is marked as test, so that has to be done for all depend test plug-ins as well.