### PR TITLE
Fix the GH action build and upgrade to Java 17

### DIFF
--- a/.github/workflows/junit.yml
+++ b/.github/workflows/junit.yml
@@ -1,0 +1,37 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build M2Eclipse"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: "artifacts/**/*.xml"
+
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,6 @@
 # This workflow will build the m2e project with Maven
 
-name: Build m2e-core
-
+name: Build M2Eclipse
 on:
   push:
     branches: 
@@ -17,16 +16,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'maven'
     - name: Generated Meta data
       run: mvn generate-sources -f m2e-maven-runtime -Pgenerate-osgi-metadata -Dtycho.mode=maven
     - name: Build m2e-core
-      run: mvn clean verify -Dmaven.test.failure.ignore=true --file pom.xml
+      uses: GabrielBB/xvfb-action@v1
+      with:
+       run: mvn clean verify -Dmaven.test.failure.ignore=true --file pom.xml
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Eclipse IDE integration for Maven (Eclipse m2e project)
+[![Build m2e-core](https://github.com/eclipse-m2e/m2e-core/actions/workflows/maven.yml/badge.svg)](https://github.com/eclipse-m2e/m2e-core/actions/workflows/maven.yml)
 
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/eclipse-m2e/m2e-core?label=Version&sort=semver)
 [![GitHub license](https://img.shields.io/github/license/eclipse-m2e/m2e-core?label=License)](https://github.com/eclipse-m2e/m2e-core/blob/master/LICENSE)


### PR DESCRIPTION
For a while we disabled the GH action build because of "strange errors", in the mean while we found out that it was because of the checkout depth and thus can enable this again now.