### PR TITLE
Consider target-files in deps-caching and set build timeout to 45min

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,9 +13,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up JDK 17
@@ -23,7 +24,14 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        cache: 'maven'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Generated Meta data
       run: mvn generate-sources -f m2e-maven-runtime -Pgenerate-osgi-metadata -Dtycho.mode=maven
     - name: Build m2e-core

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
 	options {
-		timeout(time: 180, unit: 'MINUTES')
+		timeout(time: 45, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'10'))
 		disableConcurrentBuilds(abortPrevious: true)
 	}


### PR DESCRIPTION
The dependencies stored in the .m2 folder not only depend on the content of pom.xml files but also on the content of *.target-files. Therefore the latter should be considered when computing cache-hash.

Furthermore a regular build runs ~10-15min. So a time-out of 45min should be more than sufficient even on a slow builder.