### PR TITLE
Remove unused embedded archetype-dependencies

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -76,6 +76,55 @@
 					<groupId>org.apache.maven</groupId>
 					<artifactId>maven-aether-provider</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<!-- The following excluded dependencies are not accessed at runtime and therefore don't need to be embedded. -->
+				<exclusion>
+					<groupId>org.apache.ivy</groupId>
+					<artifactId>ivy</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.maven.shared</groupId>
+					<artifactId>maven-common-artifact-filters</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.maven.shared</groupId>
+					<artifactId>maven-invoker</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.velocity</groupId>
+					<artifactId>velocity</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.groovy</groupId>
+					<artifactId>groovy-all</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.plexus</groupId>
+					<artifactId>plexus-velocity</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-collections</groupId>
+					<artifactId>commons-collections</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.sonatype.sisu</groupId>
+					<artifactId>sisu-guice</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.sonatype.sisu</groupId>
+					<artifactId>sisu-inject-bean</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.sonatype.sisu</groupId>
+					<artifactId>sisu-inject-plexus</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>
@@ -88,13 +137,15 @@
 					<artifactId>bnd-maven-plugin</artifactId>
 					<configuration>
 						<bnd>
-						<![CDATA[
+							<![CDATA[
 							-exportcontents: \
 								META-INF.plexus;-noimport:=true;x-internal:=true,\
 								org.apache.maven.archetype.*;provider=m2e;mandatory:=provider;version="${archetype-common.version}";x-friends:="org.eclipse.m2e.core.ui"
 							Require-Bundle: \
 								org.eclipse.m2e.maven.runtime;bundle-version="[3.0.0,4.0.0)",\
 								com.ibm.icu
+							Import-Package: \
+								org.slf4j;resolution:=optional;version="[1.7.0,2.0.0)"
 						]]>
 						</bnd>
 					</configuration>


### PR DESCRIPTION
In order to keep the size of the m2e.archetype.common bundle as small as possible, this removes the embedded dependencies that are never accessed at runtime.

I removed all dependencies that are now excluded one by and checked if the `ArchetypeManagerTest` still passes. If we are are really sure that this test covers all use-cases this should be fine. Nevertheless we should use the Archetype capabilities intensively in the near future so that we hopefully did not miss a case.

Size of `org.eclipse.m2e.archetype.common` bundle:
- current snapshot: 10.1MB
- latest release (1.20.1): 1.9MB
- after this change (sum of all embedded jars): 672 KB

