### PR TITLE
Add a MavenToolbox

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizardParentPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizardParentPage.java
@@ -46,6 +46,7 @@ import org.apache.maven.model.Model;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.project.ProjectImportConfiguration;
 import org.eclipse.m2e.core.ui.internal.Messages;
 import org.eclipse.m2e.core.ui.internal.WorkingSets;
@@ -221,7 +222,7 @@ public class MavenModuleWizardParentPage extends AbstractMavenWizardPage {
       parentContainer = pom.getParent();
 
       try (InputStream pomStream = pom.getContents()) {
-        parentModel = MavenPlugin.getMavenModelManager().readMavenModel(pomStream);
+        parentModel = IMavenToolbox.of(MavenPlugin.getMaven()).readModel(pomStream);
         validateParent();
         parentProjectText.setText(parentModel.getArtifactId());
       } catch(CoreException | IOException e) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -42,6 +42,7 @@ import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsProblem;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
@@ -60,9 +61,17 @@ public interface IMaven extends IComponentLookup {
 
   // POM Model read/write operations
 
-  Model readModel(InputStream in) throws CoreException;
+  /**
+   * @deprecated use the {@link MavenModelManager} instead
+   */
+  @Deprecated(forRemoval = true)
+  default Model readModel(InputStream in) throws CoreException {
+    return IMavenToolbox.of(this).readModel(in);
+  }
 
-  void writeModel(Model model, OutputStream out) throws CoreException;
+  default void writeModel(Model model, OutputStream out) throws CoreException {
+    IMavenToolbox.of(this).writeModel(model, out);
+  }
 
   // artifact resolution
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenModelManager.java
@@ -16,7 +16,6 @@ package org.eclipse.m2e.core.embedder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -24,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -68,8 +68,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 
-import org.codehaus.plexus.PlexusContainer;
-
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.DependencyManagement;
@@ -79,6 +77,7 @@ import org.apache.maven.model.building.ModelProcessor;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
@@ -105,7 +104,7 @@ public class MavenModelManager {
   private IMaven maven;
 
   public org.apache.maven.model.Model readMavenModel(InputStream reader) throws CoreException {
-    return maven.readModel(reader);
+    return IMavenToolbox.of(maven).readModel(reader);
   }
 
   /**
@@ -116,67 +115,30 @@ public class MavenModelManager {
    * @throws CoreException if the file points to a valid maven directory but the pom could not be read
    */
   public org.apache.maven.model.Model readMavenModel(File pomFile) throws CoreException {
-
-    if(pomFile.isFile()) {
-      try (FileInputStream stream = new FileInputStream(pomFile)) {
-        Model model = readMavenModel(stream);
-        model.setPomFile(pomFile);
-        return model;
-      } catch(IOException ex) {
-        throw new CoreException(Status.error(ex.getMessage(), ex));
-      }
-    }
-    //this might be a polyglot model...
     File baseDir = pomFile.isDirectory() ? pomFile : pomFile.getParentFile();
-    ClassLoader ccl = Thread.currentThread().getContextClassLoader();
-    try {
-      PlexusContainer plexusContainer = containerManager.aquire(baseDir);
-      Thread.currentThread().setContextClassLoader(plexusContainer.getContainerRealm());
-      ModelProcessor modelProcessor = plexusContainer.lookup(ModelProcessor.class);
-      File pom = modelProcessor.locatePom(baseDir);
-      if(pom != null && pom.isFile()) {
-        Model model = modelProcessor.read(pom, new HashMap<>(Map.of(ModelProcessor.SOURCE, new FileModelSource(pom))));
-        model.setPomFile(pom);
-        return model;
-      }
-    } catch(Exception ex) {
-      throw new CoreException(Status.error(ex.getMessage(), ex));
-    } finally {
-      Thread.currentThread().setContextClassLoader(ccl);
+    Objects.requireNonNull(baseDir, "not a directory and not a parent, invalid file?");
+    IComponentLookup lookup = containerManager.getComponentLookup(baseDir);
+    IMavenToolbox toolbox = IMavenToolbox.of(lookup);
+    Optional<File> locatePom = toolbox.locatePom(baseDir);
+    if(locatePom.isEmpty()) {
+      return null;
     }
-    return null;
-  }
+    ModelProcessor modelProcessor = lookup.lookup(ModelProcessor.class);
 
-  public Optional<File> locatePom(File baseDir) {
-    if(baseDir == null || !baseDir.isDirectory()) {
-      return Optional.empty();
-    }
-    File file = new File(baseDir, IMavenConstants.POM_FILE_NAME);
-    if(file.isFile()) {
-      //check the obvious case first...
-      return Optional.of(file);
-    }
-    ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+    File pom = locatePom.get();
+    Model model;
     try {
-      PlexusContainer plexusContainer = containerManager.aquire(baseDir);
-      Thread.currentThread().setContextClassLoader(plexusContainer.getContainerRealm());
-      ModelProcessor modelProcessor = plexusContainer.lookup(ModelProcessor.class);
-      File pom = modelProcessor.locatePom(baseDir);
-      if(pom != null && pom.isFile()) {
-        return Optional.of(pom);
-      }
-    } catch(Exception ex) {
-      //can't locate the pom... but don't bail to the caller...
-      MavenPluginActivator.getDefault().getLog().warn("Error while locating pom for basedir " + baseDir, ex);
-    } finally {
-      Thread.currentThread().setContextClassLoader(ccl);
+      model = modelProcessor.read(pom, new HashMap<>(Map.of(ModelProcessor.SOURCE, new FileModelSource(pom))));
+    } catch(IOException ex) {
+      throw new CoreException(Status.error(ex.getMessage(), ex));
     }
-    return Optional.empty();
+    model.setPomFile(pom);
+    return model;
   }
 
   public org.apache.maven.model.Model readMavenModel(IFile pomFile) throws CoreException {
     try (InputStream is = pomFile.getContents()) {
-      Model model = maven.readModel(is);
+      Model model = IMavenToolbox.of(maven).readModel(is);
       IPath location = pomFile.getLocation();
       if(location != null) {
         model.setPomFile(location.toFile());
@@ -197,7 +159,7 @@ public class MavenModelManager {
     try {
       ByteArrayOutputStream buf = new ByteArrayOutputStream();
 
-      maven.writeModel(model, buf);
+      IMavenToolbox.of(maven).writeModel(model, buf);
 
       // XXX MNGECLIPSE-495
       DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenToolbox.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/IMavenToolbox.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+
+import org.apache.maven.DefaultMaven;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.ModelProcessor;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.model.io.ModelWriter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+
+import org.eclipse.m2e.core.embedder.IComponentLookup;
+import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
+
+
+/**
+ * {@link IMavenToolbox} provides methods to perform common tasks from the maven world.
+ * 
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface IMavenToolbox {
+
+  Supplier<CoreException> ERROR_NO_SESSION = () -> new CoreException(
+      Status.error(Messages.MavenToolbox_sessionrequired));
+
+  Supplier<CoreException> ERROR_NO_LOOKUP = () -> new CoreException(Status.error(Messages.MavenToolbox_lookuprequired));
+
+  /**
+   * @return the lookup or an empty optional if this toolbox was not constructed in a way that a lookup could be
+   *         acquired
+   */
+  Optional<IComponentLookup> getComponentLookup();
+
+  /**
+   * @return the session or <code>null</code> or an empty optional if this toolbox was not constructed in a way that a
+   *         lookup could be acquired
+   */
+  Optional<MavenSession> getSession();
+
+  /**
+   * Loads the maven standalone project, the default implementation of this requires a session and a lookup.
+   * 
+   * @return the maven standalone project
+   * @throws CoreException
+   */
+  default MavenProject getStandaloneProject() throws CoreException {
+    MavenSession session = getSession().orElseThrow(ERROR_NO_SESSION);
+    IComponentLookup componentLookup = getComponentLookup().orElseThrow(ERROR_NO_LOOKUP);
+    MavenExecutionRequest request = session.getRequest();
+    ProjectBuilder projectBuilder = componentLookup.lookup(ProjectBuilder.class);
+
+    request.getProjectBuildingRequest().setRepositorySession(session.getRepositorySession());
+    try {
+      @SuppressWarnings("deprecation")
+      MavenProject project = projectBuilder
+          .build(new org.apache.maven.model.building.UrlModelSource(
+              DefaultMaven.class.getResource("project/standalone.xml")), request.getProjectBuildingRequest())
+          .getProject();
+      project.setExecutionRoot(true);
+      return project;
+    } catch(ProjectBuildingException ex) {
+      throw new CoreException(Status.error("Can't build standalone project!", ex));
+
+    }
+  }
+
+  /**
+   * Locate the pom file for the given basedirectory in a way that takes polyglot projects into account, the default
+   * implementation of this needs a lookup if pomless/polyglot should be found.
+   * 
+   * @param baseDir the basedir to investigate
+   * @return an empty optional if no pom could be located, or otherwise an optional containing the file of the pom
+   * @throws CoreException
+   */
+  default Optional<File> locatePom(File baseDir) {
+    if(baseDir == null || !baseDir.isDirectory()) {
+      return Optional.empty();
+    }
+    File file = new File(baseDir, IMavenConstants.POM_FILE_NAME);
+    if(file.isFile()) {
+      //check the obvious case first...
+      return Optional.of(file);
+    }
+    return getComponentLookup().map(componentLookup -> {
+      try {
+        ModelProcessor modelProcessor = componentLookup.lookup(ModelProcessor.class);
+        File pom = modelProcessor.locatePom(baseDir);
+        if(pom != null && pom.isFile()) {
+          return pom;
+        }
+      } catch(Exception ex) {
+        //can't locate the pom... but don't bail to the caller...
+        MavenPluginActivator.getDefault().getLog().warn("Error while locating pom for basedir " + baseDir, ex);
+      }
+      return null;
+    });
+  }
+
+  /**
+   * Read a maven model from the given input stream, the default implementation of this requires a lookup.
+   * 
+   * @param in the stream to read the model from
+   * @return
+   * @throws CoreException if reading failed
+   */
+  default Model readModel(InputStream in) throws CoreException {
+    IComponentLookup componentLookup = getComponentLookup().orElseThrow(ERROR_NO_LOOKUP);
+    try {
+      return componentLookup.lookup(ModelReader.class).read(in, null);
+    } catch(IOException e) {
+      throw new CoreException(Status.error(Messages.MavenImpl_error_read_pom, e));
+    }
+  }
+
+  /**
+   * Writes the given model to the output stream, the default implementation of this requires a lookup.
+   * 
+   * @param model
+   * @param out
+   * @throws CoreException if reading failed
+   */
+  default void writeModel(Model model, OutputStream out) throws CoreException {
+    IComponentLookup componentLookup = getComponentLookup().orElseThrow(ERROR_NO_LOOKUP);
+    try {
+      componentLookup.lookup(ModelWriter.class).write(out, null, model);
+    } catch(IOException ex) {
+      throw new CoreException(Status.error(Messages.MavenImpl_error_write_pom, ex));
+    }
+  }
+
+  /**
+   * Creates a toolbox from the given execution context using its component lookup and session
+   * 
+   * @param executionContext
+   * @return
+   */
+  static IMavenToolbox of(IMavenExecutionContext executionContext) {
+    return new IMavenToolbox() {
+
+      @Override
+      public Optional<IComponentLookup> getComponentLookup() {
+        return Optional.of(executionContext.getComponentLookup());
+      }
+
+      @Override
+      public Optional<MavenSession> getSession() {
+        return Optional.of(executionContext.getSession());
+      }
+
+    };
+  }
+
+  /**
+   * Creates a toolbox of the given component lookup
+   * 
+   * @param componentLookup
+   * @return
+   */
+  static IMavenToolbox of(IComponentLookup componentLookup) {
+    return of(componentLookup, null);
+  }
+
+  /**
+   * Creates a toolbox from the given lookup and session
+   * 
+   * @param componentLookup
+   * @param mavenSession
+   * @return
+   */
+  static IMavenToolbox of(IComponentLookup componentLookup, MavenSession mavenSession) {
+    Optional<IComponentLookup> optionalLookup = Optional.ofNullable(componentLookup);
+    Optional<MavenSession> optioanlSession = Optional.ofNullable(mavenSession);
+    return new IMavenToolbox() {
+
+      @Override
+      public Optional<MavenSession> getSession() {
+        return optioanlSession;
+      }
+
+      @Override
+      public Optional<IComponentLookup> getComponentLookup() {
+        return optionalLookup;
+      }
+    };
+  }
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Messages.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/Messages.java
@@ -266,6 +266,10 @@ public class Messages extends NLS {
 
   public static String ProjectConfiguratorToRunAfterNotAvailable;
 
+  public static String MavenToolbox_lookuprequired;
+
+  public static String MavenToolbox_sessionrequired;
+
   static {
     // initialize resource bundle
     NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -24,7 +24,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -98,8 +97,6 @@ import org.apache.maven.model.Repository;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.interpolation.ModelInterpolator;
-import org.apache.maven.model.io.ModelReader;
-import org.apache.maven.model.io.ModelWriter;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.InvalidPluginDescriptorException;
 import org.apache.maven.plugin.MavenPluginManager;
@@ -419,32 +416,6 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     if(MavenConfigurationChangeEvent.P_USER_SETTINGS_FILE.equals(event.getKey())
         || MavenPreferenceConstants.P_GLOBAL_SETTINGS_FILE.equals(event.getKey())) {
       reloadSettings();
-    }
-  }
-
-  @Override
-  public Model readModel(InputStream in) throws CoreException {
-    try {
-      return lookup(ModelReader.class).read(in, null);
-    } catch(IOException e) {
-      throw new CoreException(Status.error(Messages.MavenImpl_error_read_pom, e));
-    }
-  }
-
-  public Model readModel(File pomFile) throws CoreException {
-    try (InputStream is = new FileInputStream(pomFile)) {
-      return readModel(is);
-    } catch(IOException e) {
-      throw new CoreException(Status.error(Messages.MavenImpl_error_read_pom, e));
-    }
-  }
-
-  @Override
-  public void writeModel(Model model, OutputStream out) throws CoreException {
-    try {
-      lookup(ModelWriter.class).write(out, null, model);
-    } catch(IOException ex) {
-      throw new CoreException(Status.error(Messages.MavenImpl_error_write_pom, ex));
     }
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/messages.properties
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/messages.properties
@@ -119,3 +119,5 @@ pluginMarkerBuildError=Project build error\: {0}
 importProjectExists=Project "{0}" already exists.
 buildConextFileAccessOutsideOfProjectBasedir=Access "{0}" directory outside of project base directory.
 ProjectConversion_error_duplicate_conversion_participant=Duplicate Conversion Participant {0} unsupported.
+MavenToolbox_sessionrequired=This toolbox method requires a session!
+MavenToolbox_lookuprequired=This toolbox method requires a component lookup!

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -69,6 +69,7 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.embedder.MavenModelManager;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.embedder.AbstractRunnable;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
@@ -748,7 +749,7 @@ public class ProjectConfigurationManager
     Model model = projectInfo.getModel();
     if(model == null) {
       try (InputStream pomStream = Files.newInputStream(pomFile.toPath())) {
-        model = maven.readModel(pomStream);
+        model = IMavenToolbox.of(maven).readModel(pomStream);
       } catch(IOException ex) {
         log.error(Messages.MavenImpl_error_read_pom, ex);
       }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -93,6 +93,7 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.internal.ExtensionReader;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.URLConnectionCaches;
 import org.eclipse.m2e.core.internal.builder.MavenBuilder;
@@ -560,7 +561,7 @@ public class ProjectRegistryManager implements ISaveParticipant {
       if(pom.isAccessible() && pom.getProject().hasNature(IMavenConstants.NATURE_ID)) {
         try (InputStream is = pom.getContents()) {
           // MNGECLIPSE-605 embedder is not able to resolve the project due to missing configuration in the parent
-          Model model = getMaven().readModel(is);
+          Model model = IMavenToolbox.of(getMaven()).readModel(is);
           if(model != null && model.getParent() != null) {
             Parent parent = model.getParent();
             if(parent.getGroupId() != null && parent.getArtifactId() != null && parent.getVersion() != null) {

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenPomFeatureModel.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenPomFeatureModel.java
@@ -35,6 +35,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.pde.core.target.TargetBundle;
 import org.eclipse.pde.internal.core.NLResourceHelper;
 import org.eclipse.pde.internal.core.feature.AbstractFeatureModel;
@@ -75,7 +76,7 @@ class MavenPomFeatureModel extends AbstractFeatureModel {
 	public void load() throws CoreException {
 		editable = true;
 		try (FileInputStream stream = new FileInputStream(artifact.getFile())) {
-			Model model = MavenPlugin.getMaven().readModel(stream);
+			Model model = IMavenToolbox.of(MavenPlugin.getMaven()).readModel(stream);
 
 			IFeature f = getFeature();
 			String id = model.getGroupId() + "." + model.getArtifactId() + "." + model.getPackaging();

--- a/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
+++ b/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
@@ -14,7 +14,10 @@
 package org.eclipse.m2e.profiles.core.internal.management;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +33,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
@@ -50,6 +54,8 @@ import org.apache.maven.shared.utils.StringUtils;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
+import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.NoSuchComponentException;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
@@ -377,8 +383,11 @@ public class ProfileManager implements IProfileManager {
     return readModel(maven, file);
   }
 
-  @SuppressWarnings("restriction")
   private Model readModel(IMaven maven, File file) throws CoreException {
-    return ((org.eclipse.m2e.core.internal.embedder.MavenImpl) maven).readModel(file);
+    try (InputStream is = new FileInputStream(file)) {
+      return IMavenToolbox.of(maven).readModel(new FileInputStream(file));
+    } catch(IOException e) {
+      throw new CoreException(Status.error(Messages.MavenImpl_error_read_pom, e));
+    }
   }
 }

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
@@ -14,7 +14,9 @@
 package org.eclipse.m2e.scm;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -41,6 +44,7 @@ import org.apache.maven.model.Scm;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.project.AbstractProjectScanner;
 
@@ -219,8 +223,11 @@ public class MavenProjectPomScanner<T> extends AbstractProjectScanner<MavenProje
     return readModel(file);
   }
 
-  @SuppressWarnings("restriction")
   private Model readModel(File file) throws CoreException {
-    return ((org.eclipse.m2e.core.internal.embedder.MavenImpl) maven).readModel(file);
+    try (InputStream is = new FileInputStream(file)) {
+      return IMavenToolbox.of(maven).readModel(new FileInputStream(file));
+    } catch(IOException e) {
+      throw new CoreException(Status.error(Messages.MavenImpl_error_read_pom, e));
+    }
   }
 }


### PR DESCRIPTION
Currently we have some scattered places where we put useful "shorthands"
that perform some maven specific tasks as it is cumbersome to write them
down each time. Often they are not really related to the object itself
but could be written as a function of an execution and/or session.

Because it is often arguable if we should add it to the given interface
to not bloat the API and on the other hand it might became useful on
other places as well, this change introduces a "MavenToolbox" that could
be a place for such methods, easily constructed by a static method but
not intended to be implemented by clients.

This will solve several issues:
- do not require to do the same thing on different places just to not
introduce API
- prevent code from referencing internal API
- can enhance this as we like
- can deprecate methods if we think they are no longer useful without
harming actual m2e implementations

I have only refactored a few places until now so we can first decide if this is a viable option.