### PR TITLE
Add xml.resolver to M2E-launch and disable connectors in M2E-setup

### DIFF
--- a/setup/Eclipse-M2E-IDE.launch
+++ b/setup/Eclipse-M2E-IDE.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
     <setAttribute key="additional_plugins">
-        <setEntry value="org.eclipse.m2e.logback.configuration:1.16.3.qualifier:default:true:default:true"/>
+        <setEntry value="org.apache.xml.resolver:1.2.0.v20220401-1849:default:true:default:default"/>
+        <setEntry value="org.eclipse.m2e.logback.configuration:1.17.0.qualifier:default:true:default:true"/>
     </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
     <booleanAttribute key="askclear" value="true"/>

--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -96,6 +96,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
+      disabled="true"
       label="m2e - connectors">
     <requirement
         name="org.sonatype.tycho.m2e.feature.feature.group"/>


### PR DESCRIPTION
Due to an issue with PDE the 'org.apache.xml.resolver' plug-in is not
resolved and therefore not automatically added to the launch. In order
to avoid failures when launching the Eclipse-M2E-IDE temporary add that
plug-in.

Disable M2E connectors in the setup that currently cannot be
installed with the M2E snapshot because they are not yet ready for
m2e-2.0.0. Then the setup at least completes successfully.