### PR TITLE
Support Pomless in ProjectRegistry/ConfigurationManager

### DIFF
--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
@@ -41,9 +41,8 @@ public class ExtensionsTest extends AbstractMavenProjectTestCase {
 
 	@Test
 	public void testCoreExtension() throws Exception {
-		boolean skipSanityCheck = true; // TODO this should also work! But not part of this change
 		IProject[] projects = importProjects("resources/projects/pomless/", new String[] { "bundle/pom.xml" },
-				new ResolverConfiguration(), skipSanityCheck);
+				new ResolverConfiguration(), false);
 		waitForJobsToComplete(monitor);
 		assertEquals(1, projects.length);
 		IProject project = projects[0];

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerLocationService.java
@@ -110,7 +110,8 @@ public class MarkerLocationService implements IMarkerLocationService, IEditorMar
       IFile resource = (IFile) marker.getResource();
       domModel = (IDOMModel) StructuredModelManager.getModelManager().getModelForRead(resource);
       if(domModel == null) {
-        throw new IllegalArgumentException("Document is not structured: " + resource);
+        log.debug("Document is not structured: " + resource);
+        return;
       }
       IStructuredDocument document = domModel.getStructuredDocument();
       int charStart = document.getLineOffset(lineNumber - 1) + columnStart - 1;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -64,6 +64,7 @@ import org.apache.maven.model.Parent;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.IComponentLookup;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
@@ -73,6 +74,7 @@ import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.embedder.AbstractRunnable;
 import org.eclipse.m2e.core.internal.embedder.MavenImpl;
+import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
 import org.eclipse.m2e.core.internal.markers.IMavenMarkerManager;
 import org.eclipse.m2e.core.internal.preferences.ProblemSeverity;
@@ -118,6 +120,9 @@ public class ProjectConfigurationManager
 
   @Reference
   IMavenConfiguration mavenConfiguration;
+
+  @Reference
+  PlexusContainerManager containerManager;
 
   @Override
   public List<IMavenProjectImportResult> importProjects(Collection<MavenProjectInfo> projectInfos,
@@ -241,7 +246,10 @@ public class ProjectConfigurationManager
     // first, resolve maven dependencies for all projects
     Set<IFile> pomFiles = new LinkedHashSet<>();
     for(IProject project : projects) {
-      pomFiles.add(project.getFile(IMavenConstants.POM_FILE_NAME));
+      File baseDir = project.getLocation().toFile();
+      IMavenToolbox.of(containerManager.getComponentLookup(baseDir)).locatePom(baseDir).ifPresent(pomFile -> {
+        pomFiles.add(project.getFile(pomFile.getName()));
+      });
     }
     progress.subTask(Messages.ProjectConfigurationManager_task_refreshing);
 

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -517,7 +517,8 @@ public abstract class AbstractMavenProjectTestCase {
        */
       if(!skipSanityCheck) {
         Model model = projectInfos.get(i).getModel();
-        IMavenProjectFacade facade = MavenPlugin.getMavenProjectRegistry().create(projects[i], monitor);
+        IMavenProjectRegistry mavenProjectRegistry = MavenPlugin.getMavenProjectRegistry();
+        IMavenProjectFacade facade = mavenProjectRegistry.create(projects[i], monitor);
         if(facade == null) {
           fail("Project " + model.getGroupId() + "-" + model.getArtifactId() + "-" + model.getVersion()
               + " was not imported. Errors: "


### PR DESCRIPTION
Currently the use hard coded defaults, but should locate the real name for the pom instead.