### PR TITLE
Unify and improve Plug-in/Feature description

### DIFF
--- a/org.eclipse.m2e.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.tests/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.0.0,2.0)",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jdt.apt.pluggable.core;bundle-version="1.0.400"
-Bundle-Vendor: Eclipse m2e
+Bundle-Vendor: Eclipse.org - m2e
 Export-Package: org.eclipse.m2e.apt.tests;x-internal:=true
 Automatic-Module-Name: org.eclipse.m2e.apt.tests
 Fragment-Host: org.eclipse.m2e.apt.core

--- a/org.eclipse.m2e.editor.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for m2e multi-page editor
 Bundle-SymbolicName: org.eclipse.m2e.editor.tests
 Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: Eclipse m2e
+Bundle-Vendor: Eclipse.org - m2e
 Automatic-Module-Name: org.eclipse.m2e.editor.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.m2e.editor;bundle-version="1.18.2",

--- a/org.eclipse.m2e.feature/feature.properties
+++ b/org.eclipse.m2e.feature/feature.properties
@@ -16,7 +16,7 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=M2E - Maven Integration for Eclipse (includes Incubating components)
+featureName=M2E - Maven Integration for Eclipse
 
 # "providerName" property - name of the company that provides the feature
 providerName=Eclipse.org - m2e

--- a/org.eclipse.m2e.logback.feature/feature.properties
+++ b/org.eclipse.m2e.logback.feature/feature.properties
@@ -16,7 +16,7 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=M2E - SLF4J over Logback Logging (optional)
+featureName=M2E - SLF4J over Logback Logging
 
 # "providerName" property - name of the company that provides the feature
 providerName=Eclipse.org - m2e
@@ -26,7 +26,7 @@ providerName=Eclipse.org - m2e
 
 # "description" property - description of the feature
 description=slf4j over logback logging configuration for Maven Integration for Eclipse.\
-Includes Maven Console View support for logback logging backend. 
+Includes the optional Maven Console View support for logback logging backend. 
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\

--- a/org.eclipse.m2e.sdk.feature/feature.properties
+++ b/org.eclipse.m2e.sdk.feature/feature.properties
@@ -16,7 +16,7 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=M2E - Complete Development Kit (optional)
+featureName=M2E - Complete Development Kit
 
 # "providerName" property - name of the company that provides the feature
 providerName=Eclipse.org - m2e
@@ -25,7 +25,7 @@ providerName=Eclipse.org - m2e
 #updateSiteName=The Eclipse Project Updates
 
 # "description" property - description of the feature
-description=The full M2Eclipse Software Development Kit that contains all m2e plug-ins and features and their sources. (Optional)
+description=The full M2Eclipse Software Development Kit that contains all m2e plug-ins and features and their sources.
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\


### PR DESCRIPTION
Since every root Feature is optional I think there is no advantage in mentioning that in its name.
Furthermore I think it is not necessary to mention in the Feature name that m2e includes some incubating components since the majority of features is not incubation and some experimental preferences are labeled as such.

What do the others think?