### PR TITLE
Replace Arrays by suitable Collections in m2e.core APIs

### DIFF
--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerBuildParticipant.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerBuildParticipant.java
@@ -14,6 +14,7 @@ package org.eclipse.m2e.apt.internal.compiler;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFolder;
@@ -72,7 +73,8 @@ public class MavenCompilerBuildParticipant extends MojoExecutionBuildParticipant
     }
     if(!buildContext.hasDelta(mavenProjectFacade.getPomFile())) {
 
-      IPath[] sources = "compile".equals(mojoExecution.getGoal()) ? mavenProjectFacade.getCompileSourceLocations()
+      List<IPath> sources = "compile".equals(mojoExecution.getGoal()) //
+          ? mavenProjectFacade.getCompileSourceLocations()
           : mavenProjectFacade.getTestCompileSourceLocations();
 
       boolean hasSourceChanged = false;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/UpdateMavenProjectJob.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/UpdateMavenProjectJob.java
@@ -14,6 +14,7 @@
 package org.eclipse.m2e.core.ui.internal;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ import org.eclipse.m2e.core.ui.internal.util.M2EUIUtils;
 
 public class UpdateMavenProjectJob extends WorkspaceJob {
 
-  private final IProject[] projects;
+  private final Collection<IProject> projects;
 
   private final boolean offline;
 
@@ -48,12 +49,12 @@ public class UpdateMavenProjectJob extends WorkspaceJob {
 
   private final boolean refreshFromLocal;
 
-  public UpdateMavenProjectJob(IProject[] projects) {
+  public UpdateMavenProjectJob(Collection<IProject> projects) {
     this(projects, MavenPlugin.getMavenConfiguration().isOffline(), false /*forceUpdateDependencies*/,
         true /*updateConfiguration*/, true /*rebuild*/, true /*refreshFromLocal*/);
   }
 
-  public UpdateMavenProjectJob(IProject[] projects, boolean offline, boolean forceUpdateDependencies,
+  public UpdateMavenProjectJob(Collection<IProject> projects, boolean offline, boolean forceUpdateDependencies,
       boolean updateConfiguration, boolean cleanProjects, boolean refreshFromLocal) {
 
     super(Messages.UpdateSourcesAction_job_update_conf);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/WorkingSets.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/WorkingSets.java
@@ -75,7 +75,7 @@ public class WorkingSets {
    *
    * @since 1.5
    */
-  public static void addToWorkingSet(IProject[] projects, String workingSetName) {
+  public static void addToWorkingSet(List<IProject> projects, String workingSetName) {
     IWorkingSet[] workingSets = new IWorkingSet[] {getOrCreateWorkingSet(workingSetName)};
     IWorkingSetManager manager = PlatformUI.getWorkbench().getWorkingSetManager();
     for(IProject project : projects) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/ChangeNatureAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/ChangeNatureAction.java
@@ -154,8 +154,7 @@ public class ChangeNatureAction implements IObjectActionDelegate, IExecutableExt
 
       boolean offline = mavenConfiguration.isOffline();
       boolean updateSnapshots = false;
-      projectManager.refresh(new MavenUpdateRequest(projects.toArray(new IProject[projects.size()]), //
-          offline, updateSnapshots));
+      projectManager.refresh(new MavenUpdateRequest(projects, offline, updateSnapshots));
 
       return status != null ? status : Status.OK_STATUS;
     }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/NestedProjectsComposite.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/components/NestedProjectsComposite.java
@@ -16,6 +16,7 @@ package org.eclipse.m2e.core.ui.internal.components;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -81,7 +82,7 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
 
   Collection<IProject> projects;
 
-  IProject[] selectedProjects;
+  List<IProject> selectedProjects;
 
   private Link includeOutDateProjectslink;
 
@@ -466,17 +467,13 @@ public class NestedProjectsComposite extends Composite implements IMenuListener 
     return null;
   }
 
-  public IProject[] getSelectedProjects() {
+  public List<IProject> getSelectedProjects() {
     return selectedProjects;
   }
 
-  IProject[] internalGetSelectedProjects() {
+  List<IProject> internalGetSelectedProjects() {
     Object[] obj = codebaseViewer.getCheckedElements();
-    IProject[] projects = new IProject[obj.length];
-    for(int i = 0; i < obj.length; i++ ) {
-      projects[i] = (IProject) obj[i];
-    }
-    return projects;
+    return Arrays.stream(obj).map(IProject.class::cast).toList();
   }
 
   public void refresh() {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/AssignWorkingSetDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/AssignWorkingSetDialog.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.m2e.core.ui.internal.dialogs;
 
-import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
@@ -136,10 +136,10 @@ public class AssignWorkingSetDialog extends TitleAreaDialog {
   }
 
   public void assignWorkingSets() {
-    IProject[] projects = selectedProjects.getSelectedProjects();
-    if(projects != null && projects.length > 0 && workingSetName != null && !workingSetName.isEmpty()) {
+    List<IProject> projects = selectedProjects.getSelectedProjects();
+    if(projects != null && !projects.isEmpty() && workingSetName != null && !workingSetName.isEmpty()) {
       WorkingSets.addToWorkingSet(projects, workingSetName);
-      allWorkingSetProjects.addAll(Arrays.asList(projects));
+      allWorkingSetProjects.addAll(projects);
     }
   }
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/UpdateMavenProjectsDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/UpdateMavenProjectsDialog.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.core.ui.internal.dialogs;
 
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
@@ -39,7 +41,7 @@ public class UpdateMavenProjectsDialog extends TitleAreaDialog {
 
   private final IProject[] initialSelection;
 
-  private IProject[] selectedProjects;
+  private List<IProject> selectedProjects;
 
   private boolean offlineMode;
 
@@ -161,7 +163,7 @@ public class UpdateMavenProjectsDialog extends TitleAreaDialog {
     super.okPressed();
   }
 
-  public IProject[] getSelectedProjects() {
+  public List<IProject> getSelectedProjects() {
     return selectedProjects;
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerResolutionGenerator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/markers/MarkerResolutionGenerator.java
@@ -73,7 +73,7 @@ public class MarkerResolutionGenerator implements IMarkerResolutionGenerator, IM
     @Override
     public void fix(IMarker[] markers, IDocument doc, IProgressMonitor monitor) {
       final Set<IProject> projects = getProjects(Stream.of(markers));
-      new UpdateMavenProjectJob(projects.toArray(new IProject[projects.size()])).schedule();
+      new UpdateMavenProjectJob(projects).schedule();
     }
 
     @Override

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenPreferencePage.java
@@ -16,6 +16,7 @@
 package org.eclipse.m2e.core.ui.internal.preferences;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -137,18 +138,17 @@ public class MavenPreferencePage extends FieldEditorPreferencePage implements IW
     String newChecksumPolicy = getPreferenceStore().getString(MavenPreferenceConstants.P_GLOBAL_CHECKSUM_POLICY);
     boolean updateRequired = !originalChecksumPolicy.equals(newChecksumPolicy);
     if(updateRequired) {
-      IMavenProjectFacade[] facades = MavenPlugin.getMavenProjectRegistry().getProjects();
-      if(facades != null && facades.length > 0) {
+      List<IMavenProjectFacade> facades = MavenPlugin.getMavenProjectRegistry().getProjects();
+      if(facades != null && !facades.isEmpty()) {
         boolean proceed = MessageDialog.openQuestion(getShell(),
             Messages.MavenPreferencePage_updateProjectRequired_title,
             Messages.MavenPreferencePage_changingPreferencesRequiresProjectUpdate);
         if(proceed) {
-          ArrayList<IProject> allProjects = new ArrayList<>(facades.length);
+          ArrayList<IProject> allProjects = new ArrayList<>(facades.size());
           for(IMavenProjectFacade facade : facades) {
             allProjects.add(facade.getProject());
           }
-          new UpdateMavenProjectJob(
-              allProjects.toArray(new IProject[allProjects.size()]), //
+          new UpdateMavenProjectJob(allProjects, //
               MavenPlugin.getMavenConfiguration().isOffline(), true /*forceUpdateDependencies*/,
               false /*updateConfiguration*/, true /*rebuild*/, true /*refreshFromLocal*/).schedule();
         }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenSettingsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenSettingsPreferencePage.java
@@ -128,8 +128,8 @@ public class MavenSettingsPreferencePage extends PreferencePage implements IWork
     Boolean[] updateProjects = new Boolean[1];
     updateProjects[0] = updateMavenDependencies;
     if(updateMavenDependencies) {
-      IMavenProjectFacade[] projects = MavenPlugin.getMavenProjectRegistry().getProjects();
-      if(projects != null && projects.length > 0) {
+      List<IMavenProjectFacade> projects = MavenPlugin.getMavenProjectRegistry().getProjects();
+      if(projects != null && !projects.isEmpty()) {
         updateProjects[0] = MessageDialog.openQuestion(getShell(),
             Messages.MavenPreferencePage_updateProjectRequired_title,
             Messages.MavenProjectPreferencePage_dialog_message);
@@ -143,19 +143,19 @@ public class MavenSettingsPreferencePage extends PreferencePage implements IWork
         mavenConfiguration.setUserSettingsFile(userSettings);
 
         if(Boolean.TRUE.equals(updateProjects[0])) {
-          IMavenProjectFacade[] projects = MavenPlugin.getMavenProjectRegistry().getProjects();
-          List<IProject> allProjects = new ArrayList<>();
-          if(projects != null && projects.length > 0) {
+          List<IMavenProjectFacade> projects = MavenPlugin.getMavenProjectRegistry().getProjects();
+          if(projects != null && !projects.isEmpty()) {
             MavenPlugin.getMaven().reloadSettings();
 
-            SubMonitor subMonitor = SubMonitor.convert(monitor, projects.length);
+            List<IProject> allProjects = new ArrayList<>();
+            SubMonitor subMonitor = SubMonitor.convert(monitor, projects.size());
             for(IMavenProjectFacade project : projects) {
               subMonitor.split(1).beginTask(
                   NLS.bind(Messages.MavenSettingsPreferencePage_task_updating, project.getProject().getName()), 1);
               allProjects.add(project.getProject());
             }
-            MavenPlugin.getMavenProjectRegistry().refresh(
-                new MavenUpdateRequest(allProjects.toArray(IProject[]::new), mavenConfiguration.isOffline(), true));
+            MavenPlugin.getMavenProjectRegistry()
+                .refresh(new MavenUpdateRequest(allProjects, mavenConfiguration.isOffline(), true));
             subMonitor.done();
           }
         }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/WarningsPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/WarningsPreferencePage.java
@@ -120,18 +120,17 @@ public class WarningsPreferencePage extends FieldEditorPreferencePage implements
   private void updateProjects() {
     //Update projects if problem severities changed
     if(isDirty()) {
-      IMavenProjectFacade[] facades = MavenPlugin.getMavenProjectRegistry().getProjects();
-      if(facades != null && facades.length > 0) {
+      List<IMavenProjectFacade> facades = MavenPlugin.getMavenProjectRegistry().getProjects();
+      if(facades != null && !facades.isEmpty()) {
         boolean proceed = MessageDialog.openQuestion(getShell(),
             Messages.MavenPreferencePage_updateProjectRequired_title,
             Messages.MavenWarningsPreferencePage_changingProblemSeveritiesRequiresProjectUpdate);
         if(proceed) {
-          ArrayList<IProject> allProjects = new ArrayList<>(facades.length);
+          ArrayList<IProject> allProjects = new ArrayList<>(facades.size());
           for(IMavenProjectFacade facade : facades) {
             allProjects.add(facade.getProject());
           }
-          new UpdateMavenProjectJob(
-              allProjects.toArray(new IProject[allProjects.size()]), //
+          new UpdateMavenProjectJob(allProjects, //
               MavenPlugin.getMavenConfiguration().isOffline(), true /*forceUpdateDependencies*/,
               false /*updateConfiguration*/, true /*rebuild*/, true /*refreshFromLocal*/).schedule();
           initOriginalValues();

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
@@ -165,8 +165,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
                     CumulativeMappingDiscoveryJob.getInstance().addProjects(toProcessNow);
                     ProjectConfigurationManager configurationManager = (ProjectConfigurationManager) MavenPlugin
                             .getProjectConfigurationManager();
-                    MavenUpdateRequest request = new MavenUpdateRequest(
-                            toProcessNow.toArray(new IProject[toProcessNow.size()]), false, false);
+                    MavenUpdateRequest request = new MavenUpdateRequest(toProcessNow, false, false);
                     configurationManager.updateProjectConfiguration(request, true,
                             false, false, monitor);
                 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenUpdateConfigurationChangeListener.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenUpdateConfigurationChangeListener.java
@@ -23,7 +23,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.ui.internal.UpdateMavenProjectJob;
@@ -63,8 +62,7 @@ public class MavenUpdateConfigurationChangeListener implements IResourceChangeLi
   protected void updateProjectConfiguration(List<IProject> outOfDateProjects) {
     if(outOfDateProjects != null && !outOfDateProjects.isEmpty()) {
       LOG.debug("Automatic update of {}", outOfDateProjects);
-      Job updateJob = new UpdateMavenProjectJob(outOfDateProjects.toArray(new IProject[outOfDateProjects.size()]));
-      updateJob.schedule();
+      new UpdateMavenProjectJob(outOfDateProjects).schedule();
     }
   }
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenArtifactComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenArtifactComponent.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.core.ui.internal.wizards;
 
+import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.layout.GridData;
@@ -216,9 +218,9 @@ public class MavenArtifactComponent extends Composite {
     versionCombo.setText(version);
   }
 
-  public void setPackagingTypes(String[] packagingTypes) {
+  public void setPackagingTypes(List<String> packagingTypes) {
     if(packagingCombo != null) {
-      packagingCombo.setItems(packagingTypes);
+      packagingCombo.setItems(packagingTypes.toArray(String[]::new));
     }
   }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
@@ -161,7 +161,7 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
             }
           }
 
-          new UpdateMavenProjectJob(changed.toArray(new IProject[changed.size()])).schedule();
+          new UpdateMavenProjectJob(changed).schedule();
         }
 
         private Collection<IProject> getProject(Collection<MavenProject> projects) {
@@ -201,7 +201,7 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
         private void ignoreWorkspace(MojoExecutionKey key) {
           LifecycleMappingMetadataSource mapping = LifecycleMappingFactory.getWorkspaceMetadata(true);
           LifecycleMappingFactory.addLifecyclePluginExecution(mapping, key.groupId(), key.artifactId(),
-              key.version(), new String[] {key.goal()}, PluginExecutionAction.ignore);
+              key.version(), List.of(key.goal()), PluginExecutionAction.ignore);
           LifecycleMappingFactory.writeWorkspaceMetadata(mapping);
         }
       };

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenModuleWizard.java
@@ -215,7 +215,7 @@ public class MavenModuleWizard extends AbstractMavenProjectWizard implements INe
         }
       }
 
-      final String[] folders = artifactPage.getFolders();
+      final List<String> folders = artifactPage.getFolders();
 
       job = new AbstractCreateMavenProjectJob(NLS.bind(Messages.wizardProjectJobCreatingProject, moduleName)) {
         @Override

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizardPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenPomWizardPage.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.m2e.core.ui.internal.wizards;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -95,7 +98,7 @@ public class MavenPomWizardPage extends AbstractMavenWizardPage {
    */
   private void initialize() {
     String packagingToUse = MavenArtifactComponent.DEFAULT_PACKAGING;
-    String[] availablePackagingTypes = MavenArtifactComponent.PACKAGING_OPTIONS;
+    List<String> availablePackagingTypes = Arrays.asList(MavenArtifactComponent.PACKAGING_OPTIONS);
     if(selection != null && !selection.isEmpty() && selection instanceof IStructuredSelection ssel) {
       if(ssel.size() > 1) {
         return;
@@ -111,7 +114,7 @@ public class MavenPomWizardPage extends AbstractMavenWizardPage {
           projectConversionEnabler = pcm.getConversionEnablerForProject(project);
           if(projectConversionEnabler != null) {
             availablePackagingTypes = projectConversionEnabler.getPackagingTypes(project);
-            packagingToUse = availablePackagingTypes[0];
+            packagingToUse = availablePackagingTypes.get(0);
           }
         }
       }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizard.java
@@ -218,7 +218,7 @@ public class MavenProjectWizard extends AbstractMavenProjectWizard implements IN
     final AbstractCreateMavenProjectJob job;
 
     if(simpleProject.getSelection()) {
-      final String[] folders = artifactPage.getFolders();
+      final List<String> folders = artifactPage.getFolders();
 
       job = new AbstractCreateMavenProjectJob(NLS.bind(Messages.wizardProjectJobCreatingProject, projectName)) {
         @Override

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArtifactPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizardArtifactPage.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.m2e.core.ui.internal.wizards;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IStatus;
@@ -207,15 +209,9 @@ public class MavenProjectWizardArtifactPage extends AbstractMavenWizardPage {
    * @return The Maven2 directories selected by the user. Neither the array nor any of its elements is <code>null</code>
    *         .
    */
-  public String[] getFolders() {
+  public List<String> getFolders() {
     ProjectFolder[] mavenDirectories = getProjectFolders();
-
-    String[] directories = new String[mavenDirectories.length];
-    for(int i = 0; i < directories.length; i++ ) {
-      directories[i] = mavenDirectories[i].getPath();
-    }
-
-    return directories;
+    return Arrays.stream(mavenDirectories).map(ProjectFolder::getPath).toList();
   }
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateLifecycleMappingMetadataException.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateLifecycleMappingMetadataException.java
@@ -13,10 +13,9 @@
 
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
-import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
 
 
 /**
@@ -26,18 +25,17 @@ public class DuplicateLifecycleMappingMetadataException extends DuplicateMapping
 
   private static final long serialVersionUID = 1L;
 
-  private final LifecycleMappingMetadata[] lifecyclemappings;
+  private final List<LifecycleMappingMetadata> lifecyclemappings;
 
-  public DuplicateLifecycleMappingMetadataException(LifecycleMappingMetadata... lifecyclemappings) {
-    super(Arrays.stream(lifecyclemappings).map(LifecycleMappingMetadata::getSource)
-        .toArray(LifecycleMappingMetadataSource[]::new));
+  public DuplicateLifecycleMappingMetadataException(List<LifecycleMappingMetadata> lifecyclemappings) {
+    super(lifecyclemappings.stream().map(LifecycleMappingMetadata::getSource).toList());
     this.lifecyclemappings = lifecyclemappings;
   }
 
   /**
    * @return Returns the lifecyclemappings.
    */
-  public LifecycleMappingMetadata[] getConflictingMappings() {
+  public List<LifecycleMappingMetadata> getConflictingMappings() {
     return this.lifecyclemappings;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingException.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingException.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadata;
@@ -31,16 +31,16 @@ public abstract class DuplicateMappingException extends RuntimeException {
 
   private static final long serialVersionUID = -7303637464019592307L;
 
-  private final LifecycleMappingMetadataSource[] sources;
+  private final List<LifecycleMappingMetadataSource> sources;
 
-  protected DuplicateMappingException(LifecycleMappingMetadataSource... sources) {
+  protected DuplicateMappingException(List<LifecycleMappingMetadataSource> sources) {
     this.sources = sources;
   }
 
   @Override
   public String getMessage() {
     // sources might be either bundle, artifact or "default", "workspace" or MavenProject (all should provide proper toString() implementations)
-    return "Mapping defined in " + Arrays.stream(sources).map(LifecycleMappingMetadataSource::getSource)
+    return "Mapping defined in " + sources.stream().map(LifecycleMappingMetadataSource::getSource)
         .map(s -> s == null ? DESCRIPTION_UNKNOWN_SOURCE : s.toString())
         .collect(Collectors.joining("' and '", "'", "'"));
   }
@@ -48,7 +48,7 @@ public abstract class DuplicateMappingException extends RuntimeException {
   /**
    * @return Returns the sources.
    */
-  public LifecycleMappingMetadataSource[] getConflictingSources() {
+  public List<LifecycleMappingMetadataSource> getConflictingSources() {
     return this.sources;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingSourceProblem.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicateMappingSourceProblem.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.osgi.framework.Bundle;
@@ -36,17 +36,12 @@ import org.eclipse.m2e.core.internal.markers.SourceLocation;
  */
 public class DuplicateMappingSourceProblem extends MavenProblemInfo {
 
-  private final LifecycleMappingMetadataSource[] conflictingSources;
+  private final List<LifecycleMappingMetadataSource> conflictingSources;
 
   private final String type;
 
   private final String value;
 
-  /**
-   * @param location
-   * @param message
-   * @param error
-   */
   public DuplicateMappingSourceProblem(SourceLocation location, String message, String type, String value,
       DuplicateMappingException error) {
     super(location, message, error);
@@ -61,7 +56,7 @@ public class DuplicateMappingSourceProblem extends MavenProblemInfo {
     marker.setAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_TYPE, type);
     marker.setAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_VALUE, value);
 
-    Bundle[] bundles = Arrays.stream(conflictingSources).map(LifecycleMappingMetadataSource::getSource)
+    Bundle[] bundles = conflictingSources.stream().map(LifecycleMappingMetadataSource::getSource)
         .filter(Bundle.class::isInstance).map(Bundle.class::cast).toArray(Bundle[]::new);
     marker.setAttribute(IMavenConstants.MARKER_DUPLICATEMAPPING_SOURCES, bundles.length);
     for(int i = 0; i < bundles.length; i++ ) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicatePluginExecutionMetadataException.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/DuplicatePluginExecutionMetadataException.java
@@ -13,9 +13,8 @@
 
 package org.eclipse.m2e.core.internal.lifecyclemapping;
 
-import java.util.Arrays;
+import java.util.List;
 
-import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.PluginExecutionMetadata;
 
 
@@ -26,18 +25,17 @@ public class DuplicatePluginExecutionMetadataException extends DuplicateMappingE
 
   private static final long serialVersionUID = 1L;
 
-  private final PluginExecutionMetadata[] pluginExecutionMetadatas;
+  private final List<PluginExecutionMetadata> pluginExecutionMetadatas;
 
-  public DuplicatePluginExecutionMetadataException(PluginExecutionMetadata... pluginExecutionMetadatas) {
-    super(Arrays.stream(pluginExecutionMetadatas).map(PluginExecutionMetadata::getSource)
-        .toArray(LifecycleMappingMetadataSource[]::new));
+  public DuplicatePluginExecutionMetadataException(List<PluginExecutionMetadata> pluginExecutionMetadatas) {
+    super(pluginExecutionMetadatas.stream().map(PluginExecutionMetadata::getSource).toList());
     this.pluginExecutionMetadatas = pluginExecutionMetadatas;
   }
 
   /**
    * @return Returns the sources.
    */
-  public PluginExecutionMetadata[] getConflictingMetadata() {
+  public List<PluginExecutionMetadata> getConflictingMetadata() {
     return this.pluginExecutionMetadatas;
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/LifecycleMappingFactory.java
@@ -304,7 +304,7 @@ public class LifecycleMappingFactory {
   }
 
   public static void addLifecyclePluginExecution(LifecycleMappingMetadataSource mapping, String groupId,
-      String artifactId, String version, String[] goals, PluginExecutionAction action) {
+      String artifactId, String version, List<String> goals, PluginExecutionAction action) {
 
     PluginExecutionMetadata execution = getPluginExecutionMetadata(mapping, groupId, artifactId, version, action);
 
@@ -637,7 +637,7 @@ public class LifecycleMappingFactory {
               }
               if(isPrimaryMapping(executionMetadata, sorter)) {
                 if(primaryMetadata != null) {
-                  throw new DuplicatePluginExecutionMetadataException(primaryMetadata, executionMetadata);
+                  throw new DuplicatePluginExecutionMetadataException(List.of(primaryMetadata, executionMetadata));
                 }
                 primaryMetadata = executionMetadata;
               }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/SimpleMappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/SimpleMappingMetadataSource.java
@@ -81,11 +81,10 @@ public class SimpleMappingMetadataSource implements MappingMetadataSource {
     List<LifecycleMappingMetadata> matching = stream.toList();
     if(matching.isEmpty()) {
       return null;
-    }
-    if(matching.size() == 1) {
+    } else if(matching.size() == 1) {
       return matching.get(0);
     }
-    throw new DuplicateLifecycleMappingMetadataException(matching.toArray(LifecycleMappingMetadata[]::new));
+    throw new DuplicateLifecycleMappingMetadataException(matching);
   }
 
   @Override

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -64,7 +64,6 @@ import org.apache.maven.model.Parent;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IComponentLookup;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
@@ -629,7 +628,7 @@ public class ProjectConfigurationManager
   // project creation
 
   @Override
-  public void createSimpleProject(IProject project, IPath location, Model model, String[] directories,
+  public void createSimpleProject(IProject project, IPath location, Model model, List<String> directories,
       ProjectImportConfiguration configuration, IProgressMonitor monitor) throws CoreException {
     createSimpleProject(project, location, model, directories, configuration, null, monitor);
   }
@@ -649,7 +648,7 @@ public class ProjectConfigurationManager
    */
   // XXX should use Maven plugin configurations instead of manually specifying folders
   @Override
-  public void createSimpleProject(IProject project, IPath location, Model model, String[] directories,
+  public void createSimpleProject(IProject project, IPath location, Model model, List<String> directories,
       ProjectImportConfiguration configuration, IProjectCreationListener listener, IProgressMonitor monitor)
       throws CoreException {
     String projectName = project.getName();
@@ -847,7 +846,7 @@ public class ProjectConfigurationManager
   }
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     for(MavenProjectChangedEvent event : events) {
       try {
         IMavenProjectFacade facade = event.getMavenProject();
@@ -917,15 +916,11 @@ public class ProjectConfigurationManager
     if(!MavenPlugin.getMavenConfiguration().isHideFoldersOfNestedProjects()) {
       return Collections.emptyList();
     }
-    IMavenProjectFacade[] existingFacades = projectManager.getProjects();
-    if(existingFacades == null || existingFacades.length == 0) {
+    List<MavenProjectFacade> existingFacades = projectManager.getProjects();
+    if(existingFacades == null || existingFacades.isEmpty()) {
       return Collections.emptyList();
     }
-    List<IProject> existingProjects = new ArrayList<>(existingFacades.length);
-    for(IMavenProjectFacade f : existingFacades) {
-      existingProjects.add(f.getProject());
-    }
-    return existingProjects;
+    return existingFacades.stream().map(IMavenProjectFacade::getProject).toList();
   }
 
   private static final String GROUP_ID = "[groupId]"; //$NON-NLS-1$

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/WorkspaceStateWriter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/WorkspaceStateWriter.java
@@ -15,6 +15,7 @@ package org.eclipse.m2e.core.internal.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -59,7 +60,7 @@ public class WorkspaceStateWriter implements IMavenProjectChangedListener {
 
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     try {
       MutableWorkspaceState state = new MutableWorkspaceState();
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/conversion/ProjectConversionParticipantSorter.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/conversion/ProjectConversionParticipantSorter.java
@@ -20,7 +20,6 @@
 
 package org.eclipse.m2e.core.internal.project.conversion;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -108,38 +107,25 @@ public class ProjectConversionParticipantSorter {
       AbstractProjectConversionParticipant converter = converterMap.get(converterId);
 
       //Add edges for all the converters this converter should run after
-      String[] predecessors = converter.getPrecedingConverterIds();
-      if(predecessors != null) {
-        for(String id : predecessors) {
-          Vertex predecessor = dag.getVertex(id);
-          if(predecessor != null) {
-            dag.addEdge(converterVx, predecessor);
-          }
+      List<String> predecessors = converter.getPrecedingConverterIds();
+      for(String id : predecessors) {
+        Vertex predecessor = dag.getVertex(id);
+        if(predecessor != null) {
+          dag.addEdge(converterVx, predecessor);
         }
       }
 
       //Add edges for all the converters this converter should run before
-      String[] successors = converter.getSucceedingConverterIds();
-      if(successors != null) {
-        for(String id : successors) {
-          Vertex successor = dag.getVertex(id);
-          if(successor != null) {
-            dag.addEdge(successor, converterVx);
-          }
+      List<String> successors = converter.getSucceedingConverterIds();
+      for(String id : successors) {
+        Vertex successor = dag.getVertex(id);
+        if(successor != null) {
+          dag.addEdge(successor, converterVx);
         }
       }
-
     }
-
     List<String> sortedConverterIds = TopologicalSorter.sort(dag);
-
-    List<AbstractProjectConversionParticipant> sortedConverters = new ArrayList<>(
-        converters.size());
-
-    for(String id : sortedConverterIds) {
-      sortedConverters.add(converterMap.get(id));
-    }
-    this.sortedConverters = Collections.unmodifiableList(sortedConverters);
+    this.sortedConverters = sortedConverterIds.stream().map(converterMap::get).toList();
   }
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.m2e.core.internal.project.registry;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -63,6 +62,6 @@ public abstract class AbstractMavenDependencyResolver {
   }
 
   protected List<MavenProjectFacade> getProjects() {
-    return Arrays.asList(contextRegistry.getProjects());
+    return contextRegistry.getProjects();
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -123,11 +124,8 @@ abstract class BasicProjectRegistry implements Serializable {
     return workspacePoms.get(paths.iterator().next());
   }
 
-  /**
-   * @TODO return a List
-   */
-  public MavenProjectFacade[] getProjects() {
-    return workspacePoms.values().toArray(new MavenProjectFacade[workspacePoms.size()]);
+  public List<MavenProjectFacade> getProjects() {
+    return List.copyOf(workspacePoms.values());
   }
 
   public Map<ArtifactKey, Collection<IFile>> getWorkspaceArtifacts(String groupId, String artifactId) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/IProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/IProjectRegistry.java
@@ -14,6 +14,7 @@
 package org.eclipse.m2e.core.internal.project.registry;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
@@ -32,7 +33,7 @@ public interface IProjectRegistry {
 
   MavenProjectFacade getProjectFacade(String groupId, String artifactId, String version);
 
-  MavenProjectFacade[] getProjects();
+  List<MavenProjectFacade> getProjects();
 
   Map<ArtifactKey, Collection<IFile>> getWorkspaceArtifacts(String groupId, String artifactId);
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -88,13 +88,13 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
 
   private final String packaging;
 
-  private final IPath[] resourceLocations;
+  private final List<IPath> resourceLocations;
 
-  private final IPath[] testResourceLocations;
+  private final List<IPath> testResourceLocations;
 
-  private final IPath[] compileSourceLocations;
+  private final List<IPath> compileSourceLocations;
 
-  private final IPath[] testCompileSourceLocations;
+  private final List<IPath> testCompileSourceLocations;
 
   private final IPath outputLocation;
 
@@ -180,10 +180,10 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     this.packaging = other.packaging;
     this.modules = new ArrayList<>(other.modules);
 
-    this.resourceLocations = arrayCopy(other.resourceLocations);
-    this.testResourceLocations = arrayCopy(other.testResourceLocations);
-    this.compileSourceLocations = arrayCopy(other.compileSourceLocations);
-    this.testCompileSourceLocations = arrayCopy(other.testCompileSourceLocations);
+    this.resourceLocations = List.copyOf(other.resourceLocations);
+    this.testResourceLocations = List.copyOf(other.testResourceLocations);
+    this.compileSourceLocations = List.copyOf(other.compileSourceLocations);
+    this.testCompileSourceLocations = List.copyOf(other.testCompileSourceLocations);
 
     this.outputLocation = other.outputLocation;
     this.testOutputLocation = other.testOutputLocation;
@@ -196,15 +196,11 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     this.timestamp = Arrays.copyOf(other.timestamp, other.timestamp.length);
   }
 
-  private static <T> T[] arrayCopy(T[] a) {
-    return Arrays.copyOf(a, a.length);
-  }
-
   /**
    * Returns project relative paths of resource directories
    */
   @Override
-  public IPath[] getResourceLocations() {
+  public List<IPath> getResourceLocations() {
     return resourceLocations;
   }
 
@@ -212,17 +208,17 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
    * Returns project relative paths of test resource directories
    */
   @Override
-  public IPath[] getTestResourceLocations() {
+  public List<IPath> getTestResourceLocations() {
     return testResourceLocations;
   }
 
   @Override
-  public IPath[] getCompileSourceLocations() {
+  public List<IPath> getCompileSourceLocations() {
     return compileSourceLocations;
   }
 
   @Override
-  public IPath[] getTestCompileSourceLocations() {
+  public List<IPath> getTestCompileSourceLocations() {
     return testCompileSourceLocations;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectManager.java
@@ -14,7 +14,9 @@
 package org.eclipse.m2e.core.internal.project.registry;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -69,8 +71,8 @@ public class MavenProjectManager implements IMavenProjectRegistry {
     File bundleStateLocation = result.toFile();
     this.workspaceStateFile = new File(bundleStateLocation, STATE_FILENAME);
     boolean updateProjectsOnStartup = configuration.isUpdateProjectsOnStartup();
-    if(updateProjectsOnStartup || manager.getProjects().length == 0) {
-      refresh(new MavenUpdateRequest(workspace.getRoot().getProjects(), //
+    if(updateProjectsOnStartup || manager.getProjects().isEmpty()) {
+      refresh(new MavenUpdateRequest(Arrays.asList(workspace.getRoot().getProjects()), //
           configuration.isOffline() /*offline*/, false /* updateSnapshots */));
     }
   }
@@ -109,8 +111,9 @@ public class MavenProjectManager implements IMavenProjectRegistry {
   }
 
   @Override
-  public IMavenProjectFacade[] getProjects() {
-    return manager.getProjects();
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public List<IMavenProjectFacade> getProjects() {
+    return (List) manager.getProjects();
   }
 
   //XXX mkleint: this only returns a correct facade for the project's own pom.xml, if the POM file is nested, the result is wrong.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MutableProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MutableProjectRegistry.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -160,7 +161,7 @@ public class MutableProjectRegistry extends BasicProjectRegistry implements IPro
   }
 
   @Override
-  public MavenProjectFacade[] getProjects() {
+  public List<MavenProjectFacade> getProjects() {
     if(isClosed()) {
       return parent.getProjects();
     }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistry.java
@@ -49,7 +49,7 @@ public class ProjectRegistry extends BasicProjectRegistry implements IProjectReg
   }
 
   @Override
-  public synchronized MavenProjectFacade[] getProjects() {
+  public synchronized List<MavenProjectFacade> getProjects() {
     return super.getProjects();
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -822,15 +822,14 @@ public class ProjectRegistryManager implements ISaveParticipant {
   }
 
   public void notifyProjectChangeListeners(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
-    if(events.size() > 0) {
-      MavenProjectChangedEvent[] eventsArray = events.toArray(new MavenProjectChangedEvent[events.size()]);
-      ArrayList<IMavenProjectChangedListener> listeners = new ArrayList<>();
+    if(!events.isEmpty()) {
+      List<IMavenProjectChangedListener> listeners = new ArrayList<>();
       synchronized(this.projectChangeListeners) {
         listeners.addAll(this.projectChangeListeners);
       }
       listeners.addAll(ExtensionReader.readProjectChangedEventListenerExtentions());
       for(IMavenProjectChangedListener listener : listeners) {
-        listener.mavenProjectChanged(eventsArray, monitor);
+        listener.mavenProjectChanged(events, monitor);
       }
     }
   }
@@ -887,7 +886,7 @@ public class ProjectRegistryManager implements ISaveParticipant {
     }
   }
 
-  public IMavenProjectFacade[] getProjects() {
+  public List<MavenProjectFacade> getProjects() {
     return projectRegistry.getProjects();
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/repository/RepositoryRegistry.java
@@ -114,7 +114,7 @@ public class RepositoryRegistry implements IRepositoryRegistry, IMavenProjectCha
   }
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     /*
      * This method is called while holding workspace lock. Avoid long-running operations if possible.
      */

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectChangedListener.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectChangedListener.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.core.project;
 
+import java.util.List;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 
 
@@ -20,5 +22,5 @@ public interface IMavenProjectChangedListener {
   /**
    * This method is called while holding workspace lock.
    */
-  void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor);
+  void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor);
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -48,16 +48,16 @@ public interface IMavenProjectFacade extends IMavenExecutableLocation {
   /**
    * Returns project relative paths of resource directories
    */
-  IPath[] getResourceLocations();
+  List<IPath> getResourceLocations();
 
   /**
    * Returns project relative paths of test resource directories
    */
-  IPath[] getTestResourceLocations();
+  List<IPath> getTestResourceLocations();
 
-  IPath[] getCompileSourceLocations();
+  List<IPath> getCompileSourceLocations();
 
-  IPath[] getTestCompileSourceLocations();
+  List<IPath> getTestCompileSourceLocations();
 
   /**
    * Returns project resource for given file system location or null the location is outside of project.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectRegistry.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectRegistry.java
@@ -14,6 +14,7 @@
 package org.eclipse.m2e.core.project;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -57,7 +58,7 @@ public interface IMavenProjectRegistry {
   /**
    * Returns IMavenProjectFacade for all opened Maven workspace projects.
    */
-  IMavenProjectFacade[] getProjects();
+  List<IMavenProjectFacade> getProjects();
 
   /**
    * You can also use <code>Adapters.adapt(resource, IMavenProjectFacade.class)</code>.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
@@ -43,13 +43,13 @@ public interface IProjectConfigurationManager {
       ProjectImportConfiguration configuration, IProjectCreationListener importListener, IProgressMonitor monitor)
           throws CoreException;
 
-  void createSimpleProject(IProject project, IPath location, Model model, String[] folders,
+  void createSimpleProject(IProject project, IPath location, Model model, List<String> folders,
       ProjectImportConfiguration configuration, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @since 1.8
    */
-  void createSimpleProject(IProject project, IPath location, Model model, String[] folders,
+  void createSimpleProject(IProject project, IPath location, Model model, List<String> folders,
       ProjectImportConfiguration configuration, IProjectCreationListener importListener, IProgressMonitor monitor)
           throws CoreException;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenProjectUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenProjectUtils.java
@@ -53,15 +53,16 @@ public class MavenProjectUtils {
     return directory.removeFirstSegments(projectLocation.segmentCount()).makeRelative().setDevice(null);
   }
 
-  public static IPath[] getResourceLocations(IProject project, List<Resource> resources) {
+  public static List<IPath> getResourceLocations(IProject project, List<Resource> resources) {
     LinkedHashSet<IPath> locations = new LinkedHashSet<>();
     for(Resource resource : resources) {
       locations.add(getProjectRelativePath(project, resource.getDirectory()));
     }
-    return locations.toArray(new IPath[locations.size()]);
+    locations.remove(null);
+    return List.copyOf(locations);
   }
 
-  public static IPath[] getSourceLocations(IProject project, List<String> roots) {
+  public static List<IPath> getSourceLocations(IProject project, List<String> roots) {
     LinkedHashSet<IPath> locations = new LinkedHashSet<>();
     for(String root : roots) {
       IPath path = getProjectRelativePath(project, root);
@@ -69,7 +70,7 @@ public class MavenProjectUtils {
         locations.add(path);
       }
     }
-    return locations.toArray(new IPath[locations.size()]);
+    return List.copyOf(locations);
   }
 
   /**
@@ -92,3 +93,4 @@ public class MavenProjectUtils {
     return resource != null ? resource.getFullPath() : null;
   }
 }
+

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenUpdateRequest.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/MavenUpdateRequest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.m2e.core.project;
 
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -55,7 +56,7 @@ public class MavenUpdateRequest {
     addPomFile(project);
   }
 
-  public MavenUpdateRequest(IProject[] projects, boolean offline, boolean updateSnapshots) {
+  public MavenUpdateRequest(Collection<IProject> projects, boolean offline, boolean updateSnapshots) {
     this(offline, updateSnapshots);
 
     for(IProject project : projects) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
@@ -128,7 +128,7 @@ public abstract class AbstractProjectConfigurator implements IExecutableExtensio
   // IMavenProjectChangedListener
 
   @Override
-  public final void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public final void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     for(MavenProjectChangedEvent event : events) {
       try {
         mavenProjectChanged(event, monitor);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/AbstractProjectConversionEnabler.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/AbstractProjectConversionEnabler.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.core.project.conversion;
 
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -27,7 +29,8 @@ import org.eclipse.core.runtime.Status;
 public abstract class AbstractProjectConversionEnabler implements IProjectConversionEnabler {
 
   private static final String JAR = "jar"; //$NON-NLS-1$
-  private static final String[] PACKAGING_OPTIONS = {JAR};
+
+  private static final List<String> PACKAGING_OPTIONS = List.of(JAR);
 
 
   @Override
@@ -41,7 +44,7 @@ public abstract class AbstractProjectConversionEnabler implements IProjectConver
   }
 
   @Override
-  public String[] getPackagingTypes(IProject project) {
+  public List<String> getPackagingTypes(IProject project) {
     return PACKAGING_OPTIONS;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/AbstractProjectConversionParticipant.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/AbstractProjectConversionParticipant.java
@@ -16,6 +16,7 @@ package org.eclipse.m2e.core.project.conversion;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
@@ -49,9 +50,9 @@ public abstract class AbstractProjectConversionParticipant implements IExecutabl
 
   private String id;
 
-  private String[] runsAfter;
+  private List<String> runsAfter = Collections.emptyList();
 
-  private String[] runsBefore;
+  private List<String> runsBefore = Collections.emptyList();
 
   public String getName() {
     return name;
@@ -75,9 +76,9 @@ public abstract class AbstractProjectConversionParticipant implements IExecutabl
   /**
    * Split a String using the comma delimiter, ignore whitespace.
    */
-  protected String[] split(String str) {
+  protected List<String> split(String str) {
     if(str == null) {
-      return null;
+      return Collections.emptyList();
     }
     String[] split = str.split(",");
     ArrayList<String> list = new ArrayList<>(split.length);
@@ -87,10 +88,7 @@ public abstract class AbstractProjectConversionParticipant implements IExecutabl
         list.add(s);
       }
     }
-
-    String[] result = new String[list.size()];
-    list.toArray(result);
-    return result;
+    return list;
   }
 
   /**
@@ -151,7 +149,7 @@ public abstract class AbstractProjectConversionParticipant implements IExecutabl
    *
    * @since 1.3
    */
-  public String[] getPrecedingConverterIds() {
+  public List<String> getPrecedingConverterIds() {
     return runsAfter;
   }
 
@@ -160,7 +158,7 @@ public abstract class AbstractProjectConversionParticipant implements IExecutabl
    *
    * @since 1.3
    */
-  public String[] getSucceedingConverterIds() {
+  public List<String> getSucceedingConverterIds() {
     return runsBefore;
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/IProjectConversionEnabler.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/conversion/IProjectConversionEnabler.java
@@ -13,8 +13,11 @@
 
 package org.eclipse.m2e.core.project.conversion;
 
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
+
 
 /**
  * IProjectConversionEnabler
@@ -31,24 +34,20 @@ public interface IProjectConversionEnabler {
   boolean accept(IProject project);
 
   /**
-   * Test if project should be converted to Maven. Enablers might have reasons for
-   * not allowing certain types of project to be converted to Maven
+   * Test if project should be converted to Maven. Enablers might have reasons for not allowing certain types of project
+   * to be converted to Maven
    *
-   * @return IStatus indicating if project can be converted or not. if the project should
-   * not be converted, the severity must be set to IStatus.ERROR. If the project should be converted,
-   * the severity must be set to IStatus.OK. This method should not return null.
+   * @return IStatus indicating if project can be converted or not. if the project should not be converted, the severity
+   *         must be set to IStatus.ERROR. If the project should be converted, the severity must be set to IStatus.OK.
+   *         This method should not return null.
    */
   IStatus canBeConverted(IProject project);
 
-
   /**
-   * If project can be converted to Maven, the enabler should provide the suggested packaging types
-   * for the project.
+   * If project can be converted to Maven, the enabler should provide the suggested packaging types for the project.
    *
    * @return array of suggested packaging types. This should not return null.
    */
-  String[] getPackagingTypes(IProject project);
-
-
+  List<String> getPackagingTypes(IProject project);
 
 }

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/startup/UpdateConfigurationStartup.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/startup/UpdateConfigurationStartup.java
@@ -44,8 +44,8 @@ public class UpdateConfigurationStartup implements IStartup {
   private static final String PROJECT_PREF = DiscoveryActivator.PLUGIN_ID + ".pref.projects"; //$NON-NLS-1$
 
   public void earlyStartup() {
-    IProject[] projects = getSavedProjects();
-    if(projects != null && projects.length > 0) {
+    List<IProject> projects = getSavedProjects();
+    if(!projects.isEmpty()) {
       updateConfiguration(projects);
     }
     disableStartup();
@@ -88,10 +88,10 @@ public class UpdateConfigurationStartup implements IStartup {
    */
   public static void updateConfiguration() {
     Collection<IProject> projects = getMarkedProjects();
-    new UpdateMavenProjectJob(projects.toArray(new IProject[projects.size()])).schedule();
+    updateConfiguration(projects);
   }
 
-  private static void updateConfiguration(IProject[] projects) {
+  private static void updateConfiguration(Collection<IProject> projects) {
     new UpdateMavenProjectJob(projects).schedule();
   }
 
@@ -138,7 +138,7 @@ public class UpdateConfigurationStartup implements IStartup {
   }
 
   private static void setEarlyActivationPreference(String[] disabledPlugins) {// Add ourself to disabled
-	StringBuilder preference = new StringBuilder();
+    StringBuilder preference = new StringBuilder();
     for(String item : disabledPlugins) {
       preference.append(item).append(IPreferenceConstants.SEPARATOR);
     }
@@ -151,7 +151,7 @@ public class UpdateConfigurationStartup implements IStartup {
   /*
    * Get projects we saved previously
    */
-  public static IProject[] getSavedProjects() {
+  public static List<IProject> getSavedProjects() {
     String[] projectNames = DiscoveryActivator.getDefault().getPreferenceStore().getString(PROJECT_PREF)
         .split(String.valueOf(IPreferenceConstants.SEPARATOR));
     List<IProject> projects = new ArrayList<>(projectNames.length);
@@ -164,7 +164,7 @@ public class UpdateConfigurationStartup implements IStartup {
         }
       }
     }
-    return projects.toArray(new IProject[projects.size()]);
+    return projects;
   }
 
   /*

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/ConflictingLifecycleMappingResolution.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/internal/lifecycle/ConflictingLifecycleMappingResolution.java
@@ -16,7 +16,6 @@ package org.eclipse.m2e.editor.internal.lifecycle;
 import java.util.List;
 
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.text.IDocument;
@@ -84,7 +83,7 @@ public class ConflictingLifecycleMappingResolution extends AbstractLifecycleMapp
     // must kick off an update project job since the pom isn't modified.
     // Only update the project from where this quick fix was executed.
     // Other projects can be updated manually
-    new UpdateMavenProjectJob(getProjects(markers.stream()).toArray(IProject[]::new)).schedule();
+    new UpdateMavenProjectJob(getProjects(markers.stream())).schedule();
   }
 
   /**

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/DependencyTreePage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/DependencyTreePage.java
@@ -1113,7 +1113,7 @@ public class DependencyTreePage extends FormPage implements IMavenProjectChanged
   }
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     if(getManagedForm() == null || getManagedForm().getForm() == null)
       return;
 

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditor.java
@@ -1055,7 +1055,7 @@ public class MavenPomEditor extends FormEditor implements IResourceChangeListene
    */
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     IEditorInput input = getEditorInput();
     if(input instanceof IFileEditorInput fileinput) {
       for(MavenProjectChangedEvent event : events) {

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/pom/MavenPomEditorPage.java
@@ -610,8 +610,7 @@ public abstract class MavenPomEditorPage extends FormPage {
       modulePath = modulePath.append("pom.xml"); //$NON-NLS-1$
     }
     IMavenProjectRegistry projectManager = MavenPlugin.getMavenProjectRegistry();
-    IMavenProjectFacade[] facades = projectManager.getProjects();
-    for(IMavenProjectFacade facade : facades) {
+    for(IMavenProjectFacade facade : projectManager.getProjects()) {
       if(modulePath.equals(facade.getPom().getLocation())) {
         return facade;
       }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/MavenJdtPlugin.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/MavenJdtPlugin.java
@@ -24,6 +24,7 @@
 package org.eclipse.m2e.jdt;
 
 import java.io.File;
+import java.util.List;
 
 import org.osgi.framework.BundleContext;
 
@@ -234,7 +235,7 @@ public class MavenJdtPlugin extends Plugin {
       done = false;
       IMavenConfiguration mavenConfiguration = MavenPlugin.getMavenConfiguration();
       if(mavenConfiguration.isDownloadSources() || mavenConfiguration.isDownloadJavaDoc()) {
-        IMavenProjectFacade[] facades = MavenPlugin.getMavenProjectRegistry().getProjects();
+        List<IMavenProjectFacade> facades = MavenPlugin.getMavenProjectRegistry().getProjects();
         for(IMavenProjectFacade facade : facades) {
           if(monitor.isCanceled()) {
             break;

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/BuildPathManager.java
@@ -180,7 +180,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
   }
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     Set<IProject> projects = new HashSet<>();
     monitor.setTaskName(Messages.BuildPathManager_monitor_setting_cp);
     for(MavenProjectChangedEvent event : events) {
@@ -325,8 +325,8 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
   private static final String ARTIFACT_TYPE_JAR = "jar";
 
   private boolean isUnavailable(ArtifactKey a, List<ArtifactRepository> repositories) throws CoreException {
-    return maven.isUnavailable(a.groupId(), a.artifactId(), a.version(), ARTIFACT_TYPE_JAR /*type*/,
-        a.classifier(), repositories);
+    return maven.isUnavailable(a.groupId(), a.artifactId(), a.version(), ARTIFACT_TYPE_JAR /*type*/, a.classifier(),
+        repositories);
   }
 
 //  public void downloadSources(IProject project, ArtifactKey artifact, boolean downloadSources, boolean downloadJavaDoc) throws CoreException {
@@ -848,8 +848,7 @@ public class BuildPathManager implements IMavenProjectChangedListener, IResource
     if(repositories != null) {
       ArtifactKey sourcesArtifact = new ArtifactKey(a.groupId(), a.artifactId(), a.version(),
           getSourcesClassifier(a.classifier()));
-      ArtifactKey javadocArtifact = new ArtifactKey(a.groupId(), a.artifactId(), a.version(),
-          CLASSIFIER_JAVADOC);
+      ArtifactKey javadocArtifact = new ArtifactKey(a.groupId(), a.artifactId(), a.version(), CLASSIFIER_JAVADOC);
       if(downloadSources) {
         if(isUnavailable(sourcesArtifact, repositories)) {
           // 501553: fall back to requesting JavaDoc, if requested sources are missing,

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenLaunchConfigurationListener.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenLaunchConfigurationListener.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.m2e.jdt.internal.launch;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +124,7 @@ public class MavenLaunchConfigurationListener implements ILaunchConfigurationLis
   }
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     for(MavenProjectChangedEvent event : events) {
       try {
         switch(event.getKind()) {

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/AbstractPomRefactoring.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/AbstractPomRefactoring.java
@@ -106,8 +106,8 @@ public abstract class AbstractPomRefactoring extends Refactoring {
   @Override
   public Change createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
     CompositeChange res = new CompositeChange(getTitle());
-    IMavenProjectFacade[] projects = MavenPlugin.getMavenProjectRegistry().getProjects();
-    pm.beginTask(Messages.AbstractPomRefactoring_task, projects.length);
+    List<IMavenProjectFacade> projects = MavenPlugin.getMavenProjectRegistry().getProjects();
+    pm.beginTask(Messages.AbstractPomRefactoring_task, projects.size());
 
     models = new HashMap<>();
 

--- a/org.eclipse.m2e.sourcelookup/src/org/eclipse/m2e/sourcelookup/internal/launch/MavenSourceLookupParticipant.java
+++ b/org.eclipse.m2e.sourcelookup/src/org/eclipse/m2e/sourcelookup/internal/launch/MavenSourceLookupParticipant.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.m2e.sourcelookup.internal.launch;
 
+import java.util.List;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.sourcelookup.ISourceLookupDirector;
 import org.eclipse.jdt.launching.sourcelookup.advanced.AdvancedSourceLookupParticipant;
@@ -37,7 +39,7 @@ public class MavenSourceLookupParticipant extends AdvancedSourceLookupParticipan
   }
 
   @Override
-  public void mavenProjectChanged(MavenProjectChangedEvent[] events, IProgressMonitor monitor) {
+  public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
     disposeContainers();
   }
 }


### PR DESCRIPTION
In today's Java programs it is more common to use Lists (or other suitable Collections) than Arrays. Changing the APIs to return/accept Lists therefore avoid conversion, thus making the code more readable and more performant (although the overall impact is likely low).