### PR TITLE
Unify dev-data project names and make m2e-setup a project

### DIFF
--- a/products/.settings/org.eclipse.core.resources.prefs
+++ b/products/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/products/m2e-ide/Eclipse-M2E-IDE.launch
+++ b/products/m2e-ide/Eclipse-M2E-IDE.launch
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
     <setAttribute key="additional_plugins">
+        <setEntry value="org.apache.felix.scr:2.1.24.v20200924-1939:default:true:2:true"/>
+        <setEntry value="org.eclipse.core.runtime:3.25.0.v20220506-1157:default:true:default:true"/>
+        <setEntry value="org.eclipse.equinox.common:3.16.100.v20220315-2327:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.event:1.6.100.v20211021-1418:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.simpleconfigurator:1.4.0.v20210315-2228:default:true:1:true"/>
         <setEntry value="org.apache.xml.resolver:1.2.0.v20220401-1849:default:true:default:default"/>
         <setEntry value="org.eclipse.m2e.logback.configuration:1.17.0.qualifier:default:true:default:true"/>
     </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
     <booleanAttribute key="askclear" value="true"/>
-    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
+    <booleanAttribute key="automaticIncludeRequirements" value="true"/>
     <booleanAttribute key="automaticValidate" value="true"/>
     <stringAttribute key="bootstrap" value=""/>
     <stringAttribute key="checked" value="[NONE]"/>
@@ -17,16 +23,17 @@
     <booleanAttribute key="default" value="false"/>
     <stringAttribute key="featureDefaultLocation" value="workspace"/>
     <stringAttribute key="featurePluginResolution" value="workspace"/>
-    <booleanAttribute key="includeOptional" value="true"/>
-    <stringAttribute key="location" value="${workspace_loc}/../runtime-m2e-Eclipse-IDE"/>
+    <booleanAttribute key="includeOptional" value="false"/>
+    <stringAttribute key="location" value="${workspace_loc}/../runtime-m2e-ide.product"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
-    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM --illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED -Djava.security.manager=allow -Dfile.encoding=UTF-8"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
+    <stringAttribute key="productFile" value="\m2e-products\m2e-ide\m2e-ide.product"/>
     <setAttribute key="selected_features">
         <setEntry value="org.eclipse.m2e.feature:default"/>
         <setEntry value="org.eclipse.m2e.lemminx.feature:default"/>
@@ -35,7 +42,6 @@
         <setEntry value="org.eclipse.sdk:default"/>
     </setAttribute>
     <booleanAttribute key="show_selected_only" value="false"/>
-    <stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
     <booleanAttribute key="tracing" value="false"/>
     <booleanAttribute key="useCustomFeatures" value="true"/>
     <booleanAttribute key="useDefaultConfig" value="true"/>

--- a/products/m2e-ide/m2e-ide.product
+++ b/products/m2e-ide/m2e-ide.product
@@ -7,8 +7,6 @@
    </configIni>
 
    <launcherArgs>
-      <programArgs>-data @noDefault
-      </programArgs>
       <vmArgs>--add-modules=ALL-SYSTEM
 --illegal-access=permit 
 --add-opens java.base/java.lang=ALL-UNNAMED
@@ -45,6 +43,7 @@
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <property name="osgi.instance.area" value="@noDefault" />
    </configurations>
 
 </product>

--- a/setup/.project
+++ b/setup/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>m2e-target-platform</name>
+	<name>m2e-setup</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/setup/.settings/org.eclipse.core.resources.prefs
+++ b/setup/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -4,7 +4,7 @@
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.24/R-4.24-202206070700/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/eclipse/updates/4.24/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>


### PR DESCRIPTION
And fix warnings about missing project encoding and associate provided M2E launch-config with M2E product.