### PR TITLE
Move the tycho-version into the maven.config and unify build arguments

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,12 +43,12 @@ jobs:
     - name: Build m2e-core
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:
-       run: mvn clean verify -Pits -Dtycho.p2.baselineMode=failCommon --batch-mode
+       run: mvn clean verify --batch-mode -Pits -Dtycho.p2.baselineMode=failCommon -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
     - name: Upload Test Results
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: test-results-${{ matrix.os }}
-        if-no-files-found: error
+        if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
   event_file:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>4.0.4</version>
+    <version>${tycho-version}</version>
   </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -2,6 +2,7 @@
 --errors
 --update-snapshots
 --no-transfer-progress
--Dmaven.test.error.ignore=true
--Dmaven.test.failure.ignore=true
+--fail-at-end
+-Dtycho.localArtifacts=ignore
 -Dtycho.target.pomDependencies=consider
+-Dtycho-version=4.0.4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
 				xvnc(useXauthority: true) {
 					sh '''
-						mavenArgs="clean verify -Dtycho.p2.baselineMode=failCommon --batch-mode"
+						mavenArgs="clean verify --batch-mode -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Dtycho.p2.baselineMode=failCommon"
 						if [[ ${BRANCH_NAME} == master ]] || [[ ${BRANCH_NAME} =~ m2e-[0-9]+\\.[0-9]+\\.x ]]; then
 							mvn ${mavenArgs} -Peclipse-sign,its -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -Dgpg.keyname="011C526F29B2CE79"
 						else

--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -23,7 +23,6 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho-version>4.0.4</tycho-version>
 		<tycho.p2.baselineMode>warn</tycho.p2.baselineMode>
 		<scmConnectionRaw>scm:git:https://github.com/eclipse-m2e/m2e-core.git</scmConnectionRaw>
 	</properties>

--- a/setup/tychoSnapshotSettings.xml
+++ b/setup/tychoSnapshotSettings.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0	https://maven.apache.org/xsd/settings-1.0.0.xsd">
 	<!-- This Maven-settings file allows to test Tycho snapshots without the need to install them into the local Maven repository 
 		and thus makes it possible to test snapshots of Tycho's extension in the CI.
-		To use it, add the following arguments to the Maven command: -s setup/tychoSnapshotSettings.xml -U -->
+		To use it, add the following line of arguments to the '.mvn/maven.config' file: -s setup/tychoSnapshotSettings.xml -U -->
 	<profiles>
 		<profile>
 			<id>tycho-snapshots</id>


### PR DESCRIPTION
This avoids duplicated specification of build parameters in the different builds.

However I'm a bit concerned because now if one runs the build locally test failures and errors do not let the build fail and one has to look it up on the console.

Alternatively we could use --fail-at-end, but then only projects are build that don't depend on the failed once. On the other hand, a test project should not have dependents? So probably that would be the better option.