### PR TITLE
Remove legacyMavenProjects cache from ProjectRegistryManager

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,11 @@ The legacy textual editor is removed as it doesn't receive enough update/mainten
 
 m2e-apt plugins that were so far included in JBoss Tools were migrated into m2e and are shipped by default with m2e installations. So annotation processing should be better supported out of the box.
 
+### Stop caching of Maven-projects for legacy clients
+
+For for clients that request setup MojoExecution outside of MavenBuilder context the MavenProject is not longer cached any more.
+In general MojoExecutions should be set up within the scope of `MavenExecutionContext`.
+
 ## 1.20.1
 
 * 📅 Release Date: March 04th 2022


### PR DESCRIPTION
That legacy cache was introduce with commit 561d6fbfd7c132dcdc29f4bd610aa2a590c498c7.
This was 9 years ago and I think with a major release like 2.0 it is a good opportunity to get rid of that heritage.


Does anybody know if there are more places where support for legacy usage outside the scope of a `MavenExecutionContext` exists?