### PR TITLE
Make ProjectRegistryManager's project-cache size configurable

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -1128,7 +1128,7 @@ public class ProjectRegistryManager implements ISaveParticipant {
   }
 
   private Map<MavenProjectFacade, MavenProject> createProjectCache() {
-    int maxCacheSize = 5;
+    int maxCacheSize = Integer.getInteger("m2e.project.cache.size", 20);
     return Collections.synchronizedMap(new LinkedHashMap<>(maxCacheSize * 4 / 3 + 1, 0.75f, true) {
       private static final long serialVersionUID = 8022606648487974598L;
 


### PR DESCRIPTION
... and increase the default size to 20.

As requested in https://github.com/eclipse-m2e/m2e-core/pull/507#issuecomment-1086624238 and https://github.com/eclipse-m2e/m2e-core/issues/157 this make the internal `ProjectRegistryManager` cache size configurable and increases the default size of the cache from 5 to 20.

With this one can adjust the cache size to the desired value by adding a VM argument `-Dm2e.project.cache.size=<desired-value>` for example the the `eclipse.ini`.

@mickaelistria, @laeubi any objections?