### PR TITLE
Consider maven.config in multimodule root

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/java/org/apache/maven/cli/MavenCLIParser.java
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/java/org/apache/maven/cli/MavenCLIParser.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 Hannes Wellmann and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+
+package org.apache.maven.cli;
+
+import java.io.File;
+import java.util.regex.Pattern;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MavenCLIParser {
+	private MavenCLIParser() {
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MavenCLIParser.class);
+
+	public static void populateCLIOptions(MavenExecutionRequest request) {
+		try {
+			File multiModuleProjectDirectory = request.getMultiModuleProjectDirectory();
+			CommandLine cl;
+			CliRequest cliRequest = new CliRequest(new String[0], null);
+			if (multiModuleProjectDirectory != null) {
+				cliRequest.multiModuleProjectDirectory = multiModuleProjectDirectory;
+				new MavenCli().cli(cliRequest);
+				cl = cliRequest.commandLine;
+			} else {
+				cl = new CLIManager().parse(cliRequest.getArgs());
+			}
+			MavenCli.populateProperties(cl, request.getSystemProperties(), request.getUserProperties());
+
+			populateProfilesProfiles(request, cl);
+		} catch (Exception e) {
+			LOGGER.error("Failed to populate request for", e);
+		}
+	}
+
+	private static final Pattern COMMA = Pattern.compile(",");
+
+	private static void populateProfilesProfiles(MavenExecutionRequest request, CommandLine mavenConfig) {
+		// Based on MavenCli.populateRequest() section 'Profile Activation'
+		String[] profileOptionValues = mavenConfig.getOptionValues(CLIManager.ACTIVATE_PROFILES);
+		if (profileOptionValues != null) {
+			for (String profileValue : profileOptionValues) {
+				COMMA.splitAsStream(profileValue).map(String::trim).forEach(profileAction -> {
+					if (profileAction.startsWith("-") || profileAction.startsWith("!")) {
+						request.addInactiveProfile(profileAction.substring(1));
+					} else if (profileAction.startsWith("+")) {
+						request.addActiveProfile(profileAction.substring(1));
+					} else {
+						request.addActiveProfile(profileAction);
+					}
+				});
+			}
+		}
+	}
+
+	// TODO: parse more?
+
+}

--- a/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/.mvn/extensions.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>${tycho-version-for-extension-test}</version>
+	</extension>
+</extensions>

--- a/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/.mvn/maven.config
+++ b/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho-version-for-extension-test=3.0.0

--- a/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/bundle/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle
+Bundle-SymbolicName: my.bundle
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: my.bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/bundle/build.properties
+++ b/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/bundle/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/pom.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/mavenConfig/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>tycho-pomless</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<modules>
+		<module>bundle</module>
+	</modules>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version-for-extension-test}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Christoph Läubrich and others.
+ * Copyright (c) 2022, 2023 Christoph Läubrich and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -73,15 +73,26 @@ public class ExtensionsTest extends AbstractMavenProjectTestCase {
 
 	@Test
 	public void testReloadExtensionAfterDeletion() throws Exception {
-		IProject project1 = importPomlessProject("pomless", "bundle/pom.xml");
+		IProject project = importPomlessProject("pomless", "bundle/pom.xml");
+
 		waitForJobsToComplete(monitor);
-		assertEquals("my.bundle", project1.getName());
+		assertEquals("my.bundle", project.getName());
 
 		WorkspaceHelpers.cleanWorkspace();
 
-		project1 = importPomlessProject("pomless", "bundle/pom.xml");
+		project = importPomlessProject("pomless", "bundle/pom.xml");
 		waitForJobsToComplete(monitor);
-		assertEquals("my.bundle", project1.getName());
+		assertEquals("my.bundle", project.getName());
+	}
+
+	@Test
+	public void testMavenConfigWithCoreExtension() throws Exception {
+		IProject project = importPomlessProject("mavenConfig", "bundle/pom.xml");
+		projectRefreshJob.wakeUp();
+		waitForJobsToComplete(monitor);
+		assertEquals("my.bundle", project.getName());
+		assertNotNull(project.getNature("org.eclipse.m2e.core.maven2Nature"));
+		assertNoErrors(project);
 	}
 
 	@Test

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
@@ -22,22 +22,11 @@
 package org.eclipse.m2e.core.internal.embedder;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Properties;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
-
-import org.apache.maven.cli.MavenCli;
-import org.apache.maven.shared.utils.StringUtils;
 
 
 /**
@@ -50,95 +39,6 @@ import org.apache.maven.shared.utils.StringUtils;
  * @since 1.15
  */
 public class MavenProperties {
-
-  private static final Logger log = LoggerFactory.getLogger(MavenProperties.class);
-
-  private static final String BUILD_VERSION_PROPERTY = "version";
-
-  private static final String BUILD_VERSION_UNKNOWN_PROPERTY = "<version unknown>";
-
-  private static String mavenVersion;
-
-  private static String mavenBuildVersion;
-
-  static {
-    Properties properties = getMavenRuntimeProperties();
-    mavenVersion = properties.getProperty(BUILD_VERSION_PROPERTY, BUILD_VERSION_UNKNOWN_PROPERTY);
-    mavenBuildVersion = createMavenVersionString(properties);
-  }
-
-  private MavenProperties() {
-    //prevent instanciation
-  }
-
-  static Properties getMavenRuntimeProperties() {
-    Properties properties = new Properties();
-
-    try (InputStream resourceAsStream = MavenCli.class
-        .getResourceAsStream("/org/apache/maven/messages/build.properties")) {
-      if(resourceAsStream != null) {
-        properties.load(resourceAsStream);
-      }
-    } catch(IOException e) {
-      log.error("Unable to read Maven properties from JAR file: {}", e.getMessage());
-    }
-    return properties;
-  }
-
-  /**
-   * Create a human readable string containing the Maven version, buildnumber, and time of build
-   *
-   * @param buildProperties The build properties
-   * @return Readable build info
-   */
-  static String createMavenVersionString(Properties buildProperties) {
-    String timestamp = reduce(buildProperties.getProperty("timestamp"));
-    String version = reduce(buildProperties.getProperty(BUILD_VERSION_PROPERTY));
-    String rev = reduce(buildProperties.getProperty("buildNumber"));
-    String distributionName = reduce(buildProperties.getProperty("distributionName"));
-
-    String msg = distributionName + " ";
-    msg += (version != null ? version : BUILD_VERSION_UNKNOWN_PROPERTY);
-    if(rev != null || timestamp != null) {
-      msg += " (";
-      msg += (rev != null ? rev : "");
-      if(StringUtils.isNotBlank(timestamp)) {
-        String ts = formatTimestamp(Long.parseLong(timestamp));
-        msg += (rev != null ? "; " : "") + ts;
-      }
-      msg += ")";
-    }
-    return msg;
-  }
-
-  private static String reduce(String s) {
-    return (s != null ? (s.startsWith("${") && s.endsWith("}") ? null : s) : null);
-  }
-
-  private static String formatTimestamp(long timestamp) {
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
-    return sdf.format(new Date(timestamp));
-  }
-
-  public static String getMavenBuildVersion() {
-    return mavenBuildVersion;
-  }
-
-  public static String getMavenVersion() {
-    return mavenVersion;
-  }
-
-  /**
-   * Add the "maven.version" and "maven.build.version" properties to the given properties
-   *
-   * @param properties
-   */
-  public static void setProperties(Properties properties) {
-    if(properties != null) {
-      properties.setProperty("maven.version", mavenVersion);
-      properties.setProperty("maven.build.version", mavenBuildVersion);
-    }
-  }
 
   public static File computeMultiModuleProjectDirectory(IResource resource) {
     if(resource == null) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Christoph Läubrich and others
+ * Copyright (c) 2022, 2023 Christoph Läubrich and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -178,12 +178,10 @@ public class PlexusContainerManager {
         } catch(ExtensionResolutionException e) {
           //TODO should we fail or should we return the standard container then and for example create an error marker on the project?
           CoreExtension extension = e.getExtension();
-          throw new PlexusContainerException(
-              "can't create plexus container for basedir = " + basedir.getAbsolutePath() + " because the extension "
-                  + extension.getGroupId() + ":" + extension.getArtifactId() + ":" + extension.getVersion()
-                  + " can't be loaded (defined in "
-                  + new File(directory, IMavenPlexusContainer.EXTENSIONS_FILENAME).getAbsolutePath() + ").",
-              e);
+          throw new PlexusContainerException("can't create plexus container for basedir = " + basedir.getAbsolutePath()
+              + " because the extension " + extension.getGroupId() + ":" + extension.getArtifactId() + ":"
+              + extension.getVersion() + " can't be loaded (defined in "
+              + new File(directory, IMavenPlexusContainer.EXTENSIONS_FILENAME).getAbsolutePath() + ").", e);
         }
       }
       return plexusContainer;
@@ -341,11 +339,10 @@ public class PlexusContainerManager {
       container.setLookupRealm(null);
       container.setLoggerManager(loggerManager);
       thread.setContextClassLoader(container.getContainerRealm());
-      MavenExecutionRequest request = MavenExecutionContext.createExecutionRequest(mavenConfiguration,
-          wrap(container), MavenPluginActivator.getDefault().getMaven().getSettings());
+      MavenExecutionRequest request = MavenExecutionContext.createExecutionRequest(mavenConfiguration, wrap(container),
+          MavenPluginActivator.getDefault().getMaven().getSettings(), multiModuleProjectDirectory);
       container.lookup(MavenExecutionRequestPopulator.class).populateDefaults(request);
       request.setBaseDirectory(multiModuleProjectDirectory);
-      request.setMultiModuleProjectDirectory(multiModuleProjectDirectory);
       BootstrapCoreExtensionManager resolver = container.lookup(BootstrapCoreExtensionManager.class);
       return resolver.loadCoreExtensions(request, coreEntry.getExportedArtifacts(), extensions);
     } finally {
@@ -356,7 +353,7 @@ public class PlexusContainerManager {
 
   private static final class M2EClassWorld extends ClassWorld {
 
-    private File multiModuleProjectDirectory;
+    private final File multiModuleProjectDirectory;
 
     M2EClassWorld(String plexusCoreRealm, ClassLoader classLoader, File multiModuleProjectDirectory) {
       super(plexusCoreRealm, classLoader);
@@ -449,6 +446,5 @@ public class PlexusContainerManager {
   public static IComponentLookup wrap(PlexusContainer container, ClassRealm realm) {
     return new PlexusComponentLookup(container, realm);
   }
-
 
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/274

With this PR properties and profiles specified in the `.mvn/maven.config` are considered within the M2E workspace build and one can use version properties in `.mvn/extension.xml`.

As far as I can tell this works, but at the moment I'm struggling because `MavenExecutionContext.newProjectBuildRequst()` is called for a context that does not have `basedir` and context project and thus does cannot copy the user-settings and profiles to the request, which has the consequence that the variables cannot be resolved.

Furthermore a test case has to be added.

I'm on vacation until Friday and then can continue to work on this one.
Maybe @laeubi or @mickaelistria you have a hint how to solve the mentioned problem? I suspect it is rooted in how the `ProjectRegistryManager` creates execution contexts, but that is just my first guess.