### PR TITLE
Bump version of m2e.lemminx and m2e.logback feature to 2.0

### DIFF
--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="1.18.5.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.logback.feature"
       label="%featureName"
-      version="1.17.3.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.logback.configuration"
       license-feature="org.eclipse.license"


### PR DESCRIPTION
The contained plug-ins all had a major version bump and are at version
2.0, so the features should have version 2.0 as well.