### PR TITLE
Adjust M2E_VERSION extraction in Jenkinsfile to m2e.sdk/feature.xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
 							scp -r org.eclipse.m2e.repository/target/repository/* genie.m2e@projects-storage.eclipse.org:${1}
 						}
 						# Read M2E branding version
-						regex='<feature id="org\\.eclipse\\.m2e\\.sdk\\.feature" version="([0-9]\\.[0-9]\\.[0-9])\\.qualifier" '
+						regex='<feature id="org\\.eclipse\\.m2e\\.sdk\\.feature" label="%featureName" version="([0-9]\\.[0-9]\\.[0-9])\\.qualifier" '
 						content=$(echo $(<"org.eclipse.m2e.sdk.feature/feature.xml")) # replaces consecutive newline and tabs by single space
 						if [[ $content  =~ $regex ]]
 						then


### PR DESCRIPTION
If one modifies the version of the m2e.sdk feature via the PDE-Feature editor the XML-element 'feature' gets its attributes always written in a fixed order. But the Snapshot-deployment in the Jenkinsfile relies on the attribute order to extract the current M2E-Version. 
In order to not require modifications in the source tab, this adjusts the version extraction logic in the Jenkinsfile to the default feature attribute order.

This fixes the currently broken master build.