### PR TITLE
Replace pde.ui dependency with pde.core in org.eclipse.m2e.pde.target

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
- org.eclipse.pde.ui;bundle-version="3.12.0",
+ org.eclipse.pde.core;bundle-version="3.14.0",
  org.eclipse.equinox.frameworkadmin;bundle-version="2.1.400",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",


### PR DESCRIPTION
- org.eclipse.pde.ui dependencies are not used in
  org.eclipse.m2e.pde.target
- org.eclipse.pde.ui 3.12.0 corresponds to org.eclipse.pde.core 3.14.0
- org.eclipse.m2e.pde.target should explicitly depend on pde.core rather
  than implicitly through pde.ui
- Bump minor version for plugin & feature

See https://download.eclipse.org/eclipse/updates/4.18/R-4.18-202012021800/plugins/ for reference of where org.eclipse.pde.ui 3.12.0 corresponds to org.eclipse.pde.core 3.14.0.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>