### PR TITLE
Release M2E 2.0.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Eclipse m2e - Release notes
 
+## 2.0.2
+
+* 📅 Release Date: August 30th 2022
+* All changes: https://github.com/eclipse-m2e/m2e-core/compare/2.0.1...2.0.2
+
+### Support for colored Maven console printouts
+
+M2E now supports colored console printouts for Maven builds launched in the IDE out of the box.
+
+This is built on top of the new support for colored Console content, which is added to Eclipse-Platform in the 2022-09/4.25 release (which is therefore required).
+In the Run/Debug-configuration of a `Maven Build` launch it can be controlled if the printout is colored or not (i.e. the value of Maven's `style.color` property). The default is `Auto`, which enables colored print-outs if colored Console printout is generally enabled in the workspace.
+
 ## 2.0.1
 
 * 📅 Release Date: August 5th 2022
@@ -28,7 +40,7 @@ In general MojoExecutions should be set up within the scope of `MavenExecutionCo
 
 ### Multiple API breakage
 
-This major release improve (and cleans up) various legacy APIs. Some clients may require to update their code if they use removed APIs. [This commit](https://github.com/eclipse-m2e/m2e-wtp/commit/0705044047ec83124f7f3905431d0027ad4112e8) can be used as an example of how to adapt to newer APIs. Usually, calling `mavenProjectFacade.createExecutionContext().execute(...)` is a good replacement to removed APIs.
+This major release improves (and cleans up) various legacy APIs. Some clients may require to update their code if they use removed APIs. [This commit](https://github.com/eclipse-m2e/m2e-wtp/commit/0705044047ec83124f7f3905431d0027ad4112e8) can be used as an example of how to adapt to newer APIs. Usually, calling `mavenProjectFacade.createExecutionContext().execute(...)` is a good replacement to removed APIs.
 
 ## 1.20.1
 


### PR DESCRIPTION
The value of `<M2E_RELEASE>` is `2.0.2`.
The value of `<M2E_PREVIOUS_RELEASE>` is `2.0.1` and the value of `<M2E_RELEASE_WO_DOTS>` is `202`

## Release process steps:
- [ ] Add/finalize and submit an entry in the `RELEASE_NOTES.md` dedicated to this release (done with this PR).
- [ ] Run `promote-snapshots-to-release` Jenkins job with parameter `releaseVersion` value `<M2E_RELEASE>`
- [ ] Update M2E's contribution to the Eclipse Simultaneous Release
- [ ] Create and push git tag `<M2E_RELEASE>` on the maintenance branch.
- [ ] `Create a new Release` at the M2E project website: https://projects.eclipse.org/projects/technology.m2e
Name: <M2E_RELEASE>, Release date: default is today, which is usually fine. 
- [ ] Send the following announcement to the [M2E-dev mailing-list](https://accounts.eclipse.org/mailing-list/m2e-dev):
```
M2E <M2E_RELEASE> is released!

📥 P2 repository is available at https://download.eclipse.org/technology/m2e/releases/<M2E_RELEASE>
(and it also mirrored at https://download.eclipse.org/technology/m2e/releases/latest/ and referenced by Marketplace Entry https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide until a newer release is promoted)
🏷️ Git tag is <M2E_RELEASE>: https://github.com/eclipse-m2e/m2e-core/tree/<M2E_RELEASE>
📝 Release notes are available in https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS> ; full changelog is https://github.com/eclipse-m2e/m2e-core/compare/<M2E_PREVIOUS_RELEASE>...<M2E_RELEASE>
👔 PMI Release entry is at https://projects.eclipse.org/projects/technology.m2e/releases/<M2E_RELEASE>
🧑‍🤝‍🧑 M2E <M2E_RELEASE> is currently included in SimRel 2022-09
🙏  Special thanks to to everybody who contributed to this release!

Greetings
```
