### PR TITLE
Make war lifecycle mapping "default"

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lifecycleMappingMetadata>
 
+	<!-- Although it would make more sense to have it part of
+	     org.eclipse.m2e.jdt, we move the lifecycle mapping definition
+	     here so it is marked as "default" and can be overriden, eg by
+	     m2e-wtp. Otherwise: https://github.com/eclipse-m2e/m2e-core/issues/867 -->
+	<lifecycleMappings>
+		<lifecycleMapping>
+			<packagingType>war</packagingType>
+			<lifecycleMappingId>org.eclipse.m2e.jdt.JarLifecycleMapping</lifecycleMappingId>
+		</lifecycleMapping>
+	</lifecycleMappings>
+
   <pluginExecutions>
     <!-- M2E's default lifecycle mappings for standard maven plugins -->
     <pluginExecution>

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.0.2.qualifier"
+      version="2.0.3.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.m2e.jdt/lifecycle-mapping-metadata.xml
@@ -6,10 +6,6 @@
       <packagingType>jar</packagingType>
       <lifecycleMappingId>org.eclipse.m2e.jdt.JarLifecycleMapping</lifecycleMappingId>
     </lifecycleMapping>
-    <lifecycleMapping>
-      <packagingType>war</packagingType>
-      <lifecycleMappingId>org.eclipse.m2e.jdt.JarLifecycleMapping</lifecycleMappingId>
-    </lifecycleMapping>
   </lifecycleMappings>
 
   <pluginExecutions>

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.0.2.qualifier"
+      version="2.0.3.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Testing Helpers
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
@@ -23,7 +23,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e
 MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.tests.common
-Export-Package: org.eclipse.m2e.tests.common;x-friends:="org.eclipse.m2e.tests,org.eclipse.m2e.core.tests,org.eclipse.m2e.jdt.tests,org.eclipse.m2e.core.ui.tests"
+Export-Package: org.eclipse.m2e.tests.common;x-friends:="org.eclipse.m2e.tests,org.eclipse.m2e.core.tests,org.eclipse.m2e.jdt.tests,org.eclipse.m2e.core.ui.tests,org.eclipse.m2e.wtp.tests"
 Import-Package: javax.servlet;version="3.1.0",
  javax.servlet.http;version="3.1.0"
 Automatic-Module-Name: org.eclipse.m2e.tests.common


### PR DESCRIPTION
So it can be overridden by m2e-wtp.
https://github.com/eclipse-m2e/m2e-core/issues/867