### PR TITLE
Add full dependency-closure of maven.runtime to classpath of launched embedded Maven

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.0.2.qualifier
+Bundle-Version: 2.0.3.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.0.3.qualifier"
+      version="2.0.4.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.0.3.qualifier"
+      version="2.0.4.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -33,7 +33,6 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-06/"/>
 			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="ch.qos.logback.core" version="0.0.0"/>
 			<unit id="ch.qos.logback.classic" version="0.0.0"/>
 			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
@@ -62,6 +61,18 @@
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
 					<version>6.3.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>failureaccess</artifactId>
+					<version>1.0.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+					<version>31.1-jre</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
The Eclipse-Platform changed to use Google's guava jar from Maven-Central for the 2022-09 release. In contrast to the Guava-variant from Eclipse-Orbit, which was used before, that bundle is not self-contained and requires classes in other jars like guava.failureaccess.
Consequently it is not sufficient to only put first-level requirements on the classpath of the launched embedded Maven runtime. Now it has to be the full requirements closure.

If that guava bundle is installed in a Eclipse instance, launching a Maven build using M2E's embedded Maven runtime fails with the console print-out displayed below. It has to be noted that not all pre-build Eclipse EPP packages have that guava version installed (yet), but when provisioning an Eclipse Product with Oomph, that problematic guava is installed and launching Maven-builds from the IDE using the embedded Maven is broken since Eclipse 2022-09 RC1!

Alternatively M2E could again embed guava (from Maven-Central) with all required dependencies, but this would increase the size of the maven.runtime jar significantly. But I just checked (with the current TP!) that no undesired bundles are placed at the classpath, so I think this is a save approach. Furthermore we control at least the direct dependencies of the Maven-runtime.

@mickaelistria to address the currently broken launching I think this needs another release of M2E.


```
---------------------------------------------------
constituent[0]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/target/classes/
constituent[1]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/aether-connector-okhttp-0.17.8.jar
constituent[2]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/commons-cli-1.4.jar
constituent[3]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/commons-io-2.6.jar
constituent[4]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/commons-lang3-3.8.1.jar
constituent[5]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/guice-4.2.2-no_aop.jar
constituent[6]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/jansi-2.4.0.jar
constituent[7]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/javax.annotation-api-1.2.jar
constituent[8]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-artifact-3.8.6.jar
constituent[9]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-builder-support-3.8.6.jar
constituent[10]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-compat-3.8.6.jar
constituent[11]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-core-3.8.6.jar
constituent[12]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-embedder-3.8.6.jar
constituent[13]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-model-3.8.6.jar
constituent[14]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-model-builder-3.8.6.jar
constituent[15]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-plugin-api-3.8.6.jar
constituent[16]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-repository-metadata-3.8.6.jar
constituent[17]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-api-1.6.3.jar
constituent[18]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-connector-basic-1.6.3.jar
constituent[19]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-impl-1.6.3.jar
constituent[20]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-provider-3.8.6.jar
constituent[21]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-spi-1.6.3.jar
constituent[22]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-transport-wagon-1.6.3.jar
constituent[23]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-resolver-util-1.6.3.jar
constituent[24]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-settings-3.8.6.jar
constituent[25]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-settings-builder-3.8.6.jar
constituent[26]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-shared-utils-3.3.4.jar
constituent[27]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/okhttp-3.14.1.jar
constituent[28]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/okio-1.17.3.jar
constituent[29]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/org.eclipse.sisu.inject-0.3.5.jar
constituent[30]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/org.eclipse.sisu.plexus-0.3.5.jar
constituent[31]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/plexus-cipher-2.0.jar
constituent[32]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/plexus-component-annotations-2.1.0.jar
constituent[33]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/plexus-interpolation-1.26.jar
constituent[34]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/plexus-sec-dispatcher-2.0.jar
constituent[35]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/plexus-utils-3.3.1.jar
constituent[36]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/wagon-file-3.5.1.jar
constituent[37]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/wagon-provider-api-3.5.1.jar
constituent[38]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/
constituent[39]: file:/C:/dev/git/eclipse.m2e-core/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/jars/maven-slf4j-provider-3.8.6.jar
constituent[40]: file:/C:/dev/workspaces/eclipse.m2e/.metadata/.plugins/org.eclipse.pde.core/Eclipse-M2E-IDE/org.eclipse.osgi/7/0/.cp/
constituent[41]: file:/C:/dev/workspaces/eclipse.m2e/.metadata/.plugins/org.eclipse.pde.core/Eclipse-M2E-IDE/org.eclipse.osgi/367/0/.cp/
constituent[42]: file:/C:/dev/workspaces/eclipse.m2e/.metadata/.plugins/org.eclipse.pde.core/Eclipse-M2E-IDE/org.eclipse.osgi/19/0/.cp/
---------------------------------------------------
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/common/util/concurrent/internal/InternalFutureFailureAccess
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1012)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:524)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:421)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:420)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClassFromSelf(ClassRealm.java:425)
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:42)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1012)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:524)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:421)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:420)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClassFromSelf(ClassRealm.java:425)
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:42)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1012)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:524)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:421)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:420)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClassFromSelf(ClassRealm.java:425)
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:42)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	at com.google.common.cache.LocalCache$LoadingValueReference.<init>(LocalCache.java:3476)
	at com.google.common.cache.LocalCache$LoadingValueReference.<init>(LocalCache.java:3480)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2138)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3966)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3989)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4950)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4956)
	at com.google.inject.internal.Annotations$AnnotationChecker.hasAnnotations(Annotations.java:274)
	at com.google.inject.internal.Annotations.isBindingAnnotation(Annotations.java:340)
	at com.google.inject.Key.ensureIsBindingAnnotation(Key.java:349)
	at com.google.inject.Key.strategyFor(Key.java:336)
	at com.google.inject.Key.get(Key.java:219)
	at org.eclipse.sisu.wire.ParameterKeys.<clinit>(ParameterKeys.java:28)
	at org.eclipse.sisu.wire.DependencyAnalyzer.<init>(DependencyAnalyzer.java:93)
	at org.eclipse.sisu.wire.ElementAnalyzer.<init>(ElementAnalyzer.java:104)
	at org.eclipse.sisu.wire.WireModule.configure(WireModule.java:74)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:344)
	at com.google.inject.spi.Elements.getElements(Elements.java:103)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:137)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:103)
	at com.google.inject.Guice.createInjector(Guice.java:87)
	at com.google.inject.Guice.createInjector(Guice.java:69)
	at com.google.inject.Guice.createInjector(Guice.java:59)
	at org.codehaus.plexus.DefaultPlexusContainer.addPlexusInjector(DefaultPlexusContainer.java:481)
	at org.codehaus.plexus.DefaultPlexusContainer.<init>(DefaultPlexusContainer.java:206)
	at org.apache.maven.cli.MavenCli.container(MavenCli.java:651)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:286)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:196)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
Caused by: java.lang.ClassNotFoundException: com.google.common.util.concurrent.internal.InternalFutureFailureAccess
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	... 76 more
```


