### PR TITLE
Don't extract referenced bundles for Maven runtime classpath

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -169,9 +169,9 @@
 								com.google.inject.*;provider=m2e;mandatory:=provider,\
 								io.takari.*;provider=m2e;mandatory:=provider
 							Import-Package: \
-								org.slf4j;resolution:=optional;version="[1.7.0,3.0.0)",\
-								org.slf4j.spi;resolution:=optional;version="[1.7.0,3.0.0)",\
-								org.slf4j.helpers;resolution:=optional;version="[1.7.0,3.0.0)",\
+								org.slf4j;version="[1.7.31,3.0.0)",\
+								org.slf4j.spi;version="[1.7.31,3.0.0)",\
+								org.slf4j.helpers;version="[1.7.31,3.0.0)",\
 								javax.inject;version="1.0.0",\
 								javax.annotation;version="[1.2.0,2.0.0)",\
 								javax.annotation.sql;version="[1.2.0,2.0.0)",\


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/923

OSGi bundles that are referenced by the m2e.maven.runtime bundle don't
have to be extracted when added to the classpath of an about to be
launched Maven build. Not extracting them significantly speeds up the
launch of the first build after IDE start or opening the first time the
Launch-Config dialog for Maven builds or the Maven Installation
settings.

Additionally ensure that slf4j from Maven-Central is used instead of the
one from Orbit to prevent errors like the following when launching a
Maven-build with the embedded runtime from the IDE:
```
class "org.slf4j.MavenSlf4jFriend"'s signer information does not match
signer information of other classes in the same package
```
The reason for such an error is that the slf4j variant from Orbit is
jar-signed by Eclipse, while 'slf4j' and 'maven-slf4j-provider' from
Maven-Central is only PGP-signed (and not jarsigned). But because
'slf4j' and 'maven-slf4j-provider' provide classes for the package
org.slf4j they must provide the same signer information. This check is
not performed if a jar is extracted and added to the classpath as
directory, but we don't want to do that anymore.

slf4j-from Maven-central is enforced by specifing a lower bound of
1.7.31 for slf4j bundles, while Eclipse-Orbit only provides 1.7.30.