### PR TITLE
Migrate to SLF4J + Logback and Gson from Maven-Central instead of Orbit

### DIFF
--- a/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Version: 2.1.0.qualifier
 Bundle-Name: M2E Logback Appender
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Fragment-Host: ch.qos.logback.classic
+Fragment-Host: ch.qos.logback.classic;bundle-version="1.2.0"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.ui.console,

--- a/org.eclipse.m2e.logback/META-INF/p2.inf
+++ b/org.eclipse.m2e.logback/META-INF/p2.inf
@@ -1,3 +1,0 @@
-requires.1.namespace = osgi.bundle
-requires.1.name = ch.qos.logback.slf4j
-requires.1.range = 0.9.24

--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -18,6 +18,12 @@
    <feature id="org.eclipse.m2e.sdk.feature">
       <category name="m2e"/>
    </feature>
+   <bundle id="slf4j.api"/>
+   <bundle id="slf4j.api.source"/>
+   <bundle id="ch.qos.logback.core"/>
+   <bundle id="ch.qos.logback.core.source"/>
+   <bundle id="ch.qos.logback.classic"/>
+   <bundle id="ch.qos.logback.classic.source"/>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
    <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/0.15.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.20.7/" enabled="true" />

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -5,6 +5,7 @@
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/eclipse/updates/4.25/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-09/"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
@@ -27,13 +28,6 @@
 			<unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-09/"/>
-			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="ch.qos.logback.core" version="0.0.0"/>
-			<unit id="ch.qos.logback.classic" version="0.0.0"/>
-			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.15.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
 		</location>
@@ -45,7 +39,7 @@
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
-		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
 			<dependencies>
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
@@ -57,6 +51,38 @@
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
 					<version>6.3.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.service.repository</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Logging" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+					<version>1.2.11</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+					<version>1.7.36</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Misc" missingManifest="error" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+					<version>2.9.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -75,12 +101,6 @@
 					<groupId>io.takari.m2e.workspace</groupId>
 					<artifactId>org.eclipse.m2e.workspace.cli</artifactId>
 					<version>0.3.1</version>
-					<type>jar</type>
-				</dependency>
-				<dependency>
-					<groupId>org.osgi</groupId>
-					<artifactId>org.osgi.service.repository</artifactId>
-					<version>1.1.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
Build against slf4j and logback from Maven-Central and include them into m2e's p2 repo to contribute it to SimRel.
The version at Maven-Central is more recent and not jar-signed by the Eclipse-Foundation which helps to address the difficulties encountered in https://github.com/eclipse-m2e/m2e-core/pull/926.

Logback from Orbit uses a different approach to wire `org.slf4j.api` and `ch.qos.logback.classic` (both from Orbit) . Besides logback-core and classic it is split additionally into a third fragment `ch.qos.logback.slf4j` whose host is `org.slf4j.api` (from Orbit) and that contains and exports the `org.slf4j.impl` package of logback-classic and imports packages from the latter. This way effectively `org.slf4j.api` requires `ch.qos.logback.classic`.

In order to now have two slf4j bindings on the classpath of Maven-build launched from within the IDE and thus to avoid corresponding warnings, I have adjusted the code in `MavenEmbeddedRuntime` to not pull in dependencies of slf4j (with old and new bundle name).

Fixes https://github.com/eclipse-m2e/m2e-core/issues/738