### PR TITLE
Build with 'openjdk-jdk17-latest' and 'apache-maven-3.8.6' explicitly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ pipeline {
 		label "centos-latest"
 	}
 	tools {
-		maven 'apache-maven-latest'
-		jdk 'openjdk-latest'
+		maven 'apache-maven-3.8.6'
+		jdk 'openjdk-jdk17-latest'
 	}
 	stages {
 		stage('get m2e-core-tests') {


### PR DESCRIPTION
Available Jenkins tools can be found here:
https://wiki.eclipse.org/Jenkins

This hopefully fixes the test failures of current m2e builds.