### PR TITLE
Prepare for SLF4J 2.0 and require at least SLF4J 1.7

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-	<version>3.2.1-SNAPSHOT</version>
+	<version>3.2.101-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>M2E Maven Archetype Common</name>
@@ -145,7 +145,7 @@
 								org.eclipse.m2e.maven.runtime;bundle-version="[3.0.0,4.0.0)",\
 								com.ibm.icu
 							Import-Package: \
-								org.slf4j;resolution:=optional;version="[1.7.0,2.0.0)"
+								org.slf4j;resolution:=optional;version="[1.7.0,3.0.0)"
 						]]>
 						</bnd>
 					</configuration>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-	<version>3.8.601-SNAPSHOT</version>
+	<version>3.8.602-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>M2E Embedded Maven Runtime (includes Incubating components)</name>
@@ -164,9 +164,9 @@
 								com.google.inject.*;provider=m2e;mandatory:=provider,\
 								io.takari.*;provider=m2e;mandatory:=provider
 							Import-Package: \
-								org.slf4j;resolution:=optional;version="[1.6.2,2.0.0)",\
-								org.slf4j.spi;resolution:=optional;version="[1.6.2,2.0.0)",\
-								org.slf4j.helpers;resolution:=optional;version="[1.6.2,2.0.0)",\
+								org.slf4j;resolution:=optional;version="[1.7.0,3.0.0)",\
+								org.slf4j.spi;resolution:=optional;version="[1.7.0,3.0.0)",\
+								org.slf4j.helpers;resolution:=optional;version="[1.7.0,3.0.0)",\
 								javax.inject;version="1.0.0"
 							Require-Bundle: \
 								com.google.guava

--- a/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.apt.core;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
@@ -16,5 +16,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.m2e.apt;x-friends:="org.eclipse.m2e.apt.ui",
  org.eclipse.m2e.apt.preferences
-Import-Package: org.slf4j;version="1.6.2"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.apt.core

--- a/org.eclipse.m2e.apt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.apt.ui;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -19,5 +19,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
-Import-Package: org.slf4j;version="1.6.2"
 Automatic-Module-Name: org.eclipse.m2e.apt.ui

--- a/org.eclipse.m2e.binaryproject.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Binary Project Core Tests
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject.tests;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Require-Bundle: org.eclipse.m2e.core,
  org.eclipse.m2e.maven.runtime,
@@ -14,6 +14,5 @@ Require-Bundle: org.eclipse.m2e.core,
  org.eclipse.m2e.jdt,
  org.eclipse.jdt.core,
  org.eclipse.core.runtime
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.m2e.binaryproject.tests

--- a/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Binary Project Core
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
@@ -15,7 +15,6 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.debug.core;bundle-version="3.9.0",
  org.eclipse.jdt.launching;bundle-version="3.10.0"
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.m2e.binaryproject.internal;x-friends:="org.eclipse.m2e.sourcelookup,org.eclipse.m2e.sourcelookup.ui"
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
@@ -44,7 +44,7 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.ui
 Import-Package: org.eclipse.compare.rangedifferencer,
  org.eclipse.ltk.core.refactoring,
- org.slf4j;version="[1.6.2,2.0.0)"
+ org.slf4j;version="[1.7.0,3.0.0)"
 Service-Component: OSGI-INF/component.xml,
  OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypeGenerator.xml,
  OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypePlugin.xml

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -51,7 +51,7 @@ MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.core
 Import-Package: com.google.common.cache,
  javax.inject;version="1.0.0",
- org.slf4j;version="1.6.2"
+ org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.core
 Service-Component: OSGI-INF/org.eclipse.m2e.core.embedder.MavenModelManager.xml,
  OSGI-INF/org.eclipse.m2e.core.internal.embedder.EclipseLoggerManager.xml,

--- a/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.discovery;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
@@ -39,7 +39,7 @@ Import-Package: org.apache.maven.plugin;provider=m2e,
  org.eclipse.equinox.p2.metadata,
  org.eclipse.equinox.p2.repository.metadata,
  org.eclipse.equinox.p2.ui,
- org.slf4j;version="[1.6.2,2.0.0)"
+ org.slf4j;version="[1.7.0,3.0.0)"
 Bundle-Activator: org.eclipse.m2e.internal.discovery.DiscoveryActivator
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/component.xml

--- a/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, Lemminx and Maven LS extension (requires Incubating components)
 Bundle-SymbolicName: org.eclipse.m2e.editor.lemminx;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Automatic-Module-Name: org.eclipse.m2e.xmlls.extension
 Import-Package: org.eclipse.core.runtime;version="3.5.0",
  org.osgi.framework;version="1.10.0",
- org.slf4j;version="1.7.2"
+ org.slf4j;version="[1.7.0,3.0.0)"
 Require-Bundle: javax.inject,
  org.eclipse.wildwebdeveloper.xml;bundle-version="[0.15.0,0.16.0)",
  org.eclipse.lsp4e;bundle-version="0.13.7",

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -23,7 +23,7 @@
 
 	<artifactId>org.eclipse.m2e.editor.lemminx</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.1-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.m2e.editor.lemminx/src/org/eclipse/m2e/editor/lemminx/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.editor.lemminx/src/org/eclipse/m2e/editor/lemminx/MavenRuntimeClasspathProvider.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.lsp4e.LanguageServersRegistry;
 import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
@@ -33,12 +35,10 @@ import org.eclipse.m2e.core.embedder.IMavenConfigurationChangeListener;
 import org.eclipse.wildwebdeveloper.xml.LemminxClasspathExtensionProvider;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("restriction")
 public class MavenRuntimeClasspathProvider implements LemminxClasspathExtensionProvider {
-	private static final Logger LOG = LoggerFactory.getLogger(MavenRuntimeClasspathProvider.class);
+	private static final ILog LOG = Platform.getLog(MavenRuntimeClasspathProvider.class);
 
 	private static IMavenConfigurationChangeListener mavenConfigurationlistener;
 	private static final String LANGUAGE_SERVER = "org.eclipse.wildwebdeveloper.xml";

--- a/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.MavenEditorPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.jobs,
@@ -42,5 +42,5 @@ Export-Package: org.eclipse.m2e.editor;x-friends:="org.eclipse.m2e.editor.xml",
  org.eclipse.m2e.editor.internal.markers;x-internal:=true,
  org.eclipse.m2e.editor.mojo;x-friends:="org.eclipse.m2e.editor.xml",
  org.eclipse.m2e.editor.pom;x-friends:="org.eclipse.m2e.editor.xml"
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.editor

--- a/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/MavenEditorImages.java
+++ b/org.eclipse.m2e.editor/src/org/eclipse/m2e/editor/MavenEditorImages.java
@@ -16,9 +16,8 @@ package org.eclipse.m2e.editor;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.resource.ResourceLocator;
@@ -29,7 +28,7 @@ import org.eclipse.swt.graphics.Image;
  * @author Eugene Kuleshov
  */
 public class MavenEditorImages {
-  private static final Logger log = LoggerFactory.getLogger(MavenEditorImages.class);
+  private static final ILog log = Platform.getLog(MavenEditorImages.class);
 
   // image descriptors
 

--- a/org.eclipse.m2e.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt.ui;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt.ui.internal;x-internal:=true,
  org.eclipse.m2e.jdt.ui.internal.actions;x-internal:=true,
@@ -25,5 +25,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.jdt.ui.internal.MavenJdtUiPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.jdt.ui

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",
@@ -19,5 +19,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.jdt.MavenJdtPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.jdt

--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.variables,
@@ -28,6 +28,6 @@ Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.m2e.actions;x-internal:=true,
  org.eclipse.m2e.internal.launch;x-internal:=true,
  org.eclipse.m2e.ui.internal.launch;x-internal:=true
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.launching
 Service-Component: OSGI-INF/org.eclipse.m2e.internal.launch.EclipseMavenLauncher.xml

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
@@ -29,15 +29,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
@@ -67,7 +66,7 @@ import org.eclipse.m2e.core.project.IMavenProjectRegistry;
  * @author Eugene Kuleshov
  */
 public class MavenConsoleLineTracker implements IConsoleLineTracker {
-  private static final Logger log = LoggerFactory.getLogger(MavenConsoleLineTracker.class);
+  private static final ILog log = Platform.getLog(MavenConsoleLineTracker.class);
 
   private static final String PLUGIN_ID = "org.eclipse.m2e.launching"; //$NON-NLS-1$
 

--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.0.1.qualifier"
+      version="2.0.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
@@ -18,6 +18,5 @@ Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)",
  aQute.bnd.version;version="[2.2.0,3.0.0)",
  org.apache.commons.codec.digest;version="1.14.0",
  org.apache.commons.io;version="2.6.0",
- org.apache.commons.io.output;version="2.8.0",
- org.slf4j
+ org.apache.commons.io.output;version="2.8.0"
 Bundle-Vendor: Eclipse.org - m2e

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -53,9 +53,11 @@ import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.eclipse.aether.version.Version;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
@@ -74,13 +76,11 @@ import org.eclipse.pde.internal.core.ICoreConstants;
 import org.eclipse.pde.internal.core.ifeature.IFeature;
 import org.eclipse.pde.internal.core.ifeature.IFeaturePlugin;
 import org.eclipse.pde.internal.core.target.AbstractBundleContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("restriction")
 public class MavenTargetLocation extends AbstractBundleContainer {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(MavenTargetLocation.class);
+	private static final ILog LOGGER = Platform.getLog(MavenTargetLocation.class);
 	private static final String SOURCE_SUFFIX = ".source";
 	private static final String NOT_A_FEATURE = "not_a_feature";
 	public static final String ELEMENT_CLASSIFIER = "classifier";

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
@@ -20,8 +20,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.ui.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org - m2e
-Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)",
- org.slf4j;version="1.7.30"
+Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)"
 Service-Component: OSGI-INF/org.eclipse.m2e.pde.ui.target.adapter.DependencyNodeAdapterFactory.xml,
  OSGI-INF/org.eclipse.m2e.pde.ui.target.adapter.MavenTargetAdapterFactory.xml,
  OSGI-INF/org.eclipse.m2e.pde.ui.target.adapter.MavenTargetBundleAdapterFactory.xml,

--- a/org.eclipse.m2e.profiles.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.profiles.ui;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -20,5 +20,5 @@ Export-Package: org.eclipse.m2e.profiles.ui.internal;x-internal:=true,
  org.eclipse.m2e.profiles.ui.internal.actions;x-internal:=true,
  org.eclipse.m2e.profiles.ui.internal.dialog;x-internal:=true
 Import-Package: javax.inject;version="1.0.0",
- org.slf4j;version="[1.6.2,2.0.0)"
+ org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.profiles.ui

--- a/org.eclipse.m2e.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.m2e.refactoring;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Bundle-Activator: org.eclipse.m2e.refactoring.internal.Activator
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.model.edit;bundle-version="[2.0.0,3.0.0)",
@@ -24,5 +24,4 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.m2e.refactoring.exclude;x-internal:=true
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.refactoring

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/AbstractPomRefactoring.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/AbstractPomRefactoring.java
@@ -20,14 +20,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.common.command.BasicCommandStack;
 import org.eclipse.emf.common.command.CompoundCommand;
@@ -70,7 +69,7 @@ import org.eclipse.m2e.refactoring.internal.Activator;
  */
 @SuppressWarnings("restriction")
 public abstract class AbstractPomRefactoring extends Refactoring {
-  private static final Logger log = LoggerFactory.getLogger(AbstractPomRefactoring.class);
+  private static final ILog log = Platform.getLog(AbstractPomRefactoring.class);
 
   protected static final String PROBLEMS_DURING_REFACTORING = Messages.AbstractPomRefactoring_error;
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/ChangeCreator.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/ChangeCreator.java
@@ -16,13 +16,12 @@ package org.eclipse.m2e.refactoring;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.eclipse.compare.rangedifferencer.IRangeComparator;
 import org.eclipse.compare.rangedifferencer.RangeDifference;
 import org.eclipse.compare.rangedifferencer.RangeDifferencer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
@@ -41,7 +40,7 @@ import org.eclipse.text.edits.TextEditGroup;
  * @author Anton Kraev
  */
 public class ChangeCreator {
-  private static final Logger log = LoggerFactory.getLogger(ChangeCreator.class);
+  private static final ILog log = Platform.getLog(ChangeCreator.class);
 
   private final String label;
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/RefactoringModelResources.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/RefactoringModelResources.java
@@ -17,9 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
@@ -28,6 +25,8 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CompoundCommand;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -45,7 +44,7 @@ import org.eclipse.m2e.model.edit.pom.PropertyElement;
  * @author Anton Kraev
  */
 public class RefactoringModelResources {
-  private static final Logger log = LoggerFactory.getLogger(RefactoringModelResources.class);
+  private static final ILog log = Platform.getLog(RefactoringModelResources.class);
 
   private static final String TMP_PROJECT_NAME = ".m2eclipse_refactoring"; //$NON-NLS-1$
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/internal/RefactoringImages.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/internal/RefactoringImages.java
@@ -13,9 +13,8 @@
 
 package org.eclipse.m2e.refactoring.internal;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.resource.ResourceLocator;
@@ -25,7 +24,7 @@ import org.eclipse.jface.resource.ResourceLocator;
  * @author Eugene Kuleshov
  */
 public class RefactoringImages {
-  private static final Logger log = LoggerFactory.getLogger(RefactoringImages.class);
+  private static final ILog log = Platform.getLog(RefactoringImages.class);
 
   // images
 

--- a/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/rename/RenameArtifactHandler.java
+++ b/org.eclipse.m2e.refactoring/src/org/eclipse/m2e/refactoring/rename/RenameArtifactHandler.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.m2e.refactoring.rename;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation;
@@ -32,7 +31,7 @@ import org.eclipse.m2e.refactoring.internal.SaveDirtyFilesDialog;
 
 
 public class RenameArtifactHandler extends AbstractHandler {
-  private static final Logger log = LoggerFactory.getLogger(RenameArtifactHandler.class);
+  private static final ILog log = Platform.getLog(RenameArtifactHandler.class);
 
   @Override
   public Object execute(ExecutionEvent event) {

--- a/org.eclipse.m2e.scm/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.scm/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.scm;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
@@ -19,5 +19,5 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.5.2",
  org.eclipse.m2e.core.ui;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.ui.workbench;bundle-version="3.5.2",
  org.eclipse.ui.ide;bundle-version="3.5.1"
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.scm

--- a/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.sourcelookup;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Source Lookup Core
 Require-Bundle: org.eclipse.m2e.launching;bundle-version="[2.0.0,3.0.0)",
@@ -18,7 +18,6 @@ Require-Bundle: org.eclipse.m2e.launching;bundle-version="[2.0.0,3.0.0)",
  com.google.gson;bundle-version="2.2.4",
  org.eclipse.core.variables;bundle-version="3.2.0",
  org.apache.commons.codec;bundle-version="1.14.0"
-Import-Package: org.slf4j;version="[1.6.2,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir


### PR DESCRIPTION
- Update all slf4j package version ranges to [1.7.0,3.0.0) for all non-test Plugins
- Remove versions/version-ranges from Test-Plugins
- Remove unused slf4j package imports
- Migrate to Eclipse Platform ILog where suitable Events logged to slf4j are displayed in M2E's Maven console, while events logged with Eclipse-Platform ILog are displayed in Eclipse's 'Error Log' view. Therefore it is more suitable to log events from the Maven world to slf4j while Eclipse-IDE related events should be logged to Eclipse's ILog.


SLF4J 2 is a drop-in replacement for SLF4J 1:
https://www.slf4j.org/faq.html#compatibility

This helps for https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588.