### PR TITLE
Build with Tycho 2.7.5

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.5</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<tycho-version>3.0.0-SNAPSHOT</tycho-version>
+		<tycho-version>2.7.5</tycho-version>
 
 		<tycho.testArgLine>-Xmx800m</tycho.testArgLine>
 		<tycho.surefire.timeout>7200</tycho.surefire.timeout>


### PR DESCRIPTION
With the Tycho 3.0.0-SNAPSHOT the tests are failing in the GH workflow build and the license vetting is failing as well.
Therefore revert to Tycho 2.7.5 for now.