### PR TITLE
[Build] Remove now obsolete 'uts' Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,12 +435,6 @@
 			</build>
 		</profile>
 		<profile>
-			<id>uts</id>
-			<modules>
-				<module>m2e-core-tests</module>
-			</modules>
-		</profile>
-		<profile>
 			<id>its</id>
 			<modules>
 				<module>m2e-core-tests</module>

--- a/setup/m2e-core--build-with-integration-tests.launch
+++ b/setup/m2e-core--build-with-integration-tests.launch
@@ -5,7 +5,7 @@
     <stringAttribute key="M2_GOALS" value="clean verify"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
-    <stringAttribute key="M2_PROFILES" value="its,uts"/>
+    <stringAttribute key="M2_PROFILES" value="its"/>
     <listAttribute key="M2_PROPERTIES"/>
     <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
     <booleanAttribute key="M2_SKIP_TESTS" value="false"/>


### PR DESCRIPTION
Since o.e.m2e.editor.tests is part of this repo (https://github.com/eclipse-m2e/m2e-core/pull/851) the 'uts' profile has no effect anymore. Therefore it can be removed.