### PR TITLE
Remove but require javax.annotation in m2e.maven.runtime

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -119,6 +119,11 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.inject</groupId>
 			<artifactId>javax.inject</artifactId>
 			<scope>provided</scope>
@@ -167,7 +172,10 @@
 								org.slf4j;resolution:=optional;version="[1.7.0,3.0.0)",\
 								org.slf4j.spi;resolution:=optional;version="[1.7.0,3.0.0)",\
 								org.slf4j.helpers;resolution:=optional;version="[1.7.0,3.0.0)",\
-								javax.inject;version="1.0.0"
+								javax.inject;version="1.0.0",\
+								javax.annotation;version="[1.2.0,2.0.0)",\
+								javax.annotation.sql;version="[1.2.0,2.0.0)",\
+								javax.annotation.security;version="[1.2.0,2.0.0)"
 							Require-Bundle: \
 								com.google.guava
 						]]>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/resources/about.html
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/resources/about.html
@@ -87,17 +87,6 @@ A copy of the ASL is available at <a href="http://www.apache.org/licenses/LICENS
 
 
 
-<h4>javax.inject 1.0</h4>                                                                                                                                            
-<p>
-This plug-in includes the package "javax.inject" from the atinject project, which is                                                                                 
-licensed under the Apache 2.0 license, available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.             
-(a local copy can be found <a href="about_files/LICENSE-2.0.txt">here</a>)
-</p>
-<p>The source for the bundle is available from                                                                                                                       
-the atinject website at <a                                                                                                                                           
-    href="http://code.google.com/p/atinject/">http://code.google.com/p/atinject/</a>.</p>                                                                            
-
-
 <h4>Apache Commons Command Line Interface 1.4</h4>
 <p>
 The plug-in includes software developed by The Apache Software Foundation as part of the Apache Commons project.


### PR DESCRIPTION
This makes the m2e.maven.runtime a little bit smaller.