### PR TITLE
check for cancellation by callers if mvn launch hangs or takes too long

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/AbstractProjectScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/AbstractProjectScanner.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 
 
 /**
@@ -54,5 +55,12 @@ public abstract class AbstractProjectScanner<T extends MavenProjectInfo> {
 
   public abstract String getDescription();
 
+  /**
+   * Execute. Monitor cancellation will propagate as a thrown {@link OperationCanceledException}, InterruptedException
+   * is not an expected exception and remains for compatibility reasons and to handle unexpected thread interruptions.
+   * 
+   * @param monitor a progress monitor for progress and cancellation, may be null
+   * @throws InterruptedException an unexpected thread interruption occurred
+   */
   public abstract void run(IProgressMonitor monitor) throws InterruptedException;
 }

--- a/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
+++ b/org.eclipse.m2e.scm/src/org/eclipse/m2e/scm/MavenProjectPomScanner.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 
@@ -78,10 +79,12 @@ public class MavenProjectPomScanner<T> extends AbstractProjectScanner<MavenProje
     return "" + dependencies.size() + " projects"; //$NON-NLS-1$
   }
 
+  @SuppressWarnings("unused") // InterruptedException XXX unfortunately remains for API compatibility; not intentionally thrown or expected 
   public void run(IProgressMonitor monitor) throws InterruptedException {
+    monitor = IProgressMonitor.nullSafe(monitor);
     for(Dependency d : dependencies) {
-      if(monitor.isCanceled()) {
-        throw new InterruptedException();
+      if(monitor.isCanceled()) { // intentionally not an InterruptedException, to follow progress monitor expectations 
+        throw new OperationCanceledException();
       }
 
       try {


### PR DESCRIPTION
We ran into a situation where the mvn archetype command was hung (not sure why, but it could happen with network I/O !), and I was surprised to see no cancellation check in a spin-wait loop. Here's a simple change to honor cancellation (hoping it threaded through, but that's also another task)