### PR TITLE
Make archetype-project creation more robust

### DIFF
--- a/org.eclipse.m2e.editor.tests/src/org/eclipse/m2e/editor/tests/M2EEditorTest.java
+++ b/org.eclipse.m2e.editor.tests/src/org/eclipse/m2e/editor/tests/M2EEditorTest.java
@@ -74,8 +74,9 @@ public class M2EEditorTest extends AbstractMavenProjectTestCase {
 			assertTrue(DisplayHelper.waitForCondition(Display.getDefault(), 3000, () -> done[0]));
 			assertEquals(List.of(), allStatus);
 			IDocument document = effectivePomEditor.getDocumentProvider().getDocument(effectivePomEditor.getEditorInput());
-			assertTrue(document.get().contains("my-app"));
-			assertFalse(document.get().contains("Loading"));
+			String docText = document.get();
+			assertTrue(docText.contains("my-app"));
+			assertFalse(docText.contains("Loading"));
 		}
 	}
 	


### PR DESCRIPTION
Use a separate working-directory for archetype-project creation and ensure that it is used as the maven.multiModuleProjectDirectory. The parents of the working-directory are searched for a .mvn-directory and if one is found, it is used as maven.multiModuleProjectDirectory.

Consequently if one creates an archetype-project nested inside an existing multimodule-project the parent that contains the .mvn-folder is used as multiModuleProjectDirectory of the archetype-project creation build. This has the consequences that the maven-extensions defined in that mmPDir participate in the archetype build.
This is unnecessary and can cause problems if those extensions are loaded from a repository that is specified in a specified maven-settings file. This happens for example (and causes build failures) when we test Tycho-snapshots from the tycho-snapshot repo.

And add printout of archetype-project creation build in case of failure.

@laeubi any objections?
I can demonstrate/test that this works by temporarily using the Tycho 3.1 snapshot.