### PR TITLE
Extract referenced slf4j bundle for Maven runtime classpath again

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenEmbeddedRuntime.java
@@ -112,6 +112,8 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
     }
   }
 
+  public static final Set<String> SLF4J_BUNDLE_NAMES = Set.of("org.slf4j.api", "slf4j.api");
+
   private synchronized void initClasspath() {
     if(CLASSPATH == null) {
       Bundle mavenRuntimeBundle = findMavenEmbedderBundle();
@@ -120,9 +122,8 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
       addBundleClasspathEntries(allEntries, mavenRuntimeBundle, true);
       allEntries.add(getEmbeddedSLF4JBinding(mavenRuntimeBundle));
 
-      Set<String> noDependencyBundles = Set.of("org.slf4j.api", "slf4j.api");
       // Don't include dependencies of slf4j bundle to ensure no other than the slf4j-binding embedded into m2e.maven.runtime is available.
-      Set<Bundle> bundles = getRequiredBundles(mavenRuntimeBundle, noDependencyBundles);
+      Set<Bundle> bundles = getRequiredBundles(mavenRuntimeBundle, SLF4J_BUNDLE_NAMES);
 
       for(Bundle bundle : bundles) {
         addBundleClasspathEntries(allEntries, bundle, false);
@@ -141,11 +142,13 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
   }
 
   private void addBundleClasspathEntries(Set<String> entries, Bundle bundle, boolean addFragments) {
-    entries.addAll(Bundles.getClasspathEntries(bundle));
+    boolean extractRoot = SLF4J_BUNDLE_NAMES.contains(bundle.getSymbolicName());
+    // Use extracted/directory form of slf4j bundles so that their jar-signing signature by the Maven-runtime classloader
+    entries.addAll(Bundles.getClasspathEntries(bundle, extractRoot));
     Bundle[] fragments;
     if(addFragments && (fragments = Platform.getFragments(bundle)) != null) {
       for(Bundle fragment : fragments) {
-        entries.addAll(Bundles.getClasspathEntries(fragment));
+        entries.addAll(Bundles.getClasspathEntries(fragment, SLF4J_BUNDLE_NAMES.contains(fragment.getSymbolicName())));
       }
     }
   }
@@ -154,7 +157,7 @@ public class MavenEmbeddedRuntime extends AbstractMavenRuntime {
     String bindingPath = mavenBundle.getHeaders().get(M2E_SL4J_BINDING_HEADER);
     Objects.requireNonNull(bindingPath,
         () -> "Missing '" + M2E_SL4J_BINDING_HEADER + "' header in embedded Maven-runtime bundle");
-    String bindingJarPath = Bundles.getClasspathEntryPath(mavenBundle, bindingPath);
+    String bindingJarPath = Bundles.getClasspathEntryPath(mavenBundle, bindingPath, false);
     return Objects.requireNonNull(bindingJarPath, () -> M2E_SL4J_BINDING_HEADER + " '" + bindingPath + "' not found");
   }
 

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchUtils.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchUtils.java
@@ -55,7 +55,7 @@ public class MavenLaunchUtils {
   public static List<String> getCliResolver(AbstractMavenRuntime runtime) {
     if(runtime.getVersion().startsWith("3.")) { //$NON-NLS-1$
       Bundle m2eWorkspaceCLIBundle = FrameworkUtil.getBundle(WorkspaceState.class);
-      return Bundles.getClasspathEntries(m2eWorkspaceCLIBundle);
+      return Bundles.getClasspathEntries(m2eWorkspaceCLIBundle, false);
     }
     return Collections.emptyList(); // unsupported version of maven
   }


### PR DESCRIPTION
This is necessary because even the slf4j-bundle from Maven-Central is jar-singed as part of the m2e build when the m2e-repo is assembled.

If the slf4j-jar is not extraced launching the embedded maven-runtime will fail with errors like:
```
class "org.slf4j.MavenSlf4jFriend"'s signer information does not match
signer information of other classes in the same package
```
The reason for such an error is that the 'slf4j-api' jar and the 'maven-slf4j-provider' jar both provide classes for the package 'org.slf4j'. But all jars that provide classes for the same package must have the same jar-signer. And while the 'slf4j-api' jar is referenced as bundle and therefore signed in the m2e build (although it is originated from Maven-Central), the 'maven-slf4j-provider' jar embedded into the m2e.maven.runtime is not jar signed (because nested jars are not signed).
Extracting the jar and providing them from a directory This check is not performed if a jar is extracted and added to the classpath as directory. Therefore only the slf4j jar is extracted again. Effectively this reverts #926 for slf4j.

