### PR TITLE
Dont extract slf4j (again)

### DIFF
--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchDelegate.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchDelegate.java
@@ -99,8 +99,8 @@ public class MavenLaunchDelegate extends JavaLaunchDelegate implements MavenLaun
       this.extensionsSupport = MavenLaunchExtensionsSupport.create(configuration, launch);
       this.preferencesService = Platform.getPreferencesService();
 
-      log.info("" + getWorkingDirectory(configuration)); //$NON-NLS-1$
-      log.info(" mvn" + getProgramArguments(configuration)); //$NON-NLS-1$
+      log.info("Run build in \"{}\":", getWorkingDirectory(configuration)); //$NON-NLS-1$
+      log.info(" mvn {}", getProgramArguments(configuration)); //$NON-NLS-1$
 
       extensionsSupport.configureSourceLookup(configuration, launch, monitor);
 

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchUtils.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenLaunchUtils.java
@@ -55,7 +55,7 @@ public class MavenLaunchUtils {
   public static List<String> getCliResolver(AbstractMavenRuntime runtime) {
     if(runtime.getVersion().startsWith("3.")) { //$NON-NLS-1$
       Bundle m2eWorkspaceCLIBundle = FrameworkUtil.getBundle(WorkspaceState.class);
-      return Bundles.getClasspathEntries(m2eWorkspaceCLIBundle, false);
+      return Bundles.getClasspathEntries(m2eWorkspaceCLIBundle);
     }
     return Collections.emptyList(); // unsupported version of maven
   }


### PR DESCRIPTION
Now that dependencies are not signed anymore (thanks to #962), the workaround to prevent `signer information does not match` exceptions from #961 can be removed again.

But keep the part of #961 about canonicalizing the paths of referenced bundle-jars.
Furthermore improve the Maven-Console logs about the commands of launched builds and advance the debug-output about the assembled classpath of a maven-runtime from debug to info, so that it shows up once in the Maven-Console. Since the story about non-extracted dependencies in conjunction with deps from Maven or Orbit seems to be a bit sensitive, I think it is good to have another source of information relatively easy accessible.