### PR TITLE
[Core] delete obsolete ".m2/.cache/m2e/" directory and old logback logs

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/AbstractMavenProjectWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/AbstractMavenProjectWizard.java
@@ -50,12 +50,6 @@ public abstract class AbstractMavenProjectWizard extends Wizard {
     }
   }
 
-  @Override
-  public void dispose() {
-    M2EUIPluginActivator.getDefault().ungetMavenDiscovery(discovery);
-    super.dispose();
-  }
-
   public ProjectImportConfiguration getProjectImportConfiguration() {
     return importConfiguration;
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenPluginActivator.java
@@ -31,12 +31,9 @@ import org.osgi.util.tracker.ServiceTracker;
 
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.util.FileUtils;
 
 import org.apache.maven.project.DefaultProjectBuilder;
 
@@ -118,9 +115,6 @@ public class MavenPluginActivator extends Plugin {
     this.protocolHandlerService = context.registerService(URLStreamHandlerService.class,
         new MvnProtocolHandlerService(), FrameworkUtil.asDictionary(properties));
 
-    // Automatically delete now obsolete nexus cache (can be removed again if some time has passed and it is unlikely an old workspace that need to be cleaned up is used).
-    IPath nexusCache = Platform.getStateLocation(context.getBundle()).append("nexus");
-    FileUtils.deleteDirectory(nexusCache.toFile());
   }
 
   /**


### PR DESCRIPTION
Similar to https://github.com/eclipse-m2e/m2e-core/pull/606 the M2E-cache at `<user-home>/.m2/.cache/m2e/` is not used anymore and can be deleted, since we don't sue the indexer anymore. 
Anyone can check the size of that folder. This usually removes a few GB of unused files that where created by m2e in the past.
Furthermore the old logs in the state location of the now renamed o.e.m2e.lockback.configuration can be deleted, which removes up to another GB of useless data.