### PR TITLE
PGP-sign third-party dependencies in M2E repo

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,11 +34,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Generated Meta data
-      run: mvn generate-sources -f m2e-maven-runtime -Pgenerate-osgi-metadata -Dtycho.mode=maven
+      run: mvn generate-sources -f m2e-maven-runtime -B -V -Pgenerate-osgi-metadata -Dtycho.mode=maven
     - name: Build m2e-core
       uses: GabrielBB/xvfb-action@v1
       with:
-       run: mvn clean verify -B -Pits -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Dtycho.surefire.timeout=7200
+       run: mvn clean verify -B -V -Pits -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
       with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,11 @@ pipeline {
 		}
 		stage('Build') {
 			steps {
-				sh 'mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -Dtycho.mode=maven -Pgenerate-osgi-metadata'
+				sh 'mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -V -Dtycho.mode=maven -Pgenerate-osgi-metadata'
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh 'mvn clean verify -f pom.xml -B -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Peclipse-sign,its -Dtycho.surefire.timeout=7200'
+					sh 'mvn clean verify -B -V \
+						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
+						-Peclipse-sign,its'
 				}
 			}
 			post {
@@ -48,7 +50,7 @@ pipeline {
 						{
 							echo Deploy m2e repo to ${1}
 							ssh genie.m2e@projects-storage.eclipse.org "\
-								rm -rf  ${1}/* && \
+								rm -rf ${1}/* && \
 								mkdir -p ${1}"
 							scp -r org.eclipse.m2e.repository/target/repository/* genie.m2e@projects-storage.eclipse.org:${1}
 						}

--- a/org.eclipse.m2e.repository/pom.xml
+++ b/org.eclipse.m2e.repository/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2008, 2022 Sonatype, Inc. and others
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License 2.0
+	which accompanies this distribution, and is available at
+	https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+	Contributors:
+		Sonatype, Inc. - initial API and implementation
+		Hannes Wellmann - Set up PGP-signing
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.m2e</groupId>
+		<artifactId>m2e-core</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.m2e.repository</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<name>Maven Integration for Eclipse Repository</name>
+
+	<profiles>
+		<!-- Eclipse SimRel requires all artifacts to be jar- or pgp-signed. So we sign the (non eclipse) artifacts
+			and update the p2 metadata accordingly -->
+		<profile>
+			<id>eclipse-sign</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-gpg-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<executions>
+							<execution>
+								<id>pgpsigner</id>
+								<goals>
+									<goal>sign-p2-artifacts</goal>
+								</goals>
+								<configuration>
+									<skipIfJarsigned>true</skipIfJarsigned>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-repository-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>verify-repository-consistency</id>
+								<goals>
+									<goal>verify-repository</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<tycho-version>3.0.0</tycho-version>
 
 		<tycho.testArgLine>-Xmx800m</tycho.testArgLine>
-		<tycho.surefire.timeout>7200</tycho.surefire.timeout>
+		<tycho.surefire.timeout>900</tycho.surefire.timeout>
 		<tycho.surefire.useUIHarness>true</tycho.surefire.useUIHarness>
 		<tycho.surefire.useUIThread>true</tycho.surefire.useUIThread>
 		<jacoco.destFile>../target/jacoco.exec</jacoco.destFile>

--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -47,7 +47,7 @@
       xsi:type="jdt:JRETask"
       version="JavaSE-17"
       location="${jre.location-17}"
-      name="JRE for JavaSE-11">
+      name="JRE for JavaSE-17">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
Based on the desciussion in https://github.com/eclipse-m2e/m2e-core/pull/962#issuecomment-1264577708 and described in
https://docs.google.com/document/d/1MnDBvOUwKvKacB-QKnH_PzK88dUlHkjs-D-DWEKmvkY/edit
this PR enhances the M2E build to pgp-sign third-party dependencies that are not jar-signed.

The gpg-keyring and passphrase still need to be set up by the EFN IT-Infrastructure Team but, I have requested that via:
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2056
