### PR TITLE
Only evaluate major and minor version of enforcer java rule

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.0.4.qualifier
+Bundle-Version: 2.0.5.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core</artifactId>
-	<version>2.0.4-SNAPSHOT</version>
+	<version>2.0.5-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -158,6 +158,17 @@ public interface IMaven extends IComponentLookup {
       throws CoreException;
 
   /**
+   * Resolves a configuration parameter from the given {@code mojoExecution}. It coerces from String to the given type
+   * and considers expressions and default values.
+   * 
+   * @param <T>
+   * @param project the Maven project
+   * @param mojoExecution the mojo execution from which to retrieve the configuration value
+   * @param parameter the name of the parameter (may be nested with separating {@code .})
+   * @param asType the type to coerce to
+   * @param monitor the progress monitor
+   * @return the parameter value or {@code null} if the parameter with the given name was not found
+   * @throws CoreException
    * @since 1.4
    */
   <T> T getMojoParameterValue(MavenProject project, MojoExecution mojoExecution, String parameter,

--- a/org.eclipse.m2e.jdt.tests/projects/enforcerSettingsWithVersion/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/enforcerSettingsWithVersion/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
+					<configuration>
+						<source>1.8</source>
+						<target>1.8</target>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>13.0.3</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.jdt.tests/projects/enforcerSettingsWithVersionRange/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/enforcerSettingsWithVersionRange/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
+					<configuration>
+						<source>1.8</source>
+						<target>1.8</target>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[11.0.10,16)</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationFromEnforcer.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationFromEnforcer.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 Hannes Wellmann and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.jdt.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+import org.junit.Test;
+
+public class JavaConfigurationFromEnforcer extends AbstractMavenProjectTestCase {
+	private static final String JRE_CONTAINER_PREFIX = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/";
+
+	@Test
+	public void testEnforcerVersion() throws Exception {
+		IProject project = importProject("projects/enforcerSettingsWithVersion/pom.xml");
+		waitForJobsToComplete();
+		IJavaProject jproject = JavaCore.create(project);
+		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_SOURCE, false));
+		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, false));
+		assertEquals(List.of("JavaSE-13"), getJREContainerVMType(jproject));
+	}
+
+	@Test
+	public void testEnforcerVersionRange() throws Exception {
+		IProject project = importProject("projects/enforcerSettingsWithVersionRange/pom.xml");
+		waitForJobsToComplete();
+		IJavaProject jproject = JavaCore.create(project);
+		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_SOURCE, false));
+		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, false));
+		assertEquals(List.of("JavaSE-11"), getJREContainerVMType(jproject));
+	}
+
+	private static List<String> getJREContainerVMType(IJavaProject jproject) throws JavaModelException {
+		return Arrays.stream(jproject.getRawClasspath())
+				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_CONTAINER).map(IClasspathEntry::getPath)
+				.map(IPath::toString).filter(p -> p.startsWith(JRE_CONTAINER_PREFIX))
+				.map(p -> p.substring(JRE_CONTAINER_PREFIX.length())).toList();
+	}
+}

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.0.2.qualifier
+Bundle-Version: 2.0.3.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",


### PR DESCRIPTION
Fix evaluation of expressions in m-enforcer-p parameter Only select ExecutionEnvironments with at least one compatible VM installed.
This closes #842