### PR TITLE
MvnProtocolHandlerService: Implement lastModfified()

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MvnProtocolHandlerService.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MvnProtocolHandlerService.java
@@ -129,6 +129,19 @@ public class MvnProtocolHandlerService extends AbstractURLStreamHandlerService {
       String urlSpec = "jar:" + location.toURI() + "!" + subPath;
       return new URL(urlSpec).openStream();
     }
+
+    @Override
+    public long getLastModified() {
+      try {
+        connect();
+      } catch (IOException e) {
+        return 0;
+      }
+      if(artifactResult == null || artifactResult.isMissing()) {
+        return 0;
+      }
+      return artifactResult.getArtifact().getFile().lastModified();
+    }
   }
 
 }


### PR DESCRIPTION
Determine last-modified timestamp based on the referenced file.

This silences warnings such as
  ...
  [INFO] Adding repository mvn:org.eclipse.jetty:jetty-p2:11.0.12:zip:p2site
  [WARNING] [a7f3f9cb-793c-4f52-8e8e-b74719152388][extension>org.eclipse.tycho:tycho-maven-plugin:3.0.0] Server returned lastModified <= 0 for mvn:org.eclipse.jetty:jetty-p2:11.0.12:zip:p2site/content.xml
  ...

Fixes #982.