### PR TITLE
Fix multiple loads of Maven Core Extension

### DIFF
--- a/org.eclipse.m2e.core.tests/resources/projects/pomless2/.mvn/extensions.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless2/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>2.7.3</version><!-- Must be the same as in first 'pomless' project. -->
+	</extension>
+</extensions>

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless2/bundle2/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless2/bundle2/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle
+Bundle-SymbolicName: my.bundle2
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: my.bundle2
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless2/bundle2/build.properties
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless2/bundle2/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/org.eclipse.m2e.core.tests/resources/projects/pomless2/pom.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/pomless2/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>tycho-pomless</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>2.7.3</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Currently each Maven Core extension (with identical GAV) can only be loaded one time from one location.

Therefore loading Maven extensions fails in the following scenarios:
- A pomless project (and its extensions) is loaded, then delete from the Workspace and file-system and then re-created.
Then the project+extension is loaded again and loading the extension fails.
- A pomless project (and its extensions) is loaded from a first location.
Then at a disjunct pomless project, whose `.mvn`-folder resides at a different location, but references an extension with the same GAV is loaded and loading the extension fails.

In both cases the reason is that the `CLASS_WORLD` in the `PlexusContainerManager` contains the extension ClassRealm from the first load. In the first case it is not cleaned up correctly and in the second case it simply is still in use, when in `PlexusContainerManager.loadCoreExtensions()` the method `BootstrapCoreExtensionManager.loadCoreExtensions()` is called:

https://github.com/eclipse-m2e/m2e-core/blob/03b015240f32cd4c6feece22c1b8a2830b43da1c/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java#L307-L310

A first approach to solve this would be to first ensure that also the extension realms are disposed and second to make the extension realm-ids unique by appending a running number, similar like it is done in `setupContainerRealm()`.

@laeubi, @mickaelistria what do you think?


