### PR TITLE
m2e.apt: write platform-independent paths into JDT APT preferences

### DIFF
--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
@@ -165,6 +165,9 @@ public abstract class AbstractAptConfiguratorDelegate implements AptConfigurator
       File generatedSourcesRelativeDirectory = convertToProjectRelativePath(eclipseProject, generatedSourcesDirectory);
       String generatedSourcesRelativeDirectoryPath = generatedSourcesRelativeDirectory.getPath();
 
+      if (File.separatorChar != '/') {
+        generatedSourcesRelativeDirectoryPath = generatedSourcesRelativeDirectoryPath.replace(File.separatorChar, '/');
+      }
       AptConfig.setGenSrcDir(javaProject, generatedSourcesRelativeDirectoryPath);
     }
     if(generatedTestSourcesDirectory != null && setGenTestSrcDirMethod != null) {
@@ -172,6 +175,9 @@ public abstract class AbstractAptConfiguratorDelegate implements AptConfigurator
       File generatedTestSourcesRelativeDirectory = convertToProjectRelativePath(eclipseProject,
           generatedTestSourcesDirectory);
       String generatedTestSourcesRelativeDirectoryPath = generatedTestSourcesRelativeDirectory.getPath();
+      if (File.separatorChar != '/') {
+        generatedTestSourcesRelativeDirectoryPath = generatedTestSourcesRelativeDirectoryPath.replace(File.separatorChar, '/');
+      }
       try {
         setGenTestSrcDirMethod.invoke(null, javaProject, generatedTestSourcesRelativeDirectoryPath);
       } catch(IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {


### PR DESCRIPTION
Always write paths using the forward slash as separator. Otherwise, if a file generated on Windows is read on Unix, JDT would create not a directory hierarchy but a single folder with the backslashes in the name. The forward slash works on both platforms.

Fixes #989