### PR TITLE
Deprecate (and remove usages) of IMaven.readMavenProject

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -106,7 +106,10 @@ public interface IMaven extends IComponentLookup {
    * @since 1.4
    * @see {@link #readMavenProjects(File, ProjectBuildingRequest)} to group requests and improve performance (RAM and
    *      CPU)
+   * @deprecated this method should never have been API and is prone to errors, if you still need this method please
+   *             contact the m2e team to provide better alternatives for your use-case
    */
+  @Deprecated(forRemoval = true)
   MavenExecutionResult readMavenProject(File pomFile, ProjectBuildingRequest configuration) throws CoreException;
 
   /**


### PR DESCRIPTION
IMaven.readMavenProject(File, ProjectBuildingRequest) is dangerous to use in global context (aka IMaven) as it do not take basedir / extensions into account. Actually reading the raw maven model should not be exposed to consumers at all as it is very easy to get wrong and do not support caching.

This deprecates the method and converts usages to internal toolbox instead that are used in the correct context.