### PR TITLE
Adjust MavenExecutionContext to be more well-defined

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenExecutionContext.java
@@ -160,7 +160,8 @@ public interface IMavenExecutionContext {
   static IMavenExecutionContext of(File baseDir) throws CoreException {
     PlexusContainerManager containerManager = MavenPlugin.getMaven().lookup(PlexusContainerManager.class);
     try {
-      return new MavenExecutionContext(containerManager.getComponentLookup(baseDir), null);
+      //basedir scoped executions has a basedir but not a project supplier
+      return new MavenExecutionContext(containerManager.getComponentLookup(baseDir), baseDir, null);
     } catch(Exception ex) {
       throw new CoreException(
           Status.error("aquire container for basedir " + baseDir.getAbsolutePath() + " failed!", ex));

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/IMavenPlexusContainer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/IMavenPlexusContainer.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.core.internal.embedder;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.codehaus.plexus.PlexusContainer;
+
+import org.eclipse.m2e.core.embedder.IComponentLookup;
+
+
+/**
+ * IMavenPlexusContainer
+ *
+ */
+public interface IMavenPlexusContainer {
+
+  static final String MVN_FOLDER = ".mvn";
+
+  static final String EXTENSIONS_FILENAME = MVN_FOLDER + "/extensions.xml";
+
+  /**
+   * Maven allows to use a magic {@value #MVN_FOLDER} folder where one can configure several aspects of the maven run
+   * and m2e scopes containers by this directory.
+   * 
+   * @return the folder this container is rooted by or an empty Optional if this container has no {@value #MVN_FOLDER}
+   *         root
+   */
+  Optional<File> getMavenDirectory();
+
+  /**
+   * @return the underlying {@link PlexusContainer}.
+   */
+  PlexusContainer getContainer();
+
+  /**
+   * @return returns a {@link IComponentLookup} that is backed by this container
+   */
+  IComponentLookup getComponentLookup();
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -148,7 +148,6 @@ import org.eclipse.m2e.core.embedder.MavenConfigurationChangeEvent;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.preferences.MavenPreferenceConstants;
-import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 
 @Component(service = {IMaven.class, IMavenConfigurationChangeListener.class})
@@ -952,7 +951,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
 
   public PlexusContainer getPlexusContainer() throws CoreException {
     try {
-      return containerManager.aquire();
+      return containerManager.aquire().getContainer();
     } catch(Exception ex) {
       throw new CoreException(Status.error(Messages.MavenImpl_error_init_maven, ex));
     }
@@ -1040,7 +1039,7 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
     ClassLoader classLoader = project.getClassRealm();
     if(classLoader == null) {
       try {
-        return containerManager.aquire(project.getBasedir()).getContainerRealm();
+        return containerManager.aquire(project.getBasedir()).getContainer().getContainerRealm();
       } catch(Exception ex) {
         throw new RuntimeException(ex);
       }
@@ -1078,7 +1077,8 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
 
   @Override
   public MavenExecutionContext createExecutionContext() {
-      return new MavenExecutionContext(this, (IMavenProjectFacade) null);
+    //the global context do not has a basedir nor a project supplier...
+    return new MavenExecutionContext(this, null, null);
   }
 
 }


### PR DESCRIPTION
Currently we do some computations regarding the basedir in MavenExecutionContext that later influences the session created, but actually this should be the concern of the creator to decide if and what basedir has to be used, e.g. even if there is currently no project a basedir might still be known.

This changes the MavenExecutionContext to accept a basedir on construction time and changes the ImavenFacade to a more generic supplier.

FYI @HannesWell that should fix the obstacles you see regarding basedir/multiProjectBasedir