### PR TITLE
Support sync compilerArgs with delimiter

### DIFF
--- a/org.eclipse.m2e.jdt.tests/projects/compilerJpmsSettings/compilerArgsSet3.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/compilerJpmsSettings/compilerArgsSet3.xml
@@ -1,0 +1,21 @@
+<compilerArgs>
+	<!-- M2E Container exports -->
+	<arg>--add-exports=javafx.graphics/com.sun.javafx.geometry=somemodule</arg>
+	<!-- JRE Container exports -->
+	<arg>--add-exports=jdk.jartool/sun.tools.jar=somemodule</arg>
+
+	<!-- M2E Container opens -->
+	<arg>--add-opens=javafx.graphics/com.sun.javafx.geometry=somemodule</arg>
+	<!-- JRE Container opens -->
+	<arg>--add-opens=jdk.jartool/sun.tools.jar=somemodule</arg>
+
+	<!-- M2E Container reads -->
+	<arg>--add-reads=javafx.graphics=somemodule</arg>
+	<!-- JRE Container reads -->
+	<arg>--add-reads=jdk.jartool=jdk.javadoc</arg>
+
+	<!-- M2E Container patch -->
+	<arg>--patch-module=javafx.graphics=somepath/some.jar</arg>
+	<!-- JRE Container patch -->
+	<arg>--patch-module=jdk.jartool=somepath/some.jar</arg>
+</compilerArgs>

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JpmsConfigurationTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JpmsConfigurationTest.java
@@ -68,6 +68,8 @@ public class JpmsConfigurationTest extends AbstractMavenProjectTestCase {
     File pomFileFS = new File(FileLocator.toFileURL(getClass().getResource("/projects/compilerJpmsSettings/pom.xml")).getFile());
     File argsSet1FS= new File(FileLocator.toFileURL(getClass().getResource("/projects/compilerJpmsSettings/compilerArgsSet1.xml")).getFile());
     File argsSet2FS = new File(FileLocator.toFileURL(getClass().getResource("/projects/compilerJpmsSettings/compilerArgsSet2.xml")).getFile());
+	File argsSet3FS = new File(FileLocator
+			.toFileURL(getClass().getResource("/projects/compilerJpmsSettings/compilerArgsSet3.xml")).getFile());
     
     IProject project = importProject(pomFileFS.getAbsolutePath());
     waitForJobsToComplete();
@@ -92,6 +94,7 @@ public class JpmsConfigurationTest extends AbstractMavenProjectTestCase {
     String contents = Utils.read(project, pomFileFS);
     String argsSet1 = Utils.read(project, argsSet1FS);
     String argsSet2 = Utils.read(project, argsSet2FS);
+	String argsSet3 = Utils.read(project, argsSet3FS);
     
     IFile pomFileWS = project.getFile(pomFileFS.getName());
     
@@ -131,6 +134,24 @@ public class JpmsConfigurationTest extends AbstractMavenProjectTestCase {
     assertEquals(M2E_ADD_READS_VALUE1 + ATTR_VALUE_SEPARATOR + M2E_ADD_READS_VALUE2, m2eAttributes.get(ADD_READS_ATTR));
     assertEquals(M2E_PATCH_MODULE_VALUE1 + ATTR_VALUE_SEPARATOR + M2E_PATCH_MODULE_VALUE2, m2eAttributes.get(PATCH_MODULE_ATTR));
     
+	// then test attributes are created with one value each
+	String argsSet3Content = contents.replace(REPLACED_POM_STRING, argsSet3);
+	pomFileWS.setContents(new ByteArrayInputStream(argsSet3Content.getBytes()), true, false, null);
+	waitForJobsToComplete();
+
+	jreAttributes = Utils.getJreContainerAttributes(javaProject);
+	m2eAttributes = Utils.getM2eContainerAttributes(javaProject);
+
+	assertEquals(JRE_ADD_EXPORTS_VALUE1, jreAttributes.get(ADD_EXPORTS_ATTR));
+	assertEquals(JRE_ADD_OPENS_VALUE1, jreAttributes.get(ADD_OPENS_ATTR));
+	assertEquals(JRE_ADD_READS_VALUE1, jreAttributes.get(ADD_READS_ATTR));
+	assertEquals(JRE_PATCH_MODULE_VALUE1, jreAttributes.get(PATCH_MODULE_ATTR));
+
+	assertEquals(M2E_ADD_EXPORTS_VALUE1, m2eAttributes.get(ADD_EXPORTS_ATTR));
+	assertEquals(M2E_ADD_OPENS_VALUE1, m2eAttributes.get(ADD_OPENS_ATTR));
+	assertEquals(M2E_ADD_READS_VALUE1, m2eAttributes.get(ADD_READS_ATTR));
+	assertEquals(M2E_PATCH_MODULE_VALUE1, m2eAttributes.get(PATCH_MODULE_ATTR));
+
     // then test attributes are removed
     pomFileWS.setContents(new ByteArrayInputStream(contents.getBytes()), true, false, null);
     waitForJobsToComplete();


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

related to #129 

sync for jpms args has been supported in https://github.com/eclipse-m2e/m2e-core/pull/216, but there is still one way to pass arguments to compilerArgs with `=` as the delimiter between the argument type and argument value, e.g., `<arg>--add-exports=javafx.graphics/com.sun.javafx.geometry=somemodule</arg>`. If you directly run `java` in the command line, you can find the following description at the end of the help description:
```
To specify an argument for a long option, you can use --<name>=<value> or
--<name> <value>.
```

which indicates both of the two styles are supported. but currently argument within `=` can be correctly recognized by maven compiler but m2e can't pass them to the classpath entry attribute. This PR will fix it.

