### PR TITLE
Optimize Caching by distributing already loaded maven projects

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -49,7 +49,8 @@ Export-Package: org.eclipse.m2e.core,
  org.eclipse.m2e.core.repository
 MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.core
-Import-Package: com.google.common.cache,
+Import-Package: com.google.common.base;version="30.1.0",
+ com.google.common.cache,
  javax.inject;version="1.0.0",
  org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.core

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
@@ -130,7 +130,11 @@ public interface IMavenConfiguration {
   boolean buildWithNullSchedulingRule();
 
   static IMavenConfiguration getWorkspaceConfiguration() {
-    return MavenPluginActivator.getDefault().getMavenConfiguration();
+    MavenPluginActivator activator = MavenPluginActivator.getDefault();
+    if(activator == null) {
+      throw new IllegalStateException("m2e is shut down!");
+    }
+    return activator.getMavenConfiguration();
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -916,7 +916,11 @@ public class ProjectConfigurationManager
 
   @Override
   public ResolverConfiguration getResolverConfiguration(IProject project) {
-    return ResolverConfigurationIO.readResolverConfiguration(project);
+    IProjectConfiguration cfg = ResolverConfigurationIO.readResolverConfiguration(project);
+    if(cfg instanceof ResolverConfiguration) {
+      return (ResolverConfiguration) cfg;
+    }
+    return new ResolverConfiguration(cfg);
   }
 
   /* (non-Javadoc)

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ResolverConfigurationIO.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ResolverConfigurationIO.java
@@ -110,7 +110,7 @@ public class ResolverConfigurationIO {
     return false;
   }
 
-  public static ResolverConfiguration readResolverConfiguration(IProject project) {
+  public static IProjectConfiguration readResolverConfiguration(IProject project) {
     IScopeContext projectScope = new ProjectScope(project);
     IEclipsePreferences projectNode = projectScope.getNode(IMavenConstants.PLUGIN_ID);
     if(projectNode == null) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
@@ -18,14 +18,16 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalNotification;
 
 import org.eclipse.core.runtime.CoreException;
@@ -42,6 +44,7 @@ import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
 import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.internal.project.IManagedCache;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 
 
 /**
@@ -52,59 +55,69 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 @Component(service = MavenProjectCache.class)
 public class MavenProjectCache {
 
-  private static final int MAX_CACHE_SIZE = Integer.getInteger("m2e.project.cache.size", 20);
+  private static final int MAX_CACHE_SIZE = Integer.getInteger("m2e.project.cache.size", 50);
 
   private static final String CTX_MAVENPROJECTS = MavenProjectCache.class.getName() + "/mavenProjects";
 
   @Reference
   PlexusContainerManager containerManager;
 
-  private Cache<IMavenProjectFacade, MavenProject> mavenProjectCache;
+  private LoadingCache<CacheKey, CacheLine> loadingCache;
 
 
-  /**
-   * 
-   */
   public MavenProjectCache() {
-    this.mavenProjectCache = CacheBuilder.newBuilder() //
+    this.loadingCache = CacheBuilder.newBuilder() //
         .maximumSize(MAX_CACHE_SIZE) //
-        .removalListener((RemovalNotification<IMavenProjectFacade, MavenProject> removed) -> {
+        .removalListener((RemovalNotification<CacheKey, CacheLine> removed) -> {
           Map<IMavenProjectFacade, MavenProject> contextProjects = getContextProjectMap();
-          IMavenProjectFacade facade = removed.getKey();
-          if(!contextProjects.containsKey(facade)) {
-            flushMavenCaches(facade.getPomFile(), facade.getArtifactKey(), false);
-          }
-        }).build();
+          removed.getValue().projects.values().forEach(mavenProject -> {
+            if(!contextProjects.containsValue(mavenProject)) {
+              flushMavenCaches(mavenProject.getFile(), removed.getKey().artifactKey(), false);
+            }
+          });
+        }).build(CacheLoader.from(CacheLine::new));
   }
 
   /**
-   * @param facade
+   * Invalidates stored data for this facade
+   * 
+   * @param facade the facade to invalidate
    */
   public void invalidateProjectFacade(IMavenProjectFacade facade) {
-    mavenProjectCache.invalidate(facade);
+    CacheLine cacheLine = loadingCache.getIfPresent(new CacheKey(facade.getArtifactKey(), facade.getConfiguration()));
+    if(cacheLine != null) {
+      cacheLine.remove(facade.getPomFile());
+    }
   }
 
   /**
-   * @param facade
-   * @return
+   * Get (and optionally load) the MavenProject for this facade.
+   * 
+   * @param facade the facade for which a project should be returned
+   * @param projectLoader if given will be used to load a value into this cache, if <code>null</code> no loading is
+   *          attempted if no value is in the cache
+   * @return the project or null
    */
   public MavenProject getMavenProject(IMavenProjectFacade facade, Function<IMavenProjectFacade, MavenProject> projectLoader) {
-    if(projectLoader == null) {
-      return mavenProjectCache.getIfPresent(facade);
-    }
-    try {
-      return mavenProjectCache.get(facade, () -> projectLoader.apply(facade));
-    } catch(ExecutionException ex) {
-      throw new RuntimeException(ex);
-    }
+    ArtifactKey artifactKey = facade.getArtifactKey();
+    CacheLine cacheLine = loadingCache.getUnchecked(new CacheKey(artifactKey, facade.getConfiguration()));
+    return cacheLine.getProject(facade, projectLoader);
   }
 
   /**
-   * @param newFacade
-   * @param mavenProject
+   * Associates a new maven project with the given facade
+   * 
+   * @param facade the facade to update
+   * @param mavenProject the new mavenproject value
    */
-  public void updateMavenProject(IMavenProjectFacade newFacade, MavenProject mavenProject) {
-    mavenProjectCache.put(newFacade, mavenProject);
+  public void updateMavenProject(IMavenProjectFacade facade, MavenProject mavenProject) {
+    if(mavenProject == null) {
+      invalidateProjectFacade(facade);
+      return;
+    }
+    ArtifactKey artifactKey = facade.getArtifactKey();
+    CacheLine cacheLine = loadingCache.getUnchecked(new CacheKey(artifactKey, facade.getConfiguration()));
+    cacheLine.updateProject(facade, mavenProject);
   }
 
   /**
@@ -149,6 +162,63 @@ public class MavenProjectCache {
       return projects;
     }
     return new IdentityHashMap<>(1);
+  }
+
+  private final class CacheLine {
+
+    private ConcurrentMap<File, MavenProject> projects = new ConcurrentHashMap<>(1);
+
+    void remove(File pomFile) {
+      projects.remove(pomFile);
+    }
+
+    void updateProject(IMavenProjectFacade facade, MavenProject mavenProject) {
+      File pomFile = facade.getPomFile();
+      projects.compute(pomFile, (key, current) -> {
+        distributeProjectToCache(mavenProject, facade.getConfiguration());
+        return mavenProject;
+      });
+
+    }
+
+    MavenProject getProject(IMavenProjectFacade facade, Function<IMavenProjectFacade, MavenProject> loader) {
+      File pomFile = facade.getPomFile();
+      if(loader == null) {
+        return projects.get(pomFile);
+      }
+      return projects.computeIfAbsent(pomFile, f -> {
+        MavenProject mavenProject = loader.apply(facade);
+        distributeProjectToCache(mavenProject, facade.getConfiguration());
+        return mavenProject;
+      });
+    }
+
+  }
+
+  private void distributeProjectToCache(MavenProject mavenProject, IProjectConfiguration configuration) {
+    if(mavenProject == null) {
+      return;
+    }
+    MavenProject parent = mavenProject.getParent();
+    if(parent != null) {
+      File file = parent.getFile();
+      //check if this is a workspace artifact
+      if(file != null) {
+        ArtifactKey projectKey = new ArtifactKey(parent.getArtifact());
+        MavenProject cacheItem = loadingCache.getUnchecked(new CacheKey(projectKey, configuration)).projects
+            .computeIfAbsent(file, x -> parent);
+        if(cacheItem == parent) {
+          //the project was cached, go on with the parent of the parent...
+          distributeProjectToCache(parent, configuration);
+        } else {
+          //the project was already in the cache, replace the reference and we are done
+          mavenProject.setParent(cacheItem);
+        }
+      }
+    }
+  }
+  
+  private static final record CacheKey(ArtifactKey artifactKey, IProjectConfiguration configuration) {
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -33,7 +33,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 
@@ -604,7 +603,7 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
   public IMavenExecutionContext createExecutionContext() {
     try {
       IMavenPlexusContainer container = manager.getContainerManager().aquire(getPomFile());
-      MavenProject mavenProject = getMavenProject(new NullProgressMonitor());
+      MavenProject mavenProject = getMavenProject(null);
       if(mavenProject == null) {
         //could this actually happen or will a core exception be thrown instead? Should we still be able to create an execution? use always the chaed variant here?
         return new MavenExecutionContext(container.getComponentLookup(), getBaseDir(), null);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -204,7 +204,7 @@ public class ProjectRegistryManager implements ISaveParticipant {
     }
     MavenProjectFacade projectFacade = projectRegistry.getProjectFacade(pom);
     if(projectFacade == null && load) {
-      ResolverConfiguration config = ResolverConfigurationIO.readResolverConfiguration(pom.getProject());
+      IProjectConfiguration config = ResolverConfigurationIO.readResolverConfiguration(pom.getProject());
       MavenExecutionResult executionResult = readProjectsWithDependencies(pom, config, monitor).iterator().next();
       MavenProject mavenProject = executionResult.getProject();
       if(mavenProject != null && mavenProject.getArtifact() != null) {
@@ -700,17 +700,17 @@ public class ProjectRegistryManager implements ISaveParticipant {
       markerManager.deleteMarkers(pom, IMavenConstants.MARKER_POM_LOADING_ID);
     }
 
-    Map<IFile, ResolverConfiguration> resolverConfigurations = new HashMap<>(poms.size(), 1.f);
-    Map<ResolverConfiguration, Collection<IFile>> groupsToImport = poms.stream().collect(Collectors.groupingBy(pom -> {
+    Map<IFile, IProjectConfiguration> resolverConfigurations = new HashMap<>(poms.size(), 1.f);
+    Map<IProjectConfiguration, Collection<IFile>> groupsToImport = poms.stream().collect(Collectors.groupingBy(pom -> {
       subMonitor.checkCanceled();
-      ResolverConfiguration resolverConfiguration = ResolverConfigurationIO.readResolverConfiguration(pom.getProject());
+      IProjectConfiguration resolverConfiguration = ResolverConfigurationIO.readResolverConfiguration(pom.getProject());
       resolverConfigurations.put(pom, resolverConfiguration);
       return resolverConfiguration;
     }, LinkedHashMap::new, Collectors.toCollection(LinkedHashSet::new)));
 
     Map<IFile, MavenProjectFacade> result = new HashMap<>(poms.size(), 1.f);
-    for(Entry<ResolverConfiguration, Collection<IFile>> entry : groupsToImport.entrySet()) {
-      ResolverConfiguration resolverConfiguration = entry.getKey();
+    for(Entry<IProjectConfiguration, Collection<IFile>> entry : groupsToImport.entrySet()) {
+      IProjectConfiguration resolverConfiguration = entry.getKey();
       Map<IMavenPlexusContainer, List<IFile>> pomFiles = mapToContainer(entry.getValue());
       SubMonitor containerMonitor = subMonitor.split(pomFiles.size());
       containerMonitor.setWorkRemaining(pomFiles.size());


### PR DESCRIPTION
Currently when a maven project is loaded all its parent projects are loaded as well. For deeply nested multi-module setups this can easily lead to filling the cache with hundred of duplicate projects. This reads maven projects multiple times and even worse reduces an effective caching as we need to limit the cache to a smaller size with worse performance even though the data is still retained in memory.

This changes the following things:

1) do cache on the ArtifactKey and path of a pom instead of the facade object itself to always ever keep one instance in the cache per maven facade identity
2) distribute loaded parent projects to the cache so these not need to be loaded again if requested afterwards
3) raises the default caching size from 20 to 50 to account for more efficient caching

Using my camel testcase with an unlimited cache size this reduces the number of projects effectively retained with a full "Update Project" from 3500+ items to 575 (where 572 +1 would be the optimum in this case).

There is still room for improvement, because over time numbers can increase because there is no global optimization, but this would better be performed in separate PRs.