### PR TITLE
Add new IProjectConfiguration as replacement for ResolverConfiguration

### DIFF
--- a/org.eclipse.m2e.apt.tests/src/org/eclipse/m2e/apt/tests/AbstractM2eAptProjectConfiguratorTestCase.java
+++ b/org.eclipse.m2e.apt.tests/src/org/eclipse/m2e/apt/tests/AbstractM2eAptProjectConfiguratorTestCase.java
@@ -46,6 +46,7 @@ import org.eclipse.m2e.apt.MavenJdtAptPlugin;
 import org.eclipse.m2e.apt.preferences.AnnotationProcessingMode;
 import org.eclipse.m2e.apt.preferences.IPreferencesManager;
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.IProjectCreationListener;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
@@ -139,7 +140,7 @@ abstract class AbstractM2eAptProjectConfiguratorTestCase extends AbstractMavenPr
 		}
 
 		IProjectConfigurationManager configurationManager = MavenPlugin.getProjectConfigurationManager();
-		ResolverConfiguration configuration = new ResolverConfiguration();
+		IProjectConfiguration configuration = new ResolverConfiguration();
 		configurationManager.enableMavenNature(project, configuration, monitor);
 		configurationManager.updateProjectConfiguration(project, monitor);
 		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);

--- a/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Binary Project Core
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
@@ -30,8 +30,8 @@ import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.MavenProjectUtils;
-import org.eclipse.m2e.core.project.ResolverConfiguration;
 
 
 /**
@@ -69,8 +69,8 @@ public class MavenPropertyTester extends PropertyTester {
         IMavenProjectRegistry projectManager = MavenPlugin.getMavenProjectRegistry();
         IMavenProjectFacade projectFacade = projectManager.create(projectAdapter, new NullProgressMonitor());
         if(projectFacade != null) {
-          ResolverConfiguration configuration = projectFacade.getResolverConfiguration();
-          return !configuration.shouldResolveWorkspaceProjects();
+          IProjectConfiguration configuration = projectFacade.getResolverConfiguration();
+          return !configuration.isResolveWorkspaceProjects();
         }
       }
       return enableWorkspaceResolution;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenProjectPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenProjectPreferencePage.java
@@ -36,6 +36,7 @@ import org.eclipse.ui.dialogs.PropertyPage;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.core.ui.internal.Messages;
@@ -107,9 +108,9 @@ public class MavenProjectPreferencePage extends PropertyPage {
     init(new ResolverConfiguration());
   }
 
-  private void init(ResolverConfiguration configuration) {
+  private void init(IProjectConfiguration configuration) {
 
-    resolveWorspaceProjectsButton.setSelection(configuration.shouldResolveWorkspaceProjects());
+    resolveWorspaceProjectsButton.setSelection(configuration.isResolveWorkspaceProjects());
 //    includeModulesButton.setSelection(configuration.shouldIncludeModules());
     selectedProfilesText.setText(configuration.getSelectedProfiles());
   }
@@ -129,7 +130,7 @@ public class MavenProjectPreferencePage extends PropertyPage {
     final ResolverConfiguration configuration = getResolverConfiguration();
     if(configuration.getSelectedProfiles().equals(selectedProfilesText.getText()) &&
 //        configuration.shouldIncludeModules()==includeModulesButton.getSelection() &&
-        configuration.shouldResolveWorkspaceProjects() == resolveWorspaceProjectsButton.getSelection()) {
+        configuration.isResolveWorkspaceProjects() == resolveWorspaceProjectsButton.getSelection()) {
       return true;
     }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/ResolverConfigurationComponent.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/ResolverConfigurationComponent.java
@@ -29,6 +29,7 @@ import org.eclipse.ui.forms.events.ExpansionAdapter;
 import org.eclipse.ui.forms.events.ExpansionEvent;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.ProjectImportConfiguration;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.core.ui.internal.Messages;
@@ -117,14 +118,14 @@ public class ResolverConfigurationComponent extends ExpandableComposite {
   }
 
   public void loadData() {
-    resolveWorkspaceProjects.setSelection(resolverConfiguration.shouldResolveWorkspaceProjects());
+    resolveWorkspaceProjects.setSelection(resolverConfiguration.isResolveWorkspaceProjects());
     profiles.setText(resolverConfiguration.getSelectedProfiles());
     if(template != null) {
       template.setText(projectImportConfiguration.getProjectNameTemplate());
     }
   }
 
-  public ResolverConfiguration getResolverConfiguration() {
+  public IProjectConfiguration getResolverConfiguration() {
     return this.resolverConfiguration;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
@@ -42,8 +42,8 @@ import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.markers.IMavenMarkerManager;
 import org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
-import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.ILifecycleMapping;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -74,7 +74,7 @@ public class MavenBuilder extends IncrementalProjectBuilder implements DeltaProv
         return null;
       }
 
-      ResolverConfiguration resolverConfiguration = configurationManager.getResolverConfiguration(project);
+      IProjectConfiguration resolverConfiguration = configurationManager.getResolverConfiguration(project);
 
       if(resolverConfiguration == null) {
         // TODO unit test me

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -82,6 +82,7 @@ import org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectImportResult;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.IProjectCreationListener;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
@@ -503,7 +504,7 @@ public class ProjectConfigurationManager
   }
 
   @Override
-  public void enableMavenNature(IProject project, ResolverConfiguration configuration, IProgressMonitor monitor)
+  public void enableMavenNature(IProject project, IProjectConfiguration configuration, IProgressMonitor monitor)
       throws CoreException {
     monitor.subTask(Messages.ProjectConfigurationManager_task_enable_nature);
     IMavenExecutionContext.getThreadContext().orElseGet(maven::createExecutionContext).execute(new AbstractRunnable() {
@@ -515,7 +516,7 @@ public class ProjectConfigurationManager
     }, monitor);
   }
 
-  void enableBasicMavenNature(IProject project, ResolverConfiguration configuration, IProgressMonitor monitor)
+  void enableBasicMavenNature(IProject project, IProjectConfiguration configuration, IProgressMonitor monitor)
       throws CoreException {
     ResolverConfigurationIO.saveResolverConfiguration(project, configuration);
 
@@ -838,7 +839,7 @@ public class ProjectConfigurationManager
       listener.projectCreated(project);
     }
 
-    ResolverConfiguration resolverConfiguration = configuration.getResolverConfiguration();
+    IProjectConfiguration resolverConfiguration = configuration.getResolverConfiguration();
     enableBasicMavenNature(project, resolverConfiguration, monitor);
 
     // create empty/marker persistent configuration
@@ -919,7 +920,7 @@ public class ProjectConfigurationManager
   }
 
   @Override
-  public boolean setResolverConfiguration(IProject project, ResolverConfiguration configuration) {
+  public boolean setResolverConfiguration(IProject project, IProjectConfiguration configuration) {
     return ResolverConfigurationIO.saveResolverConfiguration(project, configuration);
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/DefaultMavenDependencyResolver.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/DefaultMavenDependencyResolver.java
@@ -72,7 +72,7 @@ public class DefaultMavenDependencyResolver extends AbstractMavenDependencyResol
 
     markerManager.addMarkers(facade.getPom(), IMavenConstants.MARKER_DEPENDENCY_ID, mavenResult);
 
-    if(!facade.getResolverConfiguration().shouldResolveWorkspaceProjects()) {
+    if(!facade.getResolverConfiguration().isResolveWorkspaceProjects()) {
       return;
     }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/EclipseWorkspaceArtifactRepository.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/EclipseWorkspaceArtifactRepository.java
@@ -75,7 +75,7 @@ public final class EclipseWorkspaceArtifactRepository extends LocalArtifactRepos
       return null;
     }
 
-    if(context.resolverConfiguration.shouldResolveWorkspaceProjects()) {
+    if(context.resolverConfiguration.isResolveWorkspaceProjects()) {
       IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
       IPath file = pom.getLocation();
       if(file == null) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -61,6 +61,7 @@ import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
 import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.MavenProjectUtils;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -336,6 +337,11 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
 
   @Override
   public ResolverConfiguration getResolverConfiguration() {
+    return resolverConfiguration;
+  }
+
+  @Override
+  public IProjectConfiguration getConfiguration() {
     return resolverConfiguration;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -113,6 +113,16 @@ public interface IMavenProjectFacade extends IMavenExecutableLocation {
 
   Set<ArtifactRef> getMavenProjectArtifacts();
 
+  /**
+   * @return the configuration associated with this facade
+   */
+  IProjectConfiguration getConfiguration();
+
+  /**
+   * @deprecated use {@link #getConfiguration()} instead
+   * @return
+   */
+  @Deprecated(forRemoval = true)
   ResolverConfiguration getResolverConfiguration();
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.project;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * {@link IProjectConfiguration} represents the project specific configuration, many projects can share the same
+ * configuration and are usually resolved together.
+ * 
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ */
+public interface IProjectConfiguration {
+
+  Map<String, String> getConfigurationProperties();
+
+  boolean isResolveWorkspaceProjects();
+
+  String getSelectedProfiles();
+
+  List<String> getActiveProfileList();
+
+  List<String> getInactiveProfileList();
+
+  String getLifecycleMappingId();
+
+  File getMultiModuleProjectDirectory();
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfigurationManager.java
@@ -55,7 +55,7 @@ public interface IProjectConfigurationManager {
 
   Set<MavenProjectInfo> collectProjects(Collection<MavenProjectInfo> projects);
 
-  void enableMavenNature(IProject project, ResolverConfiguration configuration, IProgressMonitor monitor)
+  void enableMavenNature(IProject project, IProjectConfiguration configuration, IProgressMonitor monitor)
       throws CoreException;
 
   void disableMavenNature(IProject project, IProgressMonitor monitor) throws CoreException;
@@ -90,6 +90,6 @@ public interface IProjectConfigurationManager {
   /**
    * PROVISIONAL
    */
-  boolean setResolverConfiguration(IProject project, ResolverConfiguration configuration);
+  boolean setResolverConfiguration(IProject project, IProjectConfiguration configuration);
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
@@ -14,11 +14,16 @@
 
 package org.eclipse.m2e.core.project;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 
 
 /**
@@ -27,7 +32,7 @@ import java.util.Properties;
  *
  * @author Eugene Kuleshov
  */
-public class ResolverConfiguration implements Serializable {
+public class ResolverConfiguration implements Serializable, IProjectConfiguration {
   private static final long serialVersionUID = 1258510761534886581L;
 
   private boolean resolveWorkspaceProjects = true;
@@ -38,26 +43,63 @@ public class ResolverConfiguration implements Serializable {
 
   private Properties properties;
 
+  private File multiModuleProjectDirectory;
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getProperties()
+   */
   public Properties getProperties() {
     return this.properties;
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getConfigurationProperties()
+   */
+  @Override
+  public Map<String, String> getConfigurationProperties() {
+    if(properties == null) {
+      return Collections.emptyMap();
+    }
+    Set<String> names = properties.stringPropertyNames();
+    Map<String, String> map = new HashMap<>();
+    for(String key : names) {
+      map.put(key, properties.getProperty(key));
+    }
+    return Collections.unmodifiableMap(map);
   }
 
   public void setProperties(Properties properties) {
     this.properties = properties;
   }
 
-  public boolean shouldResolveWorkspaceProjects() {
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#shouldResolveWorkspaceProjects()
+   */
+  @Override
+  public boolean isResolveWorkspaceProjects() {
     return this.resolveWorkspaceProjects;
   }
 
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getSelectedProfiles()
+   */
+  @Override
   public String getSelectedProfiles() {
     return this.selectedProfiles;
   }
 
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getActiveProfileList()
+   */
+  @Override
   public List<String> getActiveProfileList() {
     return parseProfiles(selectedProfiles, true);
   }
 
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getInactiveProfileList()
+   */
+  @Override
   public List<String> getInactiveProfileList() {
     return parseProfiles(selectedProfiles, false);
   }
@@ -88,9 +130,10 @@ public class ResolverConfiguration implements Serializable {
     return profiles;
   }
 
-  /**
-   * @since 1.3
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getLifecycleMappingId()
    */
+  @Override
   public String getLifecycleMappingId() {
     return lifecycleMappingId;
   }
@@ -120,11 +163,28 @@ public class ResolverConfiguration implements Serializable {
     return this.resolveWorkspaceProjects == other.resolveWorkspaceProjects
         && Objects.equals(this.selectedProfiles, other.selectedProfiles)
         && Objects.equals(this.lifecycleMappingId, other.lifecycleMappingId)
-        && Objects.equals(this.properties, other.properties);
+        && Objects.equals(this.properties, other.properties)
+        && Objects.equals(this.multiModuleProjectDirectory, other.multiModuleProjectDirectory);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(resolveWorkspaceProjects, selectedProfiles, lifecycleMappingId, properties);
+    return Objects.hash(resolveWorkspaceProjects, selectedProfiles, lifecycleMappingId, properties,
+        multiModuleProjectDirectory);
+  }
+
+  /* (non-Javadoc)
+   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getMultiModuleProjectDirectory()
+   */
+  @Override
+  public File getMultiModuleProjectDirectory() {
+    return multiModuleProjectDirectory;
+  }
+
+  /**
+   * @param multiModuleProjectDirectory The multiModuleProjectDirectory to set.
+   */
+  public void setMultiModuleProjectDirectory(File multiModuleProjectDirectory) {
+    this.multiModuleProjectDirectory = multiModuleProjectDirectory;
   }
 }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/launch/MavenRuntimeClasspathProvider.java
@@ -56,7 +56,7 @@ import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
-import org.eclipse.m2e.core.project.ResolverConfiguration;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.jdt.IClassifierClasspathProvider;
 import org.eclipse.m2e.jdt.IClasspathManager;
 import org.eclipse.m2e.jdt.IMavenClassifierManager;
@@ -313,7 +313,7 @@ public class MavenRuntimeClasspathProvider extends StandardClasspathProvider {
       return;
     }
 
-    ResolverConfiguration configuration = projectFacade.getResolverConfiguration();
+    IProjectConfiguration configuration = projectFacade.getResolverConfiguration();
     if(configuration == null) {
       return;
     }

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
@@ -66,7 +66,7 @@ import org.eclipse.m2e.core.embedder.IMavenExecutableLocation;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
-import org.eclipse.m2e.core.project.ResolverConfiguration;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.internal.launch.LaunchingUtils;
 import org.eclipse.m2e.internal.launch.Messages;
 import org.eclipse.m2e.ui.internal.launch.MavenLaunchMainTab;
@@ -236,7 +236,7 @@ public class ExecutePomAction implements ILaunchShortcut, IExecutableExtension {
     IFile pomFile = basedir.getFile(new Path(IMavenConstants.POM_FILE_NAME));
     IMavenProjectFacade projectFacade = projectManager.create(pomFile, false, new NullProgressMonitor());
     if(projectFacade != null) {
-      ResolverConfiguration configuration = projectFacade.getResolverConfiguration();
+      IProjectConfiguration configuration = projectFacade.getResolverConfiguration();
 
       String selectedProfiles = configuration.getSelectedProfiles();
       if(selectedProfiles != null && selectedProfiles.length() > 0) {

--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Profiles Management
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.1.0.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",

--- a/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
+++ b/org.eclipse.m2e.profiles.core/src/org/eclipse/m2e/profiles/core/internal/management/ProfileManager.java
@@ -58,6 +58,7 @@ import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.NoSuchComponentException;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
@@ -133,7 +134,7 @@ public class ProfileManager implements IProfileManager {
       return Collections.emptyList();
     }
 
-    ResolverConfiguration resolverConfiguration = MavenPlugin.getProjectConfigurationManager()
+    IProjectConfiguration resolverConfiguration = MavenPlugin.getProjectConfigurationManager()
         .getResolverConfiguration(facade.getProject());
 
     List<String> configuredProfiles = toList(resolverConfiguration.getSelectedProfiles());


### PR DESCRIPTION
Currently `ResolverConfiguration` is used for many purpose especially for grouping projects in resolve operations. The problem is that this class itself is modifiable and thus can change without any notice and as it is a public API class we can't easily change this or have alternative implementations. Beside that the javadoc suggest that the naming is not well chosen.

This adds a new interface `IProjectConfiguration` that also takes the new concept of MultiModuleProjectDirectory into account

Next steps would then to get rid of `ResolverConfiguration` wherever possible (e.g. in tests and core)