### PR TITLE
Use a local cache at the project level and just resolve dependencies

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectProcessingTracker.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectProcessingTracker.java
@@ -29,6 +29,8 @@ import org.eclipse.core.resources.IFile;
  */
 public class ProjectProcessingTracker {
 
+  static int MAX_INTERATIONS = Integer.getInteger("m2e.project.refresh.maxiterations", 5);
+
   static final Logger log = LoggerFactory.getLogger(ProjectProcessingTracker.class);
 
   private Set<IFile> processed = new LinkedHashSet<>();
@@ -38,6 +40,8 @@ public class ProjectProcessingTracker {
   private Set<IFile> seed;
 
   private DependencyResolutionContext context;
+
+  private int iterations;
 
   /**
    * @param allProcessedPoms
@@ -60,6 +64,12 @@ public class ProjectProcessingTracker {
       log.debug("Seed is empty.");
       return false;
     }
+    if(iterations >= MAX_INTERATIONS) {
+      log.debug("Max iterations reached!");
+      return false;
+    }
+    iterations++ ;
+    log.debug("iteration = {}", iterations);
     log.debug("seed =      {}", seed);
     log.debug("processed = {}", processed);
     log.debug("changed =   {}", changedWhileRunning);

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
@@ -88,6 +88,10 @@ public class MavenProjectCache {
     if(cacheLine != null) {
       cacheLine.remove(facade.getPomFile());
     }
+    if(facade instanceof MavenProjectFacade) {
+      MavenProjectFacade mavenProjectFacade = (MavenProjectFacade) facade;
+      mavenProjectFacade.clearMavenProjectReference();
+    }
   }
 
   /**


### PR DESCRIPTION
Currently m2e reads each project twice:

1) when refresh is called the maven-project is read without dependencies
2) afterwards when projects are setup with classpath the maven-project is read again now with dependency resolution

**THIS IS JUST A DRAFT** While testing this with the camel-project I just noticed that m2e can be caught in an endless cycle of resolving project dependencies, but still though it would be good to have it here for reference and maybe someone else likes to take a look at it.