### PR TITLE
Incooperate the multi-module-base dir into the project configuration

### DIFF
--- a/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/BinaryProjectPlugin.java
+++ b/org.eclipse.m2e.binaryproject/src/org/eclipse/m2e/binaryproject/internal/BinaryProjectPlugin.java
@@ -70,8 +70,7 @@ public class BinaryProjectPlugin {
     Artifact pomArtifact =
         maven.resolve(groupId, artifactId, version, "pom" /* type */, null /* classifier */, repositories, monitor);
 
-    ResolverConfiguration resolverConfig = new ResolverConfiguration();
-    resolverConfig.setLifecycleMappingId(LIFECYCLE_MAPPING_ID);
+
 
     String projectName = groupId + "_" + artifactId + "_" + version;
 
@@ -105,8 +104,6 @@ public class BinaryProjectPlugin {
     projectNode.put(P_GROUPID, groupId);
     projectNode.put(P_ARTIFACTID, artifactId);
     projectNode.put(P_VERSION, version);
-    // String type = projectNode.get( P_TYPE, "jar" );
-    // String classifier = projectNode.get( P_CLASSIFIER, (String) null );
 
     try {
       projectNode.flush();
@@ -115,7 +112,8 @@ public class BinaryProjectPlugin {
     }
 
     IProjectConfigurationManager configManager = MavenPlugin.getProjectConfigurationManager();
-
+	ResolverConfiguration resolverConfig = new ResolverConfiguration(project);
+	resolverConfig.setLifecycleMappingId(LIFECYCLE_MAPPING_ID);
     configManager.enableMavenNature(project, resolverConfig, monitor);
 
     return project;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/EnableNatureAction.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/EnableNatureAction.java
@@ -129,7 +129,7 @@ public class EnableNatureAction implements IObjectActionDelegate, IExecutableExt
         @Override
         protected IStatus run(IProgressMonitor monitor) {
         try {
-          ResolverConfiguration configuration = new ResolverConfiguration();
+          ResolverConfiguration configuration = new ResolverConfiguration(project);
           configuration.setResolveWorkspaceProjects(workspaceProjects);
           configuration.setSelectedProfiles(""); //$NON-NLS-1$
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
@@ -232,7 +232,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
         // copied from
         // org.eclipse.m2e.core.ui.internal.actions.EnableNatureAction
 
-        final ResolverConfiguration configuration = new ResolverConfiguration();
+        final ResolverConfiguration configuration = new ResolverConfiguration(project);
         configuration.setResolveWorkspaceProjects(true);
         try {
             if (!project.hasNature(IMavenConstants.NATURE_ID)) {
@@ -257,21 +257,6 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
     public boolean shouldBeAnEclipseProject(IContainer container, IProgressMonitor monitor) {
         IFile pomFile = container.getFile(new Path(IMavenConstants.POM_FILE_NAME));
         return pomFile.exists();
-        // debated on m2e-dev:
-        // https://dev.eclipse.org/mhonarc/lists/m2e-dev/msg01852.html
-        // if (!pomFile.exists()) {
-        // return false;
-        // }
-        // try {
-        // Model pomModel =
-        // MavenPlugin.getMavenModelManager().readMavenModel(pomFile);
-        // return !pomModel.getPackaging().equals("pom"); // TODO find symbol
-        // for "pom"
-        // } catch (CoreException ex) {
-        // Activator.log(IStatus.ERROR, "Could not parse pom file " +
-        // pomFile.getLocation(), ex);
-        // return false;
-        // }
     }
 
     @Override

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -100,6 +100,8 @@ public class MavenExecutionContext implements IMavenExecutionContext {
 
   private final IComponentLookup containerLookup;
 
+  private File multiModuleProjectDirectory;
+
   /**
    * Creates a new execution context for the given environment.
    * 
@@ -113,6 +115,12 @@ public class MavenExecutionContext implements IMavenExecutionContext {
    */
   public MavenExecutionContext(IComponentLookup lookup, File baseDir,
       Function<? super MavenExecutionContext, MavenProject> projectSupplier) {
+    this(lookup, baseDir, PlexusContainerManager.computeMultiModuleProjectDirectory(baseDir), projectSupplier);
+  }
+
+  public MavenExecutionContext(IComponentLookup lookup, File baseDir, File multiModuleProjectDirectory,
+      Function<? super MavenExecutionContext, MavenProject> projectSupplier) {
+    this.multiModuleProjectDirectory = multiModuleProjectDirectory;
     this.containerLookup = Objects.requireNonNull(lookup);
     this.basedir = baseDir;
     this.projectSupplier = projectSupplier;
@@ -144,7 +152,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
           containerLookup, MavenPlugin.getMaven().getSettings());
       request.setBaseDirectory(basedir);
     }
-    request.setMultiModuleProjectDirectory(PlexusContainerManager.computeMultiModuleProjectDirectory(basedir));
+    request.setMultiModuleProjectDirectory(multiModuleProjectDirectory);
 
     return request;
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -88,7 +88,6 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.URLConnectionCaches;
-import org.eclipse.m2e.core.internal.embedder.IMavenPlexusContainer;
 import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
 import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
@@ -711,15 +710,13 @@ public class ProjectRegistryManager implements ISaveParticipant {
     Map<IFile, MavenProjectFacade> result = new HashMap<>(poms.size(), 1.f);
     for(Entry<IProjectConfiguration, Collection<IFile>> entry : groupsToImport.entrySet()) {
       IProjectConfiguration resolverConfiguration = entry.getKey();
-      Map<IMavenPlexusContainer, List<IFile>> pomFiles = mapToContainer(entry.getValue());
-      SubMonitor containerMonitor = subMonitor.split(pomFiles.size());
-      containerMonitor.setWorkRemaining(pomFiles.size());
-      for(var containerEntry : pomFiles.entrySet()) {
-        List<IFile> fileList = containerEntry.getValue();
-        IMavenPlexusContainer mavenPlexusContainer = containerEntry.getKey();
-        MavenExecutionContext context = new MavenExecutionContext(mavenPlexusContainer.getComponentLookup(),
-            mavenPlexusContainer.getMavenDirectory().orElse(null), null);
-        configureExecutionRequest(context.getExecutionRequest(), state, fileList.size() == 1 ? fileList.get(0) : null,
+      Collection<IFile> fileList = entry.getValue();
+      File moduleProjectDirectory = resolverConfiguration.getMultiModuleProjectDirectory();
+      MavenExecutionContext context = new MavenExecutionContext(
+          containerManager.getComponentLookup(moduleProjectDirectory), moduleProjectDirectory, moduleProjectDirectory,
+          null);
+      configureExecutionRequest(context.getExecutionRequest(), state,
+          fileList.size() == 1 ? fileList.iterator().next() : null,
             resolverConfiguration);
 
         result.putAll(context.execute((ctx, mon) -> {
@@ -743,32 +740,9 @@ public class ProjectRegistryManager implements ISaveParticipant {
             }
           }
           return facades;
-        }, containerMonitor.split(1)));
-      }
+        }, subMonitor.split(1)));
     }
     return result;
-  }
-
-  /** Converts a collection of resources into a map to their base container. */
-  private <R extends IResource> Map<IMavenPlexusContainer, List<R>> mapToContainer(Collection<R> files) {
-    Map<IMavenPlexusContainer, List<R>> map = new HashMap<>();
-    for(R file : files) {
-      IMavenPlexusContainer plexusContainer = mapToContainer(file);
-      if(plexusContainer != null) {
-        map.computeIfAbsent(plexusContainer, nil -> new ArrayList<>()).add(file);
-      }
-    }
-    return map;
-  }
-
-  /** Returns the base container of the given resource. */
-  private <R extends IResource> IMavenPlexusContainer mapToContainer(R file) {
-    try {
-      return containerManager.aquire(file);
-    } catch(Exception ex) {
-      log.error("can't aquire container for file " + file + " skipping", ex);
-    }
-    return null;
   }
 
   /**
@@ -853,11 +827,11 @@ public class ProjectRegistryManager implements ISaveParticipant {
   private Collection<MavenExecutionResult> readProjectsWithDependencies(IFile pomFile,
       IProjectConfiguration resolverConfiguration, IProgressMonitor monitor) {
     try {
-      IMavenPlexusContainer container = mapToContainer(pomFile);
       Map<File, MavenExecutionResult> resultMap = Map.of();
-      if(container != null) {
-        MavenExecutionContext context = new MavenExecutionContext(container.getComponentLookup(),
-            container.getMavenDirectory().orElse(null), null);
+      File multiModuleProjectDirectory = resolverConfiguration.getMultiModuleProjectDirectory();
+      MavenExecutionContext context = new MavenExecutionContext(
+          containerManager.getComponentLookup(multiModuleProjectDirectory), pomFile.getLocation().toFile(),
+          multiModuleProjectDirectory, null);
         configureExecutionRequest(context.getExecutionRequest(), projectRegistry, pomFile, resolverConfiguration);
         resultMap = context.execute((ctx, mon) -> {
           ProjectBuildingRequest request = context.newProjectBuildingRequest();
@@ -865,7 +839,6 @@ public class ProjectRegistryManager implements ISaveParticipant {
           List<File> pomFiles = Stream.of(toJavaIoFile(pomFile)).filter(Objects::nonNull).toList();
           return IMavenToolbox.of(ctx).readMavenProjects(pomFiles, request);
         }, monitor);
-      }
       return resultMap.values();
     } catch(CoreException ex) {
       return List.of(new DefaultMavenExecutionResult().addException(ex));

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
@@ -12,6 +12,7 @@
 package org.eclipse.m2e.core.project;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -31,12 +32,34 @@ public interface IProjectConfiguration {
 
   String getSelectedProfiles();
 
-  List<String> getActiveProfileList();
+  default List<String> getActiveProfileList() {
+    return parseProfiles(getSelectedProfiles(), true);
+  }
 
-  List<String> getInactiveProfileList();
+  default List<String> getInactiveProfileList() {
+    return parseProfiles(getSelectedProfiles(), false);
+  }
 
   String getLifecycleMappingId();
 
   File getMultiModuleProjectDirectory();
+
+  private static List<String> parseProfiles(String profilesAsText, boolean status) {
+    List<String> profiles;
+    if(profilesAsText != null && profilesAsText.trim().length() > 0) {
+      String[] profilesArray = profilesAsText.split("[,\\s\\|]");
+      profiles = new ArrayList<>(profilesArray.length);
+      for(String profile : profilesArray) {
+        boolean isActive = !profile.startsWith("!");
+        if(status == isActive) {
+          profile = (isActive) ? profile : profile.substring(1);
+          profiles.add(profile);
+        }
+      }
+    } else {
+      profiles = new ArrayList<>(0);
+    }
+    return profiles;
+  }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
@@ -16,14 +16,16 @@ package org.eclipse.m2e.core.project;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
+
+import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 
 
 /**
@@ -46,6 +48,11 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
   private File multiModuleProjectDirectory;
 
   public ResolverConfiguration() {
+  }
+
+  public ResolverConfiguration(IProject project) {
+    setMultiModuleProjectDirectory(
+        PlexusContainerManager.computeMultiModuleProjectDirectory(project.getLocation().toFile()));
   }
 
   /**
@@ -109,22 +116,6 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
     return this.selectedProfiles;
   }
 
-  /* (non-Javadoc)
-   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getActiveProfileList()
-   */
-  @Override
-  public List<String> getActiveProfileList() {
-    return parseProfiles(selectedProfiles, true);
-  }
-
-  /* (non-Javadoc)
-   * @see org.eclipse.m2e.core.project.IProjectConfiguration#getInactiveProfileList()
-   */
-  @Override
-  public List<String> getInactiveProfileList() {
-    return parseProfiles(selectedProfiles, false);
-  }
-
   public void setResolveWorkspaceProjects(boolean resolveWorkspaceProjects) {
     this.resolveWorkspaceProjects = resolveWorkspaceProjects;
   }
@@ -133,23 +124,6 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
     this.selectedProfiles = profiles;
   }
 
-  private static List<String> parseProfiles(String profilesAsText, boolean status) {
-    List<String> profiles;
-    if(profilesAsText != null && profilesAsText.trim().length() > 0) {
-      String[] profilesArray = profilesAsText.split("[,\\s\\|]");
-      profiles = new ArrayList<>(profilesArray.length);
-      for(String profile : profilesArray) {
-        boolean isActive = !profile.startsWith("!");
-        if(status == isActive) {
-          profile = (isActive) ? profile : profile.substring(1);
-          profiles.add(profile);
-        }
-      }
-    } else {
-      profiles = new ArrayList<>(0);
-    }
-    return profiles;
-  }
 
   /* (non-Javadoc)
    * @see org.eclipse.m2e.core.project.IProjectConfiguration#getLifecycleMappingId()


### PR DESCRIPTION
Currently we do not consider the mmbd in the project configuration that is used to group projects "with the same config" what requires some special considerations.

This changes the behavior in a way that the mmpb is part of the persistent configuration