### PR TITLE
[PDE-Connector] Derive .classpath "lib" entries from Bundle-Classpath

### DIFF
--- a/org.eclipse.m2e.pde.connector.tests/projects/bnd/pom.xml
+++ b/org.eclipse.m2e.pde.connector.tests/projects/bnd/pom.xml
@@ -4,7 +4,6 @@
 	<artifactId>bnd</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -12,7 +11,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.3</version>
+			<version>1.7.36</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -23,6 +22,28 @@
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<overWriteReleases>true</overWriteReleases>
+					<includeScope>runtime</includeScope> <!-- only include runtime and compile time dependencies, not test or provided! -->
+				</configuration>
+				<executions>
+					<execution>
+						<?m2e execute onIncremental?>
+						<id>fetch-dependency-jars</id>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<phase>generate-resources</phase>
+						<configuration>
+							<outputDirectory>${project.basedir}/target/jars</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -44,8 +65,9 @@
 						<configuration>
 							<bnd>
 								<![CDATA[
-									Bundle-SymbolicName: ${groupId}.${artifactId}
-									Export-Package: bnd
+									-includeresource: -target/jars/;lib:=true
+									Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+									Export-Package: bnd, org.slf4j.api
 								]]>
 							</bnd>
 						</configuration>

--- a/org.eclipse.m2e.pde.connector.tests/projects/felix/pom.xml
+++ b/org.eclipse.m2e.pde.connector.tests/projects/felix/pom.xml
@@ -4,7 +4,6 @@
 	<artifactId>felix</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -47,7 +46,7 @@
 						</goals>
 						<configuration>
 							<instructions>
-								<Bundle-SymbolicName>${groupId}.${artifactId}</Bundle-SymbolicName>
+								<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 								<Export-Package>felix</Export-Package>
 							</instructions>
 							<niceManifest>true</niceManifest>

--- a/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/BNDConnectorTest.java
+++ b/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/BNDConnectorTest.java
@@ -16,11 +16,17 @@ package org.eclipse.m2e.pde.connector.tests;
 import static org.eclipse.m2e.pde.connector.tests.TychoConnectorTest.PLUGIN_NATURES;
 import static org.eclipse.m2e.pde.connector.tests.TychoConnectorTest.assertErrorFreeProjectWithBuildersAndNatures;
 import static org.eclipse.m2e.pde.connector.tests.TychoConnectorTest.assertPluginProjectExists;
+import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
@@ -37,6 +43,12 @@ public class BNDConnectorTest extends AbstractMavenProjectTestCase {
 		assertErrorFreeProjectWithBuildersAndNatures(project, PLUGIN_NATURES,
 				Set.of(JavaCore.BUILDER_ID, IMavenConstants.BUILDER_ID));
 		assertPluginProjectExists(project, "m2e.pde.connector.tests.bnd");
+
+		IPath expectedJavaxLibPath = Path.fromOSString("/bnd/target/m2e-bundleClassPath/slf4j-api-1.7.36.jar");
+		List<IClasspathEntry> javaxLibEntries = Arrays.stream(JavaCore.create(project).getRawClasspath())
+				.filter(e -> e.getEntryKind() == IClasspathEntry.CPE_LIBRARY)
+				.filter(e -> e.getPath().equals(expectedJavaxLibPath)).toList();
+		assertEquals("Embedded javax.inject library classpath entry is missing", 1, javaxLibEntries.size());
 	}
 
 }

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEProjectHelper.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEProjectHelper.java
@@ -137,7 +137,9 @@ public class PDEProjectHelper {
 			model.load();
 			monitor.done();
 			IBuildEntry entry = model.getBuild().getEntry("output." + ".");
-			return org.eclipse.core.runtime.Path.forPosix(entry.getTokens()[0]);
+			if (entry != null) {
+				return org.eclipse.core.runtime.Path.forPosix(entry.getTokens()[0]);
+			}
 		}
 		return null;
 	}
@@ -146,7 +148,7 @@ public class PDEProjectHelper {
 		AbstractProjectConfigurator.addNature(project, PDE_PLUGIN_NATURE, monitor);
 		IProjectDescription description = project.getDescription();
 		Stream<ICommand> builders = Arrays.stream(description.getBuildSpec())
-				.filter(b -> !b.getBuilderName().startsWith("org.eclipse.pde"));
+				.filter(b -> !b.getBuilderName().startsWith("org.eclipse.pde."));
 		description.setBuildSpec(builders.toArray(ICommand[]::new));
 		project.setDescription(description, monitor);
 


### PR DESCRIPTION
This requires
- https://github.com/eclipse-m2e/m2e-core/pull/1067 (currently also included).

and allows to remove the profile from the `o.e.m2e.maven.runtime/pom.xml` that is responsible to generate the .classpath file for the sub-project within the Eclipse+M2E-IDE, in:
- https://github.com/eclipse-m2e/m2e-core/pull/466

On the long run this could probably be implemented faster by performing the BND-processing directly as part of the PDE-Connector's BuildParticipant execution instead of just executing the mojo. This would allow to skip the copying to to the `project.build.outputDirectory` and instead reference the original artifacts and to only write the Manifest.MF. This would also allow to support the `bnd-maven-plugin`'s jar goal nicely, because that only generates the jar, that we would have to extract in order to have a Manifest (and resources available).

However this is for the moment sufficient for m2e's demands to complete https://github.com/eclipse-m2e/m2e-core/pull/466 withouth too many hacks. Once we can use the bnd:jar goal for the maven-runtime (which is as soon as bnd 6.4) is out, the mentioned enhancements can be done.