### PR TITLE
Execute Maven plug-ins to generate sources required for M2E compilation

### DIFF
--- a/org.eclipse.m2e.core/.project
+++ b/org.eclipse.m2e.core/.project
@@ -21,12 +21,18 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.pde.ds.core.builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2008, 2022 Sonatype, Inc. and others
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License 2.0
+	which accompanies this distribution, and is available at
+	https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.m2e</groupId>
+		<artifactId>m2e-core</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.m2e.core</artifactId>
+	<version>2.0.4-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<name>Maven Integration for Eclipse Core Plug-in</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.modello</groupId>
+				<artifactId>modello-maven-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<?m2e execute?>
+						<id>generate-modello-java-sources</id>
+						<goals>
+							<goal>java</goal>
+							<goal>xpp3-reader</goal>
+							<goal>xpp3-writer</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.basedir}/src-gen</outputDirectory>
+							<version>1.0.0</version>
+							<useJava5>true</useJava5>
+							<models>
+								<model>mdo/lifecycle-mapping-metadata-model.xml</model>
+							</models>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -32,6 +32,7 @@
 				<artifactId>maven-dependency-plugin</artifactId>
 				<executions>
 					<execution>
+						<?m2e execute onIncremental?>
 						<id>get-lemminx-maven</id>
 						<phase>generate-resources</phase>
 						<goals>
@@ -44,7 +45,7 @@
 									<artifactId>lemminx-maven</artifactId>
 									<!-- Don't release m2e if this points to SNAPSHOT -->
 									<version>0.7.0</version>
-									<outputDirectory>${basedir}</outputDirectory>
+									<outputDirectory>${project.basedir}</outputDirectory>
 									<destFileName>lemminx-maven.jar</destFileName>
 									<!-- Edit forceQualifierUpdate.txt to force usage of newer SNAPSHOT, otherwise
 										Git timestamp qualifier + Baseline replacement will ignore the change -->

--- a/pom.xml
+++ b/pom.xml
@@ -364,41 +364,5 @@
 				<module>m2e-core-tests</module>
 			</modules>
 		</profile>
-		<profile>
-			<id>modello-code-generation</id>
-			<activation>
-				<!-- Only activated for org.eclipse.m2e.core project-->
-				<file>
-					<exists>mdo/lifecycle-mapping-metadata-model.xml</exists>
-				</file>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.modello</groupId>
-						<artifactId>modello-maven-plugin</artifactId>
-						<version>1.5</version>
-						<executions>
-							<execution>
-								<id>standard</id>
-								<goals>
-									<goal>java</goal>
-									<goal>xpp3-reader</goal>
-									<goal>xpp3-writer</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>${project.basedir}/src-gen</outputDirectory>
-									<version>1.0.0</version>
-									<useJava5>true</useJava5>
-									<models>
-										<model>mdo/lifecycle-mapping-metadata-model.xml</model>
-									</models>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
The connectors for the 'maven-dependency-plugin' and the 'modello-maven-plugin' are currently broken because they are not yet adapted to M2E 2.0. Threrefore command m2e explicitly to execute those goals.

In order to make this work in the IDE the o.e.m2e.core/pom.xml had to be re-created.

@merks this should fix your problem from https://github.com/eclipse-m2e/m2e-core/discussions/1071.
You can try it by deleting the content of the src-gen folder and performing a workspace clean+full build afterwards.