### PR TITLE
Release M2E 2.1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,20 @@
 
 ## 2.1.0
 
-* 📅 Release Date: _expected_ December 2022
+* 📅 Release Date: November 24th 2022
 * All changes: https://github.com/eclipse-m2e/m2e-core/compare/2.0.2...2.1.0
+
+### Automatic configuration updates of Maven projects enabled by default
+
+The previously experimental feature of M2E to update Maven projects automatically on configuration changes matured and is now enabled by default.
+
+### Performance and memory consumption improvements
+
+For large projects the build performance has been improved and the memory consumption has been reduced.
+
+### Improved connectors for bnd-maven-plugin and maven-bundle-plugin
+
+The connector for the `bnd-maven-plugin` and `maven-bundle-plugin`, which is included into M2E, has been improved to consider the jars specified on the `Bundle-Classpath` of the generated MANIFEST.MF, when updating the Plugins JDT `.classpath`.
 
 ### Console support for polyglot Maven projects and projects without Maven nature
 


### PR DESCRIPTION
The value of `<M2E_RELEASE>` is `2.1.0`.
The value of `<M2E_PREVIOUS_RELEASE>` is `2.0.5` and the value of `<M2E_RELEASE_WO_DOTS>` is `205`

## Release process steps:
- [ ] Add/finalize and submit an entry in the `RELEASE_NOTES.md` dedicated to this release (done with this PR).
- [x] Run `m2e-promote-snapshots-to-release` M2E Jenkins job with parameter `releaseVersion` value `<M2E_RELEASE>`
- [x] Update M2E's contribution to the Eclipse Simultaneous Release:
https://git.eclipse.org/c/simrel/org.eclipse.simrel.build.git/tree/m2e.aggrcon, usually it is sufficient to update the repo URL and description.
- [ ] Create and push git tag `<M2E_RELEASE>` on the release commit (usually this PR's commit).
- [ ] `Create a new Release` at the M2E project website: https://projects.eclipse.org/projects/technology.m2e
Name: <M2E_RELEASE>, Release date: default is today, which is usually fine.
In the `Review Documentation` section add the `New & Notworthy URL`:
https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS>
- [ ] Create a new GitHub release, based on the just pushed `<M2E_RELEASE>-tag
- [ ] Send the following announcement to the [M2E-dev mailing-list](https://accounts.eclipse.org/mailing-list/m2e-dev):
```
M2E <M2E_RELEASE> is released!

📥 P2 repository is available at https://download.eclipse.org/technology/m2e/releases/<M2E_RELEASE>
(and it also mirrored at https://download.eclipse.org/technology/m2e/releases/latest/ and referenced by Marketplace Entry https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide until a newer release is promoted)
🏷️ Git tag is <M2E_RELEASE>: https://github.com/eclipse-m2e/m2e-core/tree/<M2E_RELEASE>
📝 Release notes are available in https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS> ; full changelog is https://github.com/eclipse-m2e/m2e-core/compare/<M2E_PREVIOUS_RELEASE>...<M2E_RELEASE>
👔 PMI Release entry is at https://projects.eclipse.org/projects/technology.m2e/releases/<M2E_RELEASE>
🧑‍🤝‍🧑 M2E <M2E_RELEASE> will be part of Eclipse SimRel 2022-09
🙏  Special thanks to to everybody who contributed to this release!

Greetings
```
