### PR TITLE
Sign IUs in a later build phase

### DIFF
--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -117,6 +117,7 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
+								<phase>pre-integration-test</phase>
 							</execution>
 						</executions>
 					</plugin>

--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="2.0.1.qualifier"
+      version="2.0.2.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.lemminx.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.lemminx.feature/forceQualifierUpdate.txt
@@ -1,3 +1,2 @@
 # To force a version qualifier update add the bug here
-[PDE] update biz.aQute.bndlib and -util to version 6.3.1 - https://github.com/eclipse-m2e/m2e-core/pull/772
 Ensure Features are jar-signed - https://github.com/eclipse-m2e/m2e-core/issues/1097

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.1.1.qualifier"
+      version="2.1.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/1097

The (prepare-) package phases are unfortunately really full already and IIRC the `feature-source` goal is sensitive in regard to its execution in relation to the `p2-metadata` goal.
An alternative could be to bind the `feature-source` goal to the `prepare-package` phase.
However the important part is that the eclipse-jar-signer runs after the sources jar has been created.