### PR TITLE
[Maven-Runtime] fix computation of build-qualifier and commitId

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.archetype.common/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-	<version>3.2.101-SNAPSHOT</version>
+	<version>3.2.102-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>M2E Maven Archetype Common</name>

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-	<version>3.8.603-SNAPSHOT</version>
+	<version>3.8.604-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>M2E Embedded Maven Runtime (includes Incubating components)</name>

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -208,6 +208,7 @@
 									<arg value="-n 1" />
 									<arg value="--pretty=format:%cd" />
 									<arg value="--date=format:${buildqualifier.format}" />
+									<arg value="." />
 								</exec>
 								<loadfile property="buildQualifier" srcFile="${project.build.directory}/git/buildQualifier" />
 								<delete file="${project.build.directory}/git/buildQualifier" />
@@ -222,6 +223,7 @@
 									<arg value="log" />
 									<arg value="-n 1" />
 									<arg value="--pretty=format:%H" />
+									<arg value="." />
 								</exec>
 								<loadfile property="gitCommitId" srcFile="${project.build.directory}/git/commitId" />
 								<delete file="${project.build.directory}/git/commitId" />

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.1.1.qualifier"
+      version="2.1.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.1.1.qualifier"
+      version="2.1.2.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,12 @@
 		<dependency>
 			<groupId>org.eclipse.m2e</groupId>
 			<artifactId>org.eclipse.m2e.archetype.common</artifactId>
-			<version>3.2.101-SNAPSHOT</version>
+			<version>3.2.102-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.m2e</groupId>
 			<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-			<version>3.8.603-SNAPSHOT</version>
+			<version>3.8.604-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Both values were falsely be based on the latest commit to the current branch and not on the last commit touching the corresponding project.

This PR fixes that and bumps the service version of the `m2e.maven.runtime` and `m2e.archetype.common`. This is sub-optimal because users will get another update of those components although nothing really changed, but it is still better than potentially flawed installations.