### PR TITLE
Handle config of projects with m-enforcer-p without 'requireJavaVersion'

### DIFF
--- a/org.eclipse.m2e.jdt.tests/projects/enforcerSettingsWithoutRequiredJavaVersion/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/enforcerSettingsWithoutRequiredJavaVersion/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
+					<configuration>
+						<source>1.8</source>
+						<target>1.8</target>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+						<configuration>
+							<rules>
+								<requireSnapshotVersion>
+									<message>No Releases Allowed!</message>
+								</requireSnapshotVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationFromEnforcerTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationFromEnforcerTest.java
@@ -27,11 +27,11 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.junit.Test;
 
-public class JavaConfigurationFromEnforcer extends AbstractMavenProjectTestCase {
+public class JavaConfigurationFromEnforcerTest extends AbstractMavenProjectTestCase {
 	private static final String JRE_CONTAINER_PREFIX = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/";
 
 	@Test
-	public void testEnforcerVersion() throws Exception {
+	public void testEnforcer_Version() throws Exception {
 		IProject project = importProject("projects/enforcerSettingsWithVersion/pom.xml");
 		waitForJobsToComplete();
 		IJavaProject jproject = JavaCore.create(project);
@@ -41,7 +41,7 @@ public class JavaConfigurationFromEnforcer extends AbstractMavenProjectTestCase 
 	}
 
 	@Test
-	public void testEnforcerVersionRange() throws Exception {
+	public void testEnforcer_VersionRange() throws Exception {
 		IProject project = importProject("projects/enforcerSettingsWithVersionRange/pom.xml");
 		waitForJobsToComplete();
 		IJavaProject jproject = JavaCore.create(project);
@@ -49,6 +49,17 @@ public class JavaConfigurationFromEnforcer extends AbstractMavenProjectTestCase 
 		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, false));
 		assertEquals(List.of("JavaSE-11"), getJREContainerVMType(jproject));
 	}
+
+	@Test
+	public void testEnforcer_NoVersionRange() throws Exception {
+		IProject project = importProject("projects/enforcerSettingsWithoutRequiredJavaVersion/pom.xml");
+		waitForJobsToComplete();
+		IJavaProject jproject = JavaCore.create(project);
+		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_SOURCE, false));
+		assertEquals("1.8", jproject.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, false));
+		assertEquals(List.of("JavaSE-1.8"), getJREContainerVMType(jproject));
+	}
+
 
 	private static List<String> getJREContainerVMType(IJavaProject jproject) throws JavaModelException {
 		return Arrays.stream(jproject.getRawClasspath())

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.0.3.qualifier
+Bundle-Version: 2.0.4.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -862,6 +862,9 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     // https://maven.apache.org/enforcer/enforcer-rules/requireJavaVersion.html
     String version = ((MavenImpl) maven).getMojoParameterValue(mavenProject, mojoExecution,
         List.of("rules", "requireJavaVersion", "version"), String.class, monitor);
+    if(version == null) {
+      return null;
+    }
     return getMinimumJavaBuildEnvironmentId(version);
   }
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/1103

And rename JavaConfigurationFromEnforcer to
JavaConfigurationFromEnforcerTest to enable it in the CI.