### PR TITLE
Fix build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 target/
 bin/
-src-gen/
 .DS_Store
 .polyglot*
 .tycho-consumer-pom.xml

--- a/org.eclipse.m2e.core/.classpath
+++ b/org.eclipse.m2e.core/.classpath
@@ -7,6 +7,6 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry excluding=".gitignore" kind="src" path="src-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.0.5.qualifier
+Bundle-Version: 2.0.6.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core</artifactId>
-	<version>2.0.5-SNAPSHOT</version>
+	<version>2.0.6-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>

--- a/org.eclipse.m2e.core/src-gen/.gitignore
+++ b/org.eclipse.m2e.core/src-gen/.gitignore
@@ -1,0 +1,4 @@
+# ignore all files in this directory
+*
+# except for this file itself
+!.gitignore

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.1.2.qualifier"
+      version="2.1.3.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.1.2.qualifier"
+      version="2.1.3.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
On first checkout the project has build path errors because the generated source path folder doesn't exist. Therefore please always check in all generated source folders with a gitignore, and then exclude the gitignore in the classpath settings.