### PR TITLE
[Build] Perform p2-baseline-replace for maven-runtime too

### DIFF
--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -119,6 +119,16 @@
 						</dependency>
 					</dependencies>
 				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<supportedProjectTypes>
+							<value>jar</value>
+						</supportedProjectTypes>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -338,26 +348,6 @@
 							<goal>generate-pde-source-header</goal>
 						</goals>
 						<phase>package</phase>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<?m2e ignore?>
-						<id>attached-p2-metadata</id> <!-- Required to make this project's sources discoverable for the sources-features -->
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-						<phase>package</phase>
-						<configuration>
-							<supportedProjectTypes>
-								<value>jar</value>
-							</supportedProjectTypes>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -71,6 +71,61 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>plugin-source</id>
+						<goals>
+							<goal>plugin-source</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>feature-source</id>
+						<goals>
+							<goal>feature-source</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<plugin id="org.eclipse.m2e.workspace.cli" />
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>p2-metadata</id>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+						<phase>package</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<defaultP2Metadata>false</defaultP2Metadata>
+					<baselineRepositories>
+						<repository>
+							<url>https://download.eclipse.org/technology/m2e/snapshots/latest/</url>
+						</repository>
+					</baselineRepositories>
+					<baselineReplace>all</baselineReplace>
+					<baselineMode>${tycho.p2.baselineMode}</baselineMode>
+					<writeComparatorDelta>true</writeComparatorDelta>
+					<ignoredPatterns>
+						<pattern>META-INF/ECLIPSE_.RSA</pattern>
+						<pattern>META-INF/ECLIPSE_.SF</pattern>
+						<pattern>**/org/fusesource/jansi/internal/native/Mac/*/libjansi.jnilib</pattern>
+						<pattern>org/eclipse/m2e/core/internal/lifecyclemapping/model/**/*.java</pattern>
+					</ignoredPatterns>
+				</configuration>
+			</plugin>
 		</plugins>
 
 		<pluginManagement>
@@ -117,7 +172,6 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
-								<phase>pre-integration-test</phase>
 							</execution>
 						</executions>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -174,26 +174,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<append>true</append>
-					<includes>
-						<include>org.eclipse.m2e*</include>
-						<include>org.apache.maven*</include>
-						<include>org.eclipse.aether*</include>
-					</includes>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
 				<version>${tycho-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,61 +149,6 @@
 					</environments>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>plugin-source</id>
-						<goals>
-							<goal>plugin-source</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<excludes>
-								<plugin id="org.eclipse.m2e.workspace.cli" />
-							</excludes>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>p2-metadata</id>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-						<phase>package</phase>
-					</execution>
-				</executions>
-				<configuration>
-					<defaultP2Metadata>false</defaultP2Metadata>
-					<baselineRepositories>
-						<repository>
-							<url>https://download.eclipse.org/technology/m2e/snapshots/latest/</url>
-						</repository>
-					</baselineRepositories>
-					<baselineReplace>common</baselineReplace>
-					<baselineMode>${tycho.p2.baselineMode}</baselineMode>
-					<writeComparatorDelta>true</writeComparatorDelta>
-					<ignoredPatterns>
-						<pattern>META-INF/ECLIPSE_.RSA</pattern>
-						<pattern>META-INF/ECLIPSE_.SF</pattern>
-						<pattern>**/org/fusesource/jansi/internal/native/Mac/*/libjansi.jnilib</pattern>
-						<pattern>org/eclipse/m2e/core/internal/lifecyclemapping/model/**/*.java</pattern>
-					</ignoredPatterns>
-				</configuration>
-			</plugin>
 		</plugins>
 
 		<pluginManagement>


### PR DESCRIPTION
and use `baselineReplace=all` instead of `common`. Common was only used when the source bundles for the maven-runtime were newline introduced to not have them removed. But since that is established now `all` can be used again.