### PR TITLE
Enable the Tycho Baselineplugin for m2e

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build m2e-core
       uses: GabrielBB/xvfb-action@v1
       with:
-       run: mvn clean verify -B -V -Pits -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
+       run: mvn clean verify -B -V -e -U -Pits -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
       with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
 			steps {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh 'mvn clean verify -B -V \
+					sh 'mvn clean verify -B -V -e -U \
 						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
 						-Peclipse-sign,its -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -Dgpg.keyname="011C526F29B2CE79"'
 				}}

--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -116,6 +116,8 @@
 								<ignore>META-INF/maven/*/pom.xml</ignore>
 								<ignore>META-INF/maven/*/pom.properties</ignore>
 								<ignore>OSGI-INF/*</ignore>
+								<ignore>META-INF/ECLIPSE_.RSA</ignore>                                        │
+								<ignore>META-INF/ECLIPSE_.SF</ignore>
 								<ignore>jars/*.jar</ignore>
 								<ignore>Eclipse-SourceReferences</ignore>
 							</ignores>

--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -8,8 +8,7 @@
 
 	SPDX-License-Identifier: EPL-2.0
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.eclipse.m2e</groupId>
@@ -91,6 +90,36 @@
 							<excludes>
 								<plugin id="org.eclipse.m2e.workspace.cli" />
 							</excludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-baseline-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>baseline-check</id>
+						<goals>
+							<goal>verify</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<baselines>
+								<repository>
+									<id>baseline-repo</id>
+									<url>https://download.eclipse.org/technology/m2e/releases/latest/</url>
+								</repository>
+							</baselines>
+							<ignores>
+								<ignore>META-INF/maven/*/pom.xml</ignore>
+								<ignore>META-INF/maven/*/pom.properties</ignore>
+								<ignore>OSGI-INF/*</ignore>
+								<ignore>jars/*.jar</ignore>
+								<ignore>Eclipse-SourceReferences</ignore>
+							</ignores>
+							<extensions>true</extensions>
 						</configuration>
 					</execution>
 				</executions>

--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="2.0.2.qualifier"
+      version="2.0.3.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.1.3.qualifier"
+      version="2.2.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.1.3.qualifier"
+      version="2.2.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This enables the new [tycho-baseline-plugin](https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#new-tycho-baseline-plugin) for m2e to see how/if this works out and where Tycho must improve and test it on a real world example.