### PR TITLE
Do not wrap source bundles

### DIFF
--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 2.0.300.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
- org.eclipse.pde.core;bundle-version="3.14.0",
+ org.eclipse.pde.core;bundle-version="3.16.100",
  org.eclipse.equinox.frameworkadmin;bundle-version="2.1.400",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich
+ * Copyright (c) 2020, 2022 Christoph Läubrich
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,86 +13,19 @@
 package org.eclipse.m2e.pde.target;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.util.Enumeration;
-import java.util.Objects;
-import java.util.jar.Attributes;
-import java.util.jar.Attributes.Name;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
-import java.util.jar.Manifest;
-import java.util.zip.ZipEntry;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
-import org.eclipse.m2e.pde.target.CacheManager.CacheConsumer;
 import org.eclipse.pde.core.target.TargetBundle;
-import org.osgi.framework.Constants;
 
 public class MavenSourceBundle extends TargetBundle {
 
-	@SuppressWarnings("restriction")
-	public static final String ECLIPSE_SOURCE_BUNDLE_HEADER = org.eclipse.pde.internal.core.ICoreConstants.ECLIPSE_SOURCE_BUNDLE;
-
-	public MavenSourceBundle(BundleInfo sourceTarget, Artifact artifact, CacheManager cacheManager) throws Exception {
+	public MavenSourceBundle(BundleInfo sourceTarget, Artifact artifact) throws Exception {
 		this.fSourceTarget = sourceTarget;
 		fInfo.setSymbolicName(sourceTarget.getSymbolicName() + ".source");
 		fInfo.setVersion(sourceTarget.getVersion());
-		Manifest manifest;
 		File sourceFile = artifact.getFile();
-		try (JarFile jar = new JarFile(sourceFile)) {
-			manifest = Objects.requireNonNullElseGet(jar.getManifest(), Manifest::new);
-		}
-		if (isValidSourceManifest(manifest)) {
-			fInfo.setLocation(sourceFile.toURI());
-		} else {
-			File generatedSourceBundle = cacheManager.accessArtifactFile(artifact, new CacheConsumer<File>() {
-
-				@Override
-				public File consume(File file) throws Exception {
-					if (CacheManager.isOutdated(file, sourceFile)) {
-						Attributes attr = manifest.getMainAttributes();
-						if (attr.isEmpty()) {
-							attr.put(Name.MANIFEST_VERSION, "1.0");
-						}
-						attr.putValue(ECLIPSE_SOURCE_BUNDLE_HEADER, sourceTarget.getSymbolicName() + ";version=\""
-								+ sourceTarget.getVersion() + "\";roots:=\".\"");
-						attr.putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
-						attr.putValue(Constants.BUNDLE_NAME, "Source Bundle for " + sourceTarget.getSymbolicName()
-								+ ":" + sourceTarget.getVersion());
-						attr.putValue(Constants.BUNDLE_SYMBOLICNAME, fInfo.getSymbolicName());
-						attr.putValue(Constants.BUNDLE_VERSION, fInfo.getVersion());
-						try (JarOutputStream stream = new JarOutputStream(new FileOutputStream(file), manifest)) {
-							try (JarFile jar = new JarFile(sourceFile)) {
-								Enumeration<JarEntry> entries = jar.entries();
-								while (entries.hasMoreElements()) {
-									JarEntry jarEntry = entries.nextElement();
-									if (JarFile.MANIFEST_NAME.equals(jarEntry.getName())) {
-										continue;
-									}
-									try (InputStream is = jar.getInputStream(jarEntry)) {
-										stream.putNextEntry(new ZipEntry(jarEntry.getName()));
-										is.transferTo(stream);
-										stream.closeEntry();
-									}
-								}
-							}
-						}
-					}
-					return file;
-				}
-			});
-			fInfo.setLocation(generatedSourceBundle.toURI());
-		}
-	}
-
-	private static boolean isValidSourceManifest(Manifest manifest) {
-		if (manifest != null) {
-			return manifest.getMainAttributes().getValue(ECLIPSE_SOURCE_BUNDLE_HEADER) != null;
-		}
-		return false;
+		fInfo.setLocation(sourceFile.toURI());
 	}
 
 }

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -374,8 +374,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 					Artifact resolve = RepositoryUtils.toArtifact(maven.resolve(artifact.getGroupId(),
 							artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension(), "sources",
 							repositories, new NullProgressMonitor()));
-					MavenSourceBundle sourceBundle = new MavenSourceBundle(bundle.getBundleInfo(), resolve,
-							cacheManager);
+					MavenSourceBundle sourceBundle = new MavenSourceBundle(bundle.getBundleInfo(), resolve);
 					targetBundles.bundles.put(resolve, sourceBundle);
 					targetBundles.sourceBundles.put(artifact, sourceBundle);
 				} catch (Exception e) {


### PR DESCRIPTION
Currently m2e wraps source into new artifacts having performance and space implications and can be confusing because users expect the file to be on a different location.

Due to the recent changes in PDE this is no longer required an we can remove this workaround.

See https://github.com/eclipse-pde/eclipse.pde/pull/425

This will require a new PDE release ...