### PR TITLE
Show lifecycle mappings on open

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
@@ -464,7 +464,7 @@ public class LifecycleMappingsViewer {
         sources.add("uninteresting"); //$NON-NLS-1$
       }
     }
-    return sources.stream().collect(Collectors.joining(", ")); //$NON-NLS-1$
+    return String.join(", ", sources);
   }
 
   private String getSourceLabel(Bundle bundle, boolean detailed) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.osgi.framework.Bundle;
 
@@ -428,22 +429,14 @@ public class LifecycleMappingsViewer {
   }
 
   String toString(MojoExecutionKey execution, List<IPluginExecutionMetadata> mappings) {
-    StringBuilder sb = new StringBuilder();
     if(mappings != null && !mappings.isEmpty()) {
-      for(IPluginExecutionMetadata mapping : mappings) {
-        if(sb.length() > 0) {
-          sb.append(',');
-        }
-        sb.append(mapping.getAction().toString());
-      }
-    } else {
-      if(LifecycleMappingFactory.isInterestingPhase(execution.lifecyclePhase())) {
-        sb.append(PluginExecutionAction.error.toString());
-      } else {
-        sb.append(PluginExecutionAction.ignore.toString());
-      }
+      return mappings.stream().map(IPluginExecutionMetadata::getAction).map(PluginExecutionAction::toString)
+          .collect(Collectors.joining(", ")); //$NON-NLS-1$
     }
-    return sb.toString();
+    if(LifecycleMappingFactory.isInterestingPhase(execution.lifecyclePhase())) {
+      return PluginExecutionAction.error.toString();
+    }
+    return PluginExecutionAction.ignore.toString();
   }
 
   String getSourcelabel(MojoExecutionKey execution, List<IPluginExecutionMetadata> mappings, boolean detailed) {
@@ -471,14 +464,7 @@ public class LifecycleMappingsViewer {
         sources.add("uninteresting"); //$NON-NLS-1$
       }
     }
-    StringBuilder sb = new StringBuilder();
-    for(String source : sources) {
-      if(sb.length() > 0) {
-        sb.append(',');
-      }
-      sb.append(source);
-    }
-    return sb.toString();
+    return sources.stream().collect(Collectors.joining(", ")); //$NON-NLS-1$
   }
 
   private String getSourceLabel(Bundle bundle, boolean detailed) {

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenLifecycleMappingsView.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/views/MavenLifecycleMappingsView.java
@@ -44,6 +44,8 @@ public class MavenLifecycleMappingsView extends ViewPart {
     mappingsViewer = new LifecycleMappingsViewer();
     this.composite = mappingsViewer.createContents(parent);
 
+    // react to current selection when opening the view
+    handleSelectionChanged(getSite().getPage().getSelection());
   }
 
   /* (non-Javadoc)
@@ -56,18 +58,7 @@ public class MavenLifecycleMappingsView extends ViewPart {
 
       @Override
       public void selectionChanged(IWorkbenchPart part, ISelection selection) {
-        Object element;
-        if(selection instanceof IStructuredSelection structuredSelection) {
-          element = structuredSelection.getFirstElement();
-        } else {
-          element = null;
-        }
-        IResource resource = Adapters.adapt(element, IResource.class);
-        if(resource != null) {
-          mappingsViewer.setTarget(resource.getProject());
-        } else {
-          mappingsViewer.setTarget(null);
-        }
+        handleSelectionChanged(selection);
       }
     });
   }
@@ -78,6 +69,21 @@ public class MavenLifecycleMappingsView extends ViewPart {
   @Override
   public void setFocus() {
     composite.setFocus();
+  }
+
+  private void handleSelectionChanged(ISelection selection) {
+    Object element;
+    if(selection instanceof IStructuredSelection structuredSelection) {
+      element = structuredSelection.getFirstElement();
+    } else {
+      element = null;
+    }
+    IResource resource = Adapters.adapt(element, IResource.class);
+    if(resource != null) {
+      mappingsViewer.setTarget(resource.getProject());
+    } else {
+      mappingsViewer.setTarget(null);
+    }
   }
 
 }


### PR DESCRIPTION
Instead of waiting for a first selection use the current selection when opening the view.

Also use more readable String joining with comma and blank for the entries.