### PR TITLE
Fix wrong realm used when executing mojos

### DIFF
--- a/org.eclipse.m2e.core.tests/resources/projects/resourcesWithMVNFolder/pom.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/resourcesWithMVNFolder/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo</groupId>
+	<artifactId>bar</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
+					<configuration>
+						<release>17</release>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/org.eclipse.m2e.core.tests/resources/projects/resourcesWithMVNFolder/src/main/resources/file.txt
+++ b/org.eclipse.m2e.core.tests/resources/projects/resourcesWithMVNFolder/src/main/resources/file.txt
@@ -1,0 +1,1 @@
+foo-bar-content

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.util.Collection;
 
 import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.m2e.core.embedder.IComponentLookup;
@@ -80,6 +82,16 @@ public class ExtensionsTest extends AbstractMavenProjectTestCase {
 		project1 = importPomlessProject("pomless", "bundle/pom.xml");
 		waitForJobsToComplete(monitor);
 		assertEquals("my.bundle", project1.getName());
+	}
+
+	@Test
+	public void testCopyResourcesWithMVNFolder() throws Exception {
+		IProject project = importProject("resources/projects/resourcesWithMVNFolder/pom.xml");
+		project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		WorkspaceHelpers.assertNoErrors(project);
+		IFile file = project.getFile("target/classes/file.txt");
+		assertTrue(file.exists());
+		assertEquals("foo-bar-content", new String(file.getContents().readAllBytes()));
 	}
 
 	private IProject importPomlessProject(String rootProject, String... poms) throws IOException, CoreException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -317,7 +317,8 @@ public class MavenExecutionContext implements IMavenExecutionContext {
     }
   }
 
-  private static void executeMojo(MavenSession session, MojoExecution execution, IComponentLookup lookup) {
+  private static void executeMojo(MavenSession session, MojoExecution execution, IComponentLookup lookup)
+      throws CoreException {
     Map<MavenProject, Set<Artifact>> artifacts = new HashMap<>();
     Map<MavenProject, MavenProjectMutableState> snapshots = new HashMap<>();
     for(MavenProject project : session.getProjects()) {
@@ -331,6 +332,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
       lookup.lookup(BuildPluginManager.class).executeMojo(session, execution);
     } catch(Exception ex) {
       session.getResult().addException(ex);
+      throw new CoreException(Status.error("Failed to execute mojo", ex));
     } finally {
       for(MavenProject project : session.getProjects()) {
         project.setArtifactFilter(null);


### PR DESCRIPTION
Currently the MojoSetup is cached what do not seem working fine with different containers. This now changes the way to fetch a fresh configuration that takes the current context into account.

Based on 
- https://github.com/eclipse-m2e/m2e-core/pull/1160
This fixes 
- https://github.com/eclipse-m2e/m2e-core/issues/1150