### PR TITLE
Add metatype annotations for the maven project cache to make it configurable

### DIFF
--- a/org.eclipse.m2e.core/OSGI-INF/l10n/maven.project.cache.properties
+++ b/org.eclipse.m2e.core/OSGI-INF/l10n/maven.project.cache.properties
@@ -1,0 +1,2 @@
+maven.project.cache.size=Project Cache Size
+maven.project.cache.size.description=Configure the maximum number of projects to be cached, larger values might improve performance but require more ram

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCacheConfig.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCacheConfig.java
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.core.internal.project.registry;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+/**
+ * @author christoph
+ *
+ */
+@ObjectClassDefinition(id = "maven.project.cache")
+public @interface MavenProjectCacheConfig {
+
+  static final int DEFAULT_CACHE_SIZE = 50;
+
+  @AttributeDefinition(type = AttributeType.INTEGER, description = "%maven.project.cache.size.description", name = "%maven.project.cache.size", defaultValue = DEFAULT_CACHE_SIZE
+      + "")
+  int cacheSize() default -1;
+}


### PR DESCRIPTION
This just adds the necessary annotation to show its usage and to support development of the missing tooling features:
- https://github.com/eclipse-tycho/tycho/issues/1642
- https://github.com/eclipse-pde/eclipse.pde/issues/381