### PR TITLE
Run GH verification build on Windows too

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 
@@ -45,7 +45,11 @@ jobs:
     - name: Build m2e-core
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:
-       run: mvn clean verify --batch-mode -Pits -Dtycho.p2.baselineMode=failCommon -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
+       run: >-
+           mvn clean verify --batch-mode -Pits
+           -Dtycho.p2.baselineMode=failCommon
+           -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
+           -Dtycho.surefire.deleteWorkDir=true
     - name: Upload Test Results
       uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
       with:

--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -239,6 +239,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>windows</id>
+			<activation>
+				<os>
+					<family>windows</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- The Tycho baselinging does not yet work well on Windows.
+				Temporarily skip it until it is fixed.-->
+				<tycho.baseline.skip>true</tycho.baseline.skip>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<baselineMode>warn</baselineMode>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
 								<formats>
 									<linux>tar.gz</linux>
 									<macosx>tar.gz</macosx>
+									<win32>tar.gz</win32>
 								</formats>
 							</configuration>
 						</execution>


### PR DESCRIPTION
Follow up of https://github.com/eclipse-m2e/m2e-core/pull/1081 to enable verification builds for Windows once https://github.com/actions/upload-artifact/issues/240 is resolved.

Once https://github.com/eclipse-tycho/tycho/pull/1891 is resolved disabling the tycho-baseline for Windows should also not be necessary anymore.