### PR TITLE
Add Project Wizard Shortcuts

### DIFF
--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.ui.forms;bundle-version="3.4.1",
  org.eclipse.jface.text,
  org.eclipse.core.filebuffers,
- org.eclipse.ui
+ org.eclipse.ui,
+ org.eclipse.ui.navigator
 Import-Package: org.eclipse.compare.rangedifferencer,
  org.eclipse.ltk.core.refactoring,
  org.slf4j;version="[1.7.0,3.0.0)"

--- a/org.eclipse.m2e.core.ui/plugin.xml
+++ b/org.eclipse.m2e.core.ui/plugin.xml
@@ -730,4 +730,20 @@
 			</activeWhen>
 		</projectConfigurator>
 	</extension>
+	 <extension
+	       point="org.eclipse.ui.navigator.navigatorContent">
+	    <commonWizard
+           menuGroupId="org.eclipse.m2e"
+           type="new"
+           wizardId="org.eclipse.m2e.core.wizards.Maven2ModuleWizard">
+	       <enablement>
+				<or>
+					<and>
+						<instanceof value="org.eclipse.core.resources.IProject" />
+						<test property="org.eclipse.core.resources.projectNature" value="org.eclipse.m2e.core.maven2Nature" />
+					</and>
+				</or>
+			</enablement>
+	    </commonWizard>
+	 </extension>
 </plugin>

--- a/org.eclipse.m2e.jdt.ui/plugin.xml
+++ b/org.eclipse.m2e.jdt.ui/plugin.xml
@@ -344,4 +344,12 @@
             name="M2Eclipse">
       </quickFixProcessor>
    </extension>   
+	<extension point="org.eclipse.ui.perspectiveExtensions">
+	   <perspectiveExtension
+	         targetID="org.eclipse.jdt.ui.JavaPerspective">
+	      <newWizardShortcut
+	            id="org.eclipse.m2e.core.wizards.Maven2ProjectWizard">
+	      </newWizardShortcut>
+	   </perspectiveExtension>
+	</extension>
 </fragment>

--- a/org.eclipse.m2e.pde.ui/plugin.xml
+++ b/org.eclipse.m2e.pde.ui/plugin.xml
@@ -15,4 +15,12 @@
        </locationProvider>
        
     </extension>
+	<extension point="org.eclipse.ui.perspectiveExtensions">
+	   <perspectiveExtension
+	         targetID="org.eclipse.pde.ui.PDEPerspective">
+	      <newWizardShortcut
+	            id="org.eclipse.m2e.core.wizards.Maven2ProjectWizard">
+	      </newWizardShortcut>
+	   </perspectiveExtension>
+	</extension>
 </plugin>


### PR DESCRIPTION
Currently important parts of m2e functionality are hidden in sub-menus or sub-groups. This makes it hard for users to discover them and it requires to much clicks to use them.

This adds two new short-cuts:
- For File > New > Maven Project
- For Navigator > New > Maven Module