### PR TITLE
[Build] Move args to maven.cfg and use p2.baselineMode=failCommon in CI and fix extraction of M2E_VERSION for multi-digit versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build m2e-core
       uses: GabrielBB/xvfb-action@v1
       with:
-       run: mvn clean verify -B -V -e -U -Pits -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
+       run: mvn clean verify -Pits -Dtycho.p2.baselineMode=failCommon
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
       with:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,3 @@
+-B -V -e -U
+-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
 -Dtycho.resolver.classic=false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,7 @@ pipeline {
 			steps {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh 'mvn clean verify -B -V -e -U \
-						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
+					sh 'mvn clean verify -Dtycho.p2.baselineMode=failCommon \
 						-Peclipse-sign,its -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -Dgpg.keyname="011C526F29B2CE79"'
 				}}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
 						}
 						# Read M2E branding version
 						version=$(xmllint --xpath 'string(/feature/@version)' org.eclipse.m2e.sdk.feature/feature.xml)
-						if [[ $version =~ ([0-9]\\.[0-9]\\.[0-9])\\.qualifier ]] # backslash itself has to be escaped in Jenkinsfile
+						if [[ $version =~ ([0-9]+\\.[0-9]+\\.[0-9]+)\\.qualifier ]] # backslash itself has to be escaped in Jenkinsfile
 						then
 							M2E_VERSION="${BASH_REMATCH[1]}"
 						else

--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -227,9 +227,6 @@
 	<profiles>
 		<profile>
 			<id>eclipse-sign</id>
-			<properties>
-				<tycho.p2.baselineMode>failCommon</tycho.p2.baselineMode>
-			</properties>
 			<build>
 				<plugins>
 					<plugin>

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Testing Helpers
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 2.0.2.qualifier
+Bundle-Version: 2.0.3.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/AbstractMavenProjectTestCase.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -234,6 +236,11 @@ public abstract class AbstractMavenProjectTestCase {
     LifecycleMappingFactory.setDefaultLifecycleMappingMetadataSource(null);
 
     WorkspaceHelpers.cleanWorkspace();
+
+    // Create .mvn folder to prevent Maven launches in tests from using the .mvn folder of this git repo.
+    // Otherwise MavenLaunchDelegate.findMavenProjectBasedir() find this git repos .mvn folder and its content would interfer with the tests.
+    Files.createDirectories(Path.of(workspace.getRoot().getLocationURI()).resolve(".mvn"));
+
     FilexWagon.setRequestFailPattern(null);
     FilexWagon.setRequestFilterPattern(null, true);
     driveEvents();


### PR DESCRIPTION
Move common Maven args that should be used in the CI and for local builds to the maven.config.
Use the tycho.p2.baselineMode=failCommon in Jenkins and in GitHub workflows, but in general to be more gentle in local builds. Move its definition out of the 'eclipse-sign' profile.
