### PR TITLE
Don't open the dialog if we can't propose anything to the user

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
@@ -35,6 +35,8 @@ import org.eclipse.ui.wizards.datatransfer.ProjectConfigurator;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.ILifecycleMappingRequirement;
+import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.IMavenDiscoveryProposal;
 import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.LifecycleMappingDiscoveryRequest;
 import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
 import org.eclipse.m2e.core.project.LocalProjectScanner;
@@ -88,6 +90,12 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
                 }
                 // Some errors were detected
                 discoverProposals(discoveryRequest, monitor);
+                Map<ILifecycleMappingRequirement, List<IMavenDiscoveryProposal>> proposals = discoveryRequest
+                    .getAllProposals();
+                if(proposals.isEmpty()) {
+                  //if we can't propose anything to the user there is actually no point in open the dialog.
+                  return Status.OK_STATUS;
+                }
                 openProposalWizard(toProcess, discoveryRequest);
             } finally {
                 this.toProcess.clear();


### PR DESCRIPTION
Currently if not a single connector can be proposed the dialog is still opened and disturbs the user even though there is nothing much one can do (and most probably want to do).

This first checks if there is at least one proposal before open the dialog when importing a project.

This relates to https://github.com/eclipse-m2e/m2e-core/issues/1012