### PR TITLE
Execute RCPTT tests as part of the integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,23 @@ Some tests are in a separate repository which is referenced as a Git submodule i
 * Open the project modules you want to work on (right-click > Open project) and their dependencies; approve m2e connectors installation if prompted
 * Happy coding!
 
+### ⌨️ Setting up the RCPTT Test Environment
+
+* Download and install the RCPTT IDE from [here](https://www.eclipse.org/rcptt/download/).
+
+* Create an executable application .
+    * Right-click on [m2e-ide.product](products/m2e-ide/m2e-ide.product), *Export... > Plug-in Development > Eclipse product*
+    * Execute `mvn clean verify -D skipTests` in the command line. The application is located under `products/m2e-ide/target/products`.
+ 
+ * Launch the RCPTT IDE and import [org.eclipse.m2e.rcptt.tests](org.eclipse.m2e.rcptt.tests) into your workspace.
+ 
+ * Add m2e to your applications.
+ 
+ * Right-click on the test case you want to execute, *Run As... > Test Cases*. Select the m2e application.
+ 
+Alternatively, you may also install RCPTT directly into your Eclipse IDE via the update site.
+
+When creating new test cases, it is recommended to use the *Record* functionality, to track your actions in the test application. Check the [User Guide](https://www.eclipse.org/rcptt/documentation/userguide/getstarted/) for more information.
 
 ### 🏗️ Build
 

--- a/org.eclipse.m2e.rcptt.tests/.project
+++ b/org.eclipse.m2e.rcptt.tests/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.rcptt.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.rcptt.core.builder.q7Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.rcptt.core.rcpttnature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.m2e.rcptt.tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.rcptt.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.rcptt.tests/pom.xml
+++ b/org.eclipse.m2e.rcptt.tests/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>org.eclipse.m2e</groupId>
+		<artifactId>m2e-core</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.m2e.rcptt.tests</artifactId>
+	<packaging>rcpttTest</packaging>
+	<name>M2E - RCPTT Integration tests</name>
+	
+	<pluginRepositories>
+		<pluginRepository>
+			<id>rcptt</id>
+			<name>Eclipse RCPTT repository</name>
+			<url>https://repo.eclipse.org/content/repositories/rcptt-releases/</url>
+		</pluginRepository>
+	</pluginRepositories> 
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.rcptt</groupId>
+				<artifactId>rcptt-maven-plugin</artifactId>
+				<version>${rcptt-maven-version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<aut>
+						<explicit>../products/m2e-ide/target/products/m2e-ide-[platform].tar.gz</explicit>
+					</aut>
+					<testOptions>
+						<!-- Timeout for entire test suites (in sec) -->
+						<execTimeout>1800</execTimeout>
+						<!-- Timeout for a single test (in sec) -->
+						<testExecTimeout>300</testExecTimeout>
+					</testOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.m2e.rcptt.tests/rcptt.properties
+++ b/org.eclipse.m2e.rcptt.tests/rcptt.properties
@@ -1,0 +1,9 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Element-Name: Project Settings
+Element-Type: projectMetadata
+Element-Version: 2.0
+Id: _A_5OgIe9Ee2DibE_7T1Sqw
+Runtime-Version: 2.5.4.202210020716
+Save-Time: 12/29/22, 10:09 PM
+

--- a/org.eclipse.m2e.rcptt.tests/src/Tests/org.eclipse.m2e.pde.ui/DependencyEditorTest.test
+++ b/org.eclipse.m2e.rcptt.tests/src/Tests/org.eclipse.m2e.pde.ui/DependencyEditorTest.test
@@ -1,0 +1,296 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Contexts: _mo5J8IfaEe2N1bfX2b9TRQ
+Element-Name: DependencyEditorTest
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _WA75MIfaEe2N1bfX2b9TRQ
+Runtime-Version: 2.5.4.202210020716
+Save-Time: 2/3/23, 7:35 PM
+Tags: org.eclipse.m2e.pde.ui
+Testcase-Type: ecl
+Verifications: _7el9kIfGEe2DibE_7T1Sqw
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+with [get-view "Project Explorer" | get-tree] {
+    select "target-platform" | double-click
+    select "target-platform/target-platform.target" | double-click
+}
+
+with [get-editor "target-platform.target" | get-section Locations | get-tree] {
+    get-item -path "Maven Central.*" | click
+    select "Maven Central.*" | double-click
+}
+
+with [get-window "Maven Artifact Target Entry - Maven Central"] {
+    // Check the initial button enablement. All buttons except Undo/Redo should be enabled. 
+    get-button Add | get-property enablement | equals true | verify-true
+    get-button Remove | get-property enablement | equals true | verify-true
+    get-button Update | get-property enablement | equals true | verify-true
+    get-button Undo | get-property enablement | equals false | verify-true
+    get-button Redo | get-property enablement | equals false | verify-true
+    
+    // #################################################################### //
+    //                                                                      //
+    // [I] Check behavior of the Add button with and without the clipboard  //
+    //                                                                      //
+    // #################################################################### //
+    
+    to-clipboard -input ""
+
+    // Click add -> Create blank dependency
+    get-button Add | click -metaKeys ""
+    
+    // Invalid GAV -> Update & Finish button should be disabled
+    get-button Update | get-property enablement | equals false | verify-true
+    get-button Finish | get-property enablement | equals false | verify-true
+    
+    // Check error messages
+    get-editbox -after [get-label "Edit Maven Dependency"] | get-property text 
+        | equals "The target location contains one or more incomplete Maven dependencies.\n"
+        + " Each dependency requires a group id, artifact id, version and type." | verify-true
+    
+    get-label "" -after [get-label "Edit Maven Dependency"] 
+        | get-property "image.path" | equals "org.eclipse.jface/icons/full/message_error.png" | verify-true
+    
+    with [get-table | get-item -path "<required>"] {
+        get-property "columns[0]" | equals "<required>" | verify-true
+        get-property "columns[1]" | equals "<required>" | verify-true
+        get-property "columns[2]" | equals "<required>" | verify-true
+    }
+
+    // Fill the row with meaningful data...
+    with [get-window "Maven Artifact Target Entry - Maven Central" | get-table] {
+        get-property "getItems().TableItem[19].getData().getClassifier()" | equals "" | verify-true
+        get-property "getItems().TableItem[19].getData().getType()" | equals jar | verify-true
+        get-property "getItems().TableItem[19].getData().getVersion()" | equals "" | verify-true
+        get-property "getItems().TableItem[19].getData().getGroupId()" | equals "" | verify-true
+        get-property "getItems().TableItem[19].getData().getArtifactId()" | equals "" | verify-true
+        // Check selection
+        get-property "getSelectionCount()" | equals 1 | verify-true
+        get-property "getSelection().TableItem[0].getData().getKey()" | equals "::jar:" | verify-true
+        // Set GAV to org.apache.commons:commons-lang3:3.12.0
+        select "<required>" | activate-cell-edit -type MouseClickSelection
+        get-editbox | set-text "org.apache.commons"
+        select "<required>" | apply-cell-edit -deactivate
+        select "org.apache.commons" | activate-cell-edit -column 1 -type MouseClickSelection
+        get-editbox | set-text "commons-lang3"
+        select "org.apache.commons" | apply-cell-edit -deactivate
+        select "org.apache.commons" | activate-cell-edit -column 2 -type MouseClickSelection
+        get-editbox | set-text "3.12.0"
+        apply-cell-edit -deactivate
+        select "org.apache.commons" | activate-cell-edit -column 3 -type MouseClickSelection
+    }
+    
+    //Valid GAV -> Update & Finish button should now be enabled again
+    get-button Update | get-property enablement | equals true | verify-true
+    get-button Finish | get-property enablement | equals true | verify-true
+    
+    to-clipboard -input "<dependency>\
+                            <groupId>org.eclipse.platform</groupId>\
+                            <artifactId>org.eclipse.core.runtime</artifactId>\
+                            <version>3.26.100</version>\
+                         </dependency>"
+    
+    // Click add -> Copy dependency from clipboard
+    get-button Add | click -metaKeys ""
+
+    with [get-window "Maven Artifact Target Entry - Maven Central" | get-table] {
+        get-property "getItems().TableItem[20].getData().getClassifier()" | equals "" | verify-true
+        get-property "getItems().TableItem[20].getData().getType()" | equals jar | verify-true
+        get-property "getItems().TableItem[20].getData().getVersion()" | equals "3.26.100" | verify-true
+        get-property "getItems().TableItem[20].getData().getGroupId()" | equals "org.eclipse.platform" | verify-true
+        get-property "getItems().TableItem[20].getData().getArtifactId()" | equals "org.eclipse.core.runtime"
+            | verify-true
+        // Check selection
+        get-property "getSelectionCount()" | equals 1 | verify-true
+        get-property "getSelection().TableItem[0].getData().getKey()" 
+            | equals "org.eclipse.platform:org.eclipse.core.runtime:jar:3.26.100" | verify-true
+    }
+    
+    // Check whether you can edit the remaining columns directly. I.e. whether SWT.FULL_SELECTION is enabled.
+    with [get-table] {
+        select "org.eclipse.jdt" | activate-cell-edit -type MouseClickSelection
+        get-editbox | set-text newGroupId
+        select "org.apache.commons" | apply-cell-edit -deactivate
+        select newGroupId | activate-cell-edit -column 1 -type MouseClickSelection
+        get-editbox | set-text newArtifactId
+        select "jakarta.xml.bind" | apply-cell-edit -deactivate
+        select "jakarta.xml.bind" | activate-cell-edit -column 2 -type MouseClickSelection
+        get-editbox | set-text newVersion
+        apply-cell-edit -deactivate
+    }
+    
+    // ############################################################################# //
+    //                                                                               //
+    // [II] Check behavior of the Update button with one more more selected elements //
+    //                                                                               //
+    // ############################################################################# //
+
+    // Select org.jetbrains.kotlin:kotlin-stdlib-common -> Click Update
+    with [get-table] {
+        select "org.jetbrains.kotlin" | activate-cell-edit -type MouseClickSelection
+        get-editbox | click-text 1 21
+        cancel-cell-edit
+        deactivate-cell-edit
+    }
+
+    get-button Update | click -metaKeys ""
+
+    with [get-table] {
+        get-property "getItems().TableItem[12].getData().getVersion()" | equals "1.7.22" | verify-false
+    }
+
+    // Select org.jetbrains.kotlin:kotlin-stdlib-jdk7 to org.jetbrains.kotlin:kotlin-stdlib -> Click Update
+    with [get-table] {
+        select [get-item -path "org.jetbrains.kotlin" -index 1] | activate-cell-edit -type MouseClickSelection
+        get-editbox | click-text 1 21
+        cancel-cell-edit
+        deactivate-cell-edit
+        select [get-item -path "org.jetbrains.kotlin" -index 3] [get-item -path "org.jetbrains.kotlin" 
+            -index 2] [get-item -path "org.jetbrains.kotlin" -index 1]
+    }
+
+    get-button Update | click -metaKeys ""
+
+    with [get-table] {
+        get-property "getItems().TableItem[13].getData().getVersion()" | equals "1.7.22" | verify-false
+        get-property "getItems().TableItem[14].getData().getVersion()" | equals "1.7.22" | verify-false
+        get-property "getItems().TableItem[15].getData().getVersion()" | equals "1.7.22" | verify-false
+    }
+    
+    // ########################################################################## //
+    //                                                                            //
+    // [III] Check behavior of the Remove button on one or more selected elements //
+    //                                                                            //
+    // ########################################################################## //
+    
+    // Selected and remove com.fasterxml.jackson.core:jackson-annotations to com.fasterxml.jackson.core:jackson-databind
+    with [get-table] {
+        select "com.fasterxml.jackson.core" | activate-cell-edit -type MouseClickSelection
+        get-editbox | click-text 1 27
+        cancel-cell-edit
+        deactivate-cell-edit
+        select [get-item -path "com.fasterxml.jackson.core" -index 2] [get-item -path "com.fasterxml.jackson.core" 
+            -index 1] "com.fasterxml.jackson.core"
+    }
+    
+    get-button Remove | click -metaKeys ""
+    
+    // The selected elements should no longer be in the table, with com.github.ben-manes.caffeine:caffeine being the first element
+    with [get-table] {
+        get-property "getSelection().length" | equals 0 
+        get-property "getItemCount()" | equals 18 | verify-true
+        get-property "getItems().TableItem[0].getText()" | equals "com.github.ben-manes.caffeine" | verify-true
+    }
+    
+    get-button Undo | click -metaKeys ""
+    
+    // The artifacts com.fasterxml.jackson.core:jackson-annotations to com.fasterxml.jackson.core:jackson-databind are back and selected
+    with [get-table] {
+        get-property "getItemCount()" | equals 21 | verify-true
+        get-property "getSelection().length" | equals 3 | verify-true
+        get-property "getSelection().TableItem[0].getData().getKey()" 
+            | equals "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.1" | verify-true
+        get-property "getSelection().TableItem[1].getData().getKey()" 
+            | equals "com.fasterxml.jackson.core:jackson-core:jar:2.14.1" | verify-true
+        get-property "getSelection().TableItem[2].getData().getKey()" 
+            | equals "com.fasterxml.jackson.core:jackson-databind:jar:2.14.1" | verify-true
+    }
+    
+    // Select and remove com.squareup.okio:okio-jvm
+    with [get-table] {
+        select "com.squareup.okio" | activate-cell-edit -type MouseClickSelection
+        get-editbox | click-text 1 18
+        cancel-cell-edit
+        deactivate-cell-edit
+    }
+    
+    get-button Remove | click -metaKeys ""
+    
+    // The artifact jakarta.activation:jakarta.activation-api should now be selected, because it now at the same position as the removed element
+    with [get-table] {
+        get-property "getSelection().length" | equals 1 | verify-true
+        get-property "getSelection().TableItem[0].getData().getKey()" 
+            | equals "jakarta.activation:jakarta.activation-api:jar:1.2.2" | verify-true
+    }
+    
+    // ############################################ //
+    //                                              //
+    // [IV] Check behavior when sorting by columns  //
+    //                                              //
+    // ############################################ //
+    
+    with [get-table] {
+        // Sort by Version -> jakarta.inject:jakarta.inject-api should be first element
+        get-column-header Version | click
+        get-property "getItems().TableItem[0].getData().getKey()" | equals "jakarta.inject:jakarta.inject-api:jar:1.0.5" 
+            | verify-true
+        // Sort by Artifact Id -> com.github.ben-manes.caffeine:caffeine should be the first element
+        get-column-header "Artifact Id" | click
+        get-property "getItems().TableItem[0].getData().getKey()" 
+            | equals "com.github.ben-manes.caffeine:caffeine:jar:3.1.2" | verify-true
+        // Sort by Group Id -> com.fasterxml.jackson.core:jackson-annotations should be the first element
+        get-column-header "Group Id" | click
+        get-property "getItems().TableItem[0].getData().getKey()" 
+            | equals "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.1" | verify-true
+    }
+    
+    // Check whether dependencies are inserted into the correct position when the table is sorted
+    to-clipboard -input "<dependency>\
+                            <groupId>com.fasterxml.jackson.core</groupId>\
+                            <artifactId>jackson-databind</artifactId>\
+                            <version>2.14.0</version>\
+                         </dependency>"
+    
+    get-button Add | click -metaKeys ""
+    
+    with [get-table] {
+        get-property enablement | equals true | verify-true
+        get-property "getItems().TableItem[2].getData().getKey()" 
+            | equals "com.fasterxml.jackson.core:jackson-databind:jar:2.14.0" | verify-true
+    }
+    
+    // ################################## //
+    //                                    //
+    // [V] Check multi-selection behavior //
+    //                                    //
+    // ################################## //
+    
+    // Make sure items don't get lost when selecting more than one element
+    with [get-table] {
+        // Forward selection
+        select "com.fasterxml.jackson.core" | activate-cell-edit -type MouseClickSelection
+        get-editbox | click-text 1 27
+        cancel-cell-edit
+        deactivate-cell-edit
+        select "com.github.ben-manes.caffeine" [get-item -path "com.fasterxml.jackson.core" -index 3] [get-item 
+            -path "com.fasterxml.jackson.core" -index 2] [get-item -path "com.fasterxml.jackson.core" 
+            -index 1] "com.fasterxml.jackson.core"
+            
+        get-property "selection[0].path[0]" | equals "com.fasterxml.jackson.core" | verify-true
+        get-property "selection[1].path[0]" | equals "com.fasterxml.jackson.core%1%" | verify-true
+        get-property "selection[2].path[0]" | equals "com.fasterxml.jackson.core%2%" | verify-true
+        get-property "selection[3].path[0]" | equals "com.fasterxml.jackson.core%3%" | verify-true
+        get-property "selection[4].path[0]" | equals "com.github.ben-manes.caffeine" | verify-true
+        
+        // Backward selection
+        select [get-item -path "org.slf4j" -index 2] | activate-cell-edit -type MouseClickSelection
+        get-editbox | click-text 1 10
+        cancel-cell-edit
+        deactivate-cell-edit
+        select [get-item -path "org.slf4j" -index 2] [get-item -path "org.slf4j" -index 1] "org.slf4j" [get-item 
+            -path "org.jetbrains.kotlin" -index 3] [get-item -path "org.jetbrains.kotlin" -index 2]
+        
+        get-property "selection[0].path[0]" | equals "org.jetbrains.kotlin%2%" | verify-true
+        get-property "selection[1].path[0]" | equals "org.jetbrains.kotlin%3%" | verify-true
+        get-property "selection[2].path[0]" | equals "org.slf4j" | verify-true
+        get-property "selection[3].path[0]" | equals "org.slf4j%1%" | verify-true
+        get-property "selection[4].path[0]" | equals "org.slf4j%2%" | verify-true
+    }
+}
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/org.eclipse.m2e.rcptt.tests/src/Tests/org.eclipse.m2e.pde.ui/_Context/WorkspaceWithTargetPlatform.ctx
+++ b/org.eclipse.m2e.rcptt.tests/src/Tests/org.eclipse.m2e.pde.ui/_Context/WorkspaceWithTargetPlatform.ctx
@@ -1,0 +1,60 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Context-Type: org.eclipse.rcptt.ctx.workspace
+Element-Name: WorkspaceWithTargetPlatform
+Element-Type: context
+Element-Version: 2.0
+Id: _mo5J8IfaEe2N1bfX2b9TRQ
+Runtime-Version: 2.5.4.202210020716
+Save-Time: 12/30/22, 1:40 AM
+
+------=_contents/target-platform/target-platform.target-39adf134-5244-371e-a7da-2823002f1d57
+Content-Type: q7/binary
+Entry-Name: contents/target-platform/target-platform.target
+
+UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAADdl8+OmzAQxs+bp0Dc
+cUjYNjlAcmhVqYc9bfsAE3sgJsamtkmbt6+B/NnNSjXSiijdnGD4Bn+/kT1k0vWfSgR71IYrmYUzEocB
+SqoYl0UW/vzxLVqGgbEgGQglMQulCterSbquGV7SErLsohZ0gTaQUDllfxPVAmyudBWuJoH7pUJRsC7L
+rCYPrwIBl1Q0DL9ijZI5Ewd3ZbftkhLDt0+fqarRZCFVVc3FRfGsGk3b9XXjggI2KLLwCfYogy8orQYR
+BhU3xhE+geQ5GpuFBUrUYF2CPdR41DvLD71HdlqVY+v7OnroYn2w0Kqpv7OVs0VyMBa1qzApge6MkoQq
+jen0pLlkgbY8B2pd8CiNQEpl+1Kl0xfPL0nH+q/mZPZIZun0dH9RtDDuhTqddldn59Mr6zfA6aX/PwcD
+Cxsu2Z2wFNxumw3ZoIwqkGgIhTxHLn04F9k/MRIyI/PxKcyvBjQ2NVG7rbV14jHfqzzWXfljEt/UO1de
+41xF5b7yVn0+tvMSds4CEGeB77su493/1wkR1NwD4jbP2Nvn7OvcLoeCnBMGgSTk021AuCyR2oEQvXgQ
+QHwrgN+GaDPQf6cdYN+1U/L5Nvbb70Lf4AcRnOSDIBKSjAuhdEGQCl4bJCXz7aIr9asz5CGZk0U8cotq
+3ZVoNxq4NGSnrOC+s92LImOZ4Bv3l6OqvCgzsiDzkXvUu0lKtlt8EI7lB+C4EwQj8sfS16aoiJQzEh3F
+nmMdj91lh/ruNIN66p1ZNryqhX/SeZ/rq1g/lfbB0zh9HLenL+Zt99JuJl/9BVBLBwjVgN3qVwIAAPYP
+AABQSwECFAAUAAgICAAAACEA1YDd6lcCAAD2DwAACAAJAAAAAAAAAAAAAAAAAAAALmNvbnRlbnRVVAUA
+AQAAAABQSwUGAAAAAAEAAQA/AAAAlgIAAAAA
+------=_contents/target-platform/target-platform.target-39adf134-5244-371e-a7da-2823002f1d57--
+------=_contents/target-platform/.project-faabef30-8b6b-367d-9526-544b3980ac44
+Content-Type: q7/binary
+Entry-Name: contents/target-platform/.project
+
+UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAABVjsEOwiAQRM/2Kxru
+Fb15oPRi+gPqByBdGwwsZNkaP1+s2tjbm5mdzajuGXz9AMouYiv2252oAW0cHI6tuJz75iA6XalE8Q6W
+j5AtucTlWFcbhSaAZkMjcJO84VukoOTsltTGEABZK/mjYn4f5TfLf3GdnB9OCeycrBQangg+lYWX9mrT
+C1BLBwhlg0YFhgAAANAAAABQSwECFAAUAAgICAAAACEAZYNGBYYAAADQAAAACAAJAAAAAAAAAAAAAAAA
+AAAALmNvbnRlbnRVVAUAAQAAAABQSwUGAAAAAAEAAQA/AAAAxQAAAAAA
+------=_contents/target-platform/.project-faabef30-8b6b-367d-9526-544b3980ac44--
+------=_contents/target-platform/.settings/org.eclipse.core.resources.prefs-423fdf98-40c5-315c-9909-2031eed35758
+Content-Type: q7/binary
+Entry-Name: contents/target-platform/.settings/org.eclipse.core.resources.prefs
+
+UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAABLTc7JLChO1SsoSk1L
+LUrNS04t1itLLSrOzM+zNeQC8vNTMvPS9W0KivKzUpNL7GxDQ9x0LbgAUEsHCA3o3k03AAAANwAAAFBL
+AQIUABQACAgIAAAAIQAN6N5NNwAAADcAAAAIAAkAAAAAAAAAAAAAAAAAAAAuY29udGVudFVUBQABAAAA
+AFBLBQYAAAAAAQABAD8AAAB2AAAAAAA=
+------=_contents/target-platform/.settings/org.eclipse.core.resources.prefs-423fdf98-40c5-315c-9909-2031eed35758--
+------=_.q7.content-3d2e0690-ce48-3609-83e0-c704d49f1eaf
+Content-Type: q7/binary
+Entry-Name: .q7.content
+
+UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAACVkV1rgzAUhu/7K0Lu
+m6zCoBO1F2MXHWxso9DeDRtPbDZNJDmd/vxFa0RKYewuH895Tt6TZNPVFfkB65TRKV2xO0pAC1MoXab0
+jHK5pptskRhbMhCVahwwKxpEJrBjrbHfrskFxPuwejQaoUPS1SqetFGv9Y20i/15Sk+ITcx527bM1CXz
+cn542Qbkj15TeWD68oHjnuMTR4nOa09PT9srPO1yWwK+VTlKY2tKVJHSz9rcP6+3Mn+C6HV1lIfo+LD7
+eKfZgpBE9Hk09mu/a6z5AoFuVONgWzZBd6E8J1UFAWJjEeU3r68c7LKfw6Yq/CCDzQGi/xw3Nbvyzacn
+jPUjBGfOVoDzDwHpZmY+qsdwPKQbgvMpecL/+/vZ4hdQSwcIDa6p8x0BAABYAgAAUEsBAhQAFAAICAgA
+AAAhAA2uqfMdAQAAWAIAAAgACQAAAAAAAAAAAAAAAAAAAC5jb250ZW50VVQFAAEAAAAAUEsFBgAAAAAB
+AAEAPwAAAFwBAAAAAA==
+------=_.q7.content-3d2e0690-ce48-3609-83e0-c704d49f1eaf--

--- a/org.eclipse.m2e.rcptt.tests/src/Verification/Empty Log Verification.verification
+++ b/org.eclipse.m2e.rcptt.tests/src/Verification/Empty Log Verification.verification
@@ -1,0 +1,25 @@
+--- RCPTT verification ---
+Format-Version: 1.0
+Element-Name: Empty Log Verification
+Element-Type: verification
+Element-Version: 2.0
+Id: _7el9kIfGEe2DibE_7T1Sqw
+Runtime-Version: 2.5.4.202210020716
+Save-Time: 12/29/22, 11:33 PM
+Verification-Type: org.eclipse.rcptt.verifications.log
+
+------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
+Content-Type: text/plain
+Entry-Name: .description
+
+Validates that no error has been thrown during the test execution.
+------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa--
+------=_.errorlog.verification-3ceb5b18-8b7c-3939-9191-416e6e78eb57
+Content-Type: text/errorlog-verification
+Entry-Name: .errorlog.verification
+
+INCLUDE CONTEXTS: true
+DENIED:
+4 0 .* Message:.*
+
+------=_.errorlog.verification-3ceb5b18-8b7c-3939-9191-416e6e78eb57--

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 	<name>Maven Integration for Eclipse (root)</name>
 
 	<properties>
+		<rcptt-maven-version>2.5.4</rcptt-maven-version>
 		<tychoDefaultTestArgLine>-Xmx800m</tychoDefaultTestArgLine>
 		<tycho.testArgLine>${tychoDefaultTestArgLine}</tycho.testArgLine>
 		<tycho.surefire.timeout>900</tycho.surefire.timeout>
@@ -91,6 +92,9 @@
 		
 		<!-- products -->
 		<module>products</module>
+		
+		<!-- UI/Integration tests -->
+		<module>org.eclipse.m2e.rcptt.tests</module>
 	</modules>
 
 	<dependencies>


### PR DESCRIPTION
In relation to #1157, I think it makes sense to test complex UI features via RCPTT, rather than JUnit. Simply because there is no elegant way to describe e.g. mouse clicks or validate widget properties. It also provides another way one can contribute test cases to reproduce bugs in a controlled environment.

The structure of the test project mimics the structure of the m2e project. So tests related to e.g. `org.eclipse.m2e.pde.ui` are located in a folder with the same name. 

The tests can be executed from the command line via `mvn clean verify`

If you want to run them manually, those steps have to be followed:

- Assemble the product you want to test via `mvn clean verify -D skipTests`. The zip file is located under products/m2e-ide/target/products.
- Download and install the IDE from the official [website](https://www.eclipse.org/rcptt/download/)
- Launch RCPTT and import the `org.eclipse.m2e.tests.rcptt` project into your workspace
- Unpack and add the assembled m2e product to your applications
- Right-click on the test case you want to execute and click "Run as -> Test Cases"

There is also an Eclipse IDE integration for RCPTT, but I have never tested how good/bad it works.

From experience, it is usually more efficient to have a few large test cases, instead of many small ones. This is because preparing the test environment usually takes a few seconds. So a lot of time is wasted if the tests themselves are shorter than the preparation.

You also don't write the tests from hand. Rather, you use the record functionality to track your user input in the started application and then format and restructure the recorded statements in order to become more readable.

I've attach an initial test case to verify the functionality of the table-based dependency editor.