### PR TITLE
Directly pass offline/update status in ProjectRegistryRefreshJob

### DIFF
--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/RegistryTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/project/registry/RegistryTest.java
@@ -30,10 +30,8 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
-import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
 import org.eclipse.m2e.core.project.ProjectImportConfiguration;
@@ -72,23 +70,21 @@ public class RegistryTest extends AbstractMavenProjectTestCase {
     assertEquals(Collections.singleton(project.getFile("pom.xml")), registry.getDependents(parentCapability, false));
   }
 
-  @Test
-  public void testMultiRefreshKeepsCapabilities() throws IOException, CoreException, InterruptedException {
-    IProject dependentProject = createExisting("dependent", "resources/projects/dependency/dependent", true);
-    IProject dependencyProject = createExisting("dependency", "resources/projects/dependency/dependency", true);
-    waitForJobsToComplete(monitor);
-    ProjectRegistryManager registryManager = MavenPluginActivator.getDefault().getMavenProjectManagerImpl();
-    Collection<IFile> pomFiles = new ArrayList<>(2);
-    pomFiles.add(dependentProject.getFile("pom.xml"));
-    pomFiles.add(dependencyProject.getFile("pom.xml"));
-    MutableProjectRegistry state = MavenPluginActivator.getDefault().getMavenProjectManagerImpl().newMutableProjectRegistry();
-    state.clear();
-	MavenImpl.execute(MavenPlugin.getMaven(), false, false, (context, aMonitor) -> {
-      registryManager.refresh(state, pomFiles, aMonitor);
-      return null;
-    }, monitor);
-    Assert.assertNotEquals(Collections.emptyMap(), state.requiredCapabilities);
-  }
+	@Test
+	public void testMultiRefreshKeepsCapabilities() throws IOException, CoreException, InterruptedException {
+		IProject dependentProject = createExisting("dependent", "resources/projects/dependency/dependent", true);
+		IProject dependencyProject = createExisting("dependency", "resources/projects/dependency/dependency", true);
+		waitForJobsToComplete(monitor);
+		ProjectRegistryManager registryManager = MavenPluginActivator.getDefault().getMavenProjectManagerImpl();
+		Collection<IFile> pomFiles = new ArrayList<>(2);
+		pomFiles.add(dependentProject.getFile("pom.xml"));
+		pomFiles.add(dependencyProject.getFile("pom.xml"));
+		MutableProjectRegistry state = MavenPluginActivator.getDefault().getMavenProjectManagerImpl()
+				.newMutableProjectRegistry();
+		state.clear();
+		registryManager.refresh(state, new DependencyResolutionContext(pomFiles, false, false), monitor);
+		Assert.assertNotEquals(Collections.emptyMap(), state.requiredCapabilities);
+	}
 
   @Ignore(value = "This test doesn't manage to reproduce Bug 547172 while similar manual steps do lead to an error")
   @Test

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/DependencyResolutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/DependencyResolutionContext.java
@@ -12,7 +12,7 @@
  *      Christoph Läubrich - M2Eclipse gets stuck in endless update loop
  *******************************************************************************/
 
-package org.eclipse.m2e.core.internal.project;
+package org.eclipse.m2e.core.internal.project.registry;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -30,7 +30,17 @@ public class DependencyResolutionContext {
   /** Set of all pom files to resolve */
   private final LinkedHashSet<IFile> pomFiles;
 
+  private boolean offline;
+
+  private boolean updateSnapshots;
+
   public DependencyResolutionContext(Collection<IFile> pomFiles) {
+    this(pomFiles, false, false);
+  }
+
+  public DependencyResolutionContext(Collection<IFile> pomFiles, boolean offline, boolean updateSnapshots) {
+    this.offline = offline;
+    this.updateSnapshots = updateSnapshots;
     this.pomFiles = new LinkedHashSet<>(pomFiles);
   }
 
@@ -58,6 +68,14 @@ public class DependencyResolutionContext {
    */
   public void forcePomFile(IFile file) {
     pomFiles.add(file);
+  }
+
+  boolean isOffline() {
+    return offline;
+  }
+
+  boolean isUpdateSnapshots() {
+    return this.updateSnapshots;
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectProcessingTracker.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectProcessingTracker.java
@@ -11,7 +11,7 @@
  * Contributors:
  *      Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.m2e.core.internal.project;
+package org.eclipse.m2e.core.internal.project.registry;
 
 import java.util.Iterator;
 import java.util.LinkedHashSet;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -302,13 +302,17 @@ public class ProjectRegistryManager implements ISaveParticipant {
    *
    * @since 1.4
    */
-  public void refresh(Collection<IFile> pomFiles, IProgressMonitor monitor) throws CoreException {
+  public void refresh(Collection<IFile> files, IProgressMonitor monitor) throws CoreException {
+    refresh(new DependencyResolutionContext(files), monitor);
+  }
+
+  public void refresh(DependencyResolutionContext context, IProgressMonitor monitor) throws CoreException {
     SubMonitor progress = SubMonitor.convert(monitor, Messages.ProjectRegistryManager_task_refreshing, 100);
     ISchedulingRule rule = ResourcesPlugin.getWorkspace().getRoot();
     Job.getJobManager().beginRule(rule, progress);
     syncRefreshThread = Thread.currentThread();
     try (MutableProjectRegistry newState = newMutableProjectRegistry()) {
-      refresh(newState, new DependencyResolutionContext(pomFiles), progress.newChild(95));
+      refresh(newState, context, progress.newChild(95));
 
       applyMutableProjectRegistry(newState, progress.newChild(5));
     } finally {


### PR DESCRIPTION
Currently the `ProjectRegistryRefreshJob` does nest calls with global maven context to pass online/update settings, instead we should instruct the `ProjectRegistryManager` directly about our intend.