### PR TITLE
Have a name for all modules

### DIFF
--- a/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.m2e.core.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Integration for Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.m2e.core.ui.tests
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e
 Require-Bundle: org.eclipse.m2e.tests.common,

--- a/org.eclipse.m2e.core.ui.tests/pom.xml
+++ b/org.eclipse.m2e.core.ui.tests/pom.xml
@@ -22,7 +22,8 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core.ui.tests</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<name>M2E Maven Integration for Eclipse UI Tests</name>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, Lemminx and Maven LS extension (requires Incubating components)
+Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, LemMinX and Maven LS extension (requires Incubating components)
 Bundle-SymbolicName: org.eclipse.m2e.editor.lemminx;singleton:=true
-Bundle-Version: 2.0.1.qualifier
+Bundle-Version: 2.0.2.qualifier
 Automatic-Module-Name: org.eclipse.m2e.xmlls.extension
 Import-Package: org.eclipse.core.runtime;version="3.5.0",
  org.osgi.framework;version="1.10.0",

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -22,8 +22,9 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.editor.lemminx</artifactId>
+	<name>M2E Maven POM File Editor (Wild Web Developer, LemMinX, LS)</name>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.2-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.m2e.pde.connector.tests/pom.xml
+++ b/org.eclipse.m2e.pde.connector.tests/pom.xml
@@ -19,6 +19,7 @@
 		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.m2e.pde.connector.tests</artifactId>
+	<name>M2E PDE Connector Tests</name>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>


### PR DESCRIPTION
Avoids the mixture between FQNs and readable names in the Maven summary.