### PR TITLE
Disable search in Maven-Central for PDE-SourceLookup

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/Messages.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/Messages.java
@@ -403,6 +403,8 @@ public class Messages extends NLS {
 
   public static String MavenPreferencePage_changingPreferencesRequiresProjectUpdate;
 
+  public static String MavenPreferencePage_queryCentralToIdentifyArtifacts;
+
   public static String MavenPreferencePage_download;
 
   public static String MavenPreferencePage_hide;

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/messages.properties
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/messages.properties
@@ -237,6 +237,7 @@ MavenPreferencePage_autoUpdateProjectConfiguration=Automatically update Maven pr
 MavenPreferencePage_updateProjectRequired_title=Update project required
 MavenPreferencePage_warnIncompleteMapping=Hide warning for incomplete mapping
 MavenPreferencePage_changingPreferencesRequiresProjectUpdate=Changing the checksum policy requires updating the Maven projects for the changes to take effect. Do you want to update projects now?
+MavenPreferencePage_queryCentralToIdentifyArtifacts=Use Maven-Central to identify unknown artifacts (e.g. when locating sources)
 MavenProjectPreferencePage_btnResolve=Resolve dependencies from &Workspace projects
 MavenProjectPreferencePage_dialog_message=Maven settings have changed. Do you want to update project configuration?
 MavenProjectPreferencePage_dialog_title=Maven Settings

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenPreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/MavenPreferencePage.java
@@ -97,8 +97,10 @@ public class MavenPreferencePage extends FieldEditorPreferencePage implements IW
     addField(new BooleanFieldEditor(MavenPreferenceConstants.P_HIDE_FOLDERS_OF_NESTED_PROJECTS, //
         Messages.MavenPreferencePage_hide, getFieldEditorParent()));
 
-    String[][] checksumPolicies = new String[][] {
-        new String[] {Messages.preferencesGlobalChecksumPolicy_default, null},
+    addField(new BooleanFieldEditor(MavenPreferenceConstants.P_QUERY_CENTRAL_TO_IDENTIFY_ARTIFACT, //
+        Messages.MavenPreferencePage_queryCentralToIdentifyArtifacts, getFieldEditorParent()));
+
+    String[][] checksumPolicies = new String[][] {new String[] {Messages.preferencesGlobalChecksumPolicy_default, null},
         new String[] {Messages.preferencesGlobalChecksumPolicy_ignore, ArtifactRepositoryPolicy.CHECKSUM_POLICY_IGNORE},
         new String[] {Messages.preferencesGlobalChecksumPolicy_warn, ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN},
         new String[] {Messages.preferencesGlobalChecksumPolicy_fail, ArtifactRepositoryPolicy.CHECKSUM_POLICY_FAIL}};
@@ -106,8 +108,8 @@ public class MavenPreferencePage extends FieldEditorPreferencePage implements IW
 
     FieldEditor checksumPolicy = new ComboFieldEditor(MavenPreferenceConstants.P_GLOBAL_CHECKSUM_POLICY,
         Messages.preferencesGlobalChecksumPolicy, checksumPolicies, getFieldEditorParent());
-    checksumPolicy.getLabelControl(getFieldEditorParent()).setToolTipText(
-        Messages.preferencesGlobalChecksumPolicy_tooltip);
+    checksumPolicy.getLabelControl(getFieldEditorParent())
+        .setToolTipText(Messages.preferencesGlobalChecksumPolicy_tooltip);
     addField(checksumPolicy);
 
     if(M2EUIPluginActivator.showExperimentalFeatures()) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
@@ -36,7 +36,9 @@ public interface MavenPreferenceConstants {
   /** boolean */
   String P_OFFLINE = PREFIX + "offline"; //$NON-NLS-1$
 
-  /** boolean. if true, use org.eclipse.aether.repository.RepositoryPolicy.UPDATE_POLICY_NEVER as global update policy */
+  /**
+   * boolean. if true, use org.eclipse.aether.repository.RepositoryPolicy.UPDATE_POLICY_NEVER as global update policy
+   */
   String P_GLOBAL_UPDATE_NEVER = PREFIX + "globalUpdatePolicy"; //$NON-NLS-1$
 
   /** boolean */
@@ -150,6 +152,9 @@ public interface MavenPreferenceConstants {
   String P_AUTO_UPDATE_CONFIGURATION = PREFIX + "autoUpdateProjects"; //$NON-NLS-1$
 
   String P_DEFAULT_MOJO_EXECUTION_ACTION = PREFIX + "unkownMojoExecutionAction"; //$NON-NLS-1$
+
+  /** boolean */
+  String P_QUERY_CENTRAL_TO_IDENTIFY_ARTIFACT = PREFIX + "queryCentralToIdentifyArtifact"; //$NON-NLS-1$
 
   /**
    * boolean.

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceInitializer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceInitializer.java
@@ -48,6 +48,7 @@ public class MavenPreferenceInitializer extends AbstractPreferenceInitializer {
     store.putBoolean(MavenPreferenceConstants.P_UPDATE_PROJECTS, false);
 
     store.putBoolean(MavenPreferenceConstants.P_HIDE_FOLDERS_OF_NESTED_PROJECTS, false);
+    store.putBoolean(MavenPreferenceConstants.P_QUERY_CENTRAL_TO_IDENTIFY_ARTIFACT, false);
     store.putBoolean(MavenPreferenceConstants.P_DEFAULT_POM_EDITOR_PAGE, true);
 
     store.putBoolean(MavenPreferenceConstants.P_SHOW_CONSOLE_ON_ERR, true);


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/1196

There could be a preference, as suggested in https://github.com/eclipse-m2e/m2e-core/issues/1196#issuecomment-1381565091, which is off by default. But as elaborated in https://github.com/eclipse-m2e/m2e-core/issues/1196#issuecomment-1381557334 the chances for a hit in the file-hash based search in central are probably low, when the pom.properties are absent.