### PR TITLE
Fix ArtifactKey creation when looking-up the id in the pom.xml and improve code in MetaInfMavenScanner

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MetaInfMavenScanner.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MetaInfMavenScanner.java
@@ -197,6 +197,6 @@ public abstract class MetaInfMavenScanner<T> {
     if(version == null && parent != null) {
       version = parent.getVersion();
     }
-    return new ArtifactKey(groupId, model.getArtifactId(), null, version);
+    return new ArtifactKey(groupId, model.getArtifactId(), version, null);
   }
 }


### PR DESCRIPTION
When reading the ArtifactKey from the pom.xml the key was created falsely:
`new ArtifactKey(groupId, model.getArtifactId(), null, version);`
instead of
`new ArtifactKey(groupId, model.getArtifactId(), version, null);`


The second commit re-orders the code to improve its structure.