### PR TITLE
Add workaround for classes kept forever around in LifecycleManager

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -167,7 +167,8 @@
 								org.sonatype.plexus.*;provider=m2e;mandatory:=provider,\
 								org.eclipse.aether.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version},\
 								com.google.inject.*;provider=m2e;mandatory:=provider,\
-								io.takari.*;provider=m2e;mandatory:=provider
+								io.takari.*;provider=m2e;mandatory:=provider,\
+								org.eclipse.sisu.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version}
 							Import-Package: \
 								org.slf4j;version="[1.7.31,3.0.0)",\
 								org.slf4j.spi;version="[1.7.31,3.0.0)",\

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/LifecycleManagerDisposer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/LifecycleManagerDisposer.java
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.core.internal.embedder;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.eclipse.sisu.bean.BeanManager;
+import org.eclipse.sisu.bean.LifecycleManager;
+import org.eclipse.sisu.plexus.PlexusLifecycleManager;
+
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.classworlds.ClassWorldListener;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+
+
+public class LifecycleManagerDisposer implements ClassWorldListener {
+
+  private DefaultPlexusContainer container;
+
+  public LifecycleManagerDisposer(DefaultPlexusContainer container) {
+    this.container = container;
+  }
+
+  @Override
+  public void realmCreated(ClassRealm realm) {
+  }
+
+  @Override
+  public void realmDisposed(ClassRealm realm) {
+    // Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=581407
+    try {
+      BeanManager beanManager = container.lookup(BeanManager.class);
+      if(beanManager instanceof PlexusLifecycleManager plexus) {
+        Field delegateField = plexus.getClass().getDeclaredField("delegate");
+        delegateField.setAccessible(true);
+        Object delegate = delegateField.get(plexus);
+        if(delegate instanceof LifecycleManager manager) {
+          disposeOutdatedEntries(realm, manager);
+        }
+      }
+    } catch(Exception ex) {
+      ex.printStackTrace();
+    }
+  }
+
+  private void disposeOutdatedEntries(ClassRealm realm, LifecycleManager manager)
+      throws NoSuchFieldException, IllegalAccessException {
+    Field lifecyclesMapField = manager.getClass().getDeclaredField("lifecycles");
+    lifecyclesMapField.setAccessible(true);
+    Object lifecycles = lifecyclesMapField.get(manager);
+    if(lifecycles instanceof Map<?, ?> map) {
+      for(Object key : map.keySet().toArray()) {
+        if(key instanceof Class<?> clazz) {
+          if(clazz.getClassLoader() == realm) {
+            map.remove(key);
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -244,6 +244,7 @@ public class PlexusContainerManager {
         bind(CoreExports.class).toInstance(exports);
       }
     }, new ExtensionModule());
+    classWorld.addListener(new LifecycleManagerDisposer(container));
     container.setLookupRealm(null);
     Thread thread = Thread.currentThread();
     ClassLoader ccl = thread.getContextClassLoader();

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
@@ -40,6 +40,7 @@ import org.apache.maven.project.ProjectRealmCache;
 import org.apache.maven.project.artifact.MavenMetadataCache;
 
 import org.eclipse.m2e.core.embedder.ArtifactKey;
+import org.eclipse.m2e.core.embedder.IComponentLookup;
 import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
 import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.internal.project.IManagedCache;
@@ -125,17 +126,19 @@ public class MavenProjectCache {
    */
   Set<File> flushMavenCaches(File pom, ArtifactKey key, boolean force) {
     Set<File> affected = new HashSet<>();
-    affected.addAll(flushMavenCache(ProjectRealmCache.class, pom, key, force));
-    affected.addAll(flushMavenCache(ExtensionRealmCache.class, pom, key, force));
-    affected.addAll(flushMavenCache(PluginRealmCache.class, pom, key, force));
-    affected.addAll(flushMavenCache(MavenMetadataCache.class, pom, key, force));
-    affected.addAll(flushMavenCache(PluginArtifactsCache.class, pom, key, force));
+    IComponentLookup componentLookup = containerManager.getComponentLookup(pom);
+    affected.addAll(flushMavenCache(componentLookup, ProjectRealmCache.class, pom, key, force));
+    affected.addAll(flushMavenCache(componentLookup, ExtensionRealmCache.class, pom, key, force));
+    affected.addAll(flushMavenCache(componentLookup, PluginRealmCache.class, pom, key, force));
+    affected.addAll(flushMavenCache(componentLookup, MavenMetadataCache.class, pom, key, force));
+    affected.addAll(flushMavenCache(componentLookup, PluginArtifactsCache.class, pom, key, force));
     return affected;
   }
 
-  private Set<File> flushMavenCache(Class<?> clazz, File pom, ArtifactKey key, boolean force) {
+  private Set<File> flushMavenCache(IComponentLookup componentLookup, Class<?> clazz, File pom, ArtifactKey key,
+      boolean force) {
     try {
-      Object lookup = containerManager.getComponentLookup(pom).lookup(clazz);
+      Object lookup = componentLookup.lookup(clazz);
       if(lookup instanceof IManagedCache cache) {
         return cache.removeProject(pom, key, force);
       }


### PR DESCRIPTION
Fix https://github.com/eclipse-m2e/m2e-core/issues/1214

FYI @odrotbohm I can see in the debugger that classes for the realm are removed from the map, can you verify that this fixes the problem you see with byte-buddy?