### PR TITLE
Bump m2e.feature to 2.2.0 and include gson into the m2e repository

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/LifecycleManagerDisposer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/LifecycleManagerDisposer.java
@@ -61,13 +61,7 @@ public class LifecycleManagerDisposer implements ClassWorldListener {
     lifecyclesMapField.setAccessible(true);
     Object lifecycles = lifecyclesMapField.get(manager);
     if(lifecycles instanceof Map<?, ?> map) {
-      for(Object key : map.keySet().toArray()) {
-        if(key instanceof Class<?> clazz) {
-          if(clazz.getClassLoader() == realm) {
-            map.remove(key);
-          }
-        }
-      }
+      map.keySet().removeIf(key -> key instanceof Class<?> clazz && clazz.getClassLoader() == realm);
     }
   }
 

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.1.3.qualifier"
+      version="2.2.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -24,6 +24,8 @@
    <bundle id="ch.qos.logback.core.source"/>
    <bundle id="ch.qos.logback.classic"/>
    <bundle id="ch.qos.logback.classic.source"/>
+   <bundle id="com.google.gson"/>
+   <bundle id="com.google.gson.source"/>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
    <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/1.0.1/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.21.0/" enabled="true" />


### PR DESCRIPTION
The version was already bumped in commit b8a7fb34d8808b06b2a9a4b1f43a09f656f0b41c, which was reverted shortly later. But the contained changes where applied again so we should bump that version again. Furthermore significant changes have been made in the core of m2e, which justify a minor version bump.

Include the newly used version of com.google.gson into the m2e repository since nobody else seems to provide it in a p2-repo at the moment.

Both helps in https://github.com/eclipse-m2e/m2e-core/issues/1214#issuecomment-1404120935.

And simplify LifecycleManagerDisposer.