### PR TITLE
Initialize the dependency table viewer with SWT.FULL_SELECTION.

### DIFF
--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/internal/DependencyTable.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/internal/DependencyTable.java
@@ -84,7 +84,7 @@ public class DependencyTable {
 	}
 
 	private void createTable(Composite parent) {
-		viewer = new TableViewer(parent);
+		viewer = new TableViewer(parent, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER | SWT.FULL_SELECTION);
 		viewer.setContentProvider(ArrayContentProvider.getInstance());
 		viewer.getTable().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		viewer.getTable().setHeaderVisible(true);


### PR DESCRIPTION
This is required for tables with more than one column, where each column should be editable. If you want to edit a cell, you currently have to first select the row you want to edit, by clicking on the item in the first column. In order to then edit a different cell, you then have to first select the new column, before the cell becomes editable.

This issue only seems to exist on Windows machines.

I noticed this issue after trying out the new editor on a Windows machine. Why this doesn't happen with GTK is anyones guess...

From the ViewerColumn documentation:
> Users setting up an editable TreeViewer or TableViewer with more than 1 column **have**
> to pass the SWT.FULL_SELECTION style bit when creating the viewer