### PR TITLE
Execute the AptConfig calls to the source directories in own thread

### DIFF
--- a/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.apt.core;singleton:=true
-Bundle-Version: 2.0.2.qualifier
+Bundle-Version: 2.2.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.eclipse.jdt.core,
- org.eclipse.jdt.apt.core,
+ org.eclipse.jdt.core;bundle-version="3.32.0",
+ org.eclipse.jdt.apt.core;bundle-version="3.7.50",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.jdt;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)"


### PR DESCRIPTION
Due to
- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/689

Fix https://github.com/eclipse-m2e/m2e-core/issues/984

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>