### PR TITLE
Take the properties from .mvn/maven.config into account in project conf

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -53,6 +53,7 @@ Import-Package: com.google.common.base;version="30.1.0",
  com.google.common.cache,
  com.google.gson;version="[2.10.0,3.0.0)",
  javax.inject;version="1.0.0",
+ org.apache.commons.cli;version="1.4.0",
  org.apache.commons.codec.digest;version="[1.14.0,2.0.0)",
  org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.core

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
@@ -188,26 +188,29 @@ public class MavenBuilder extends IncrementalProjectBuilder implements DeltaProv
   };
 
   @Override
-  protected IProject[] build(final int kind, final Map<String, String> args, final IProgressMonitor monitor)
-      throws CoreException {
+  protected IProject[] build(final int kind, final Map<String, String> args, final IProgressMonitor monitor) {
     log.debug("Building project {}", getProject().getName()); //$NON-NLS-1$
     final long start = System.currentTimeMillis();
     try {
-      return methodBuild.execute(kind, args, monitor);
-    } finally {
+      IProject[] projects = methodBuild.execute(kind, args, monitor);
       log.debug("Built project {} in {} ms", getProject().getName(), System.currentTimeMillis() - start); //$NON-NLS-1$
+      return projects;
+    } catch(CoreException | RuntimeException ex) {
+      MavenPluginActivator.getDefault().getLog().error("Can't build project " + getProject().getName(), ex);
+      return null;
     }
   }
 
   @Override
-  protected void clean(final IProgressMonitor monitor) throws CoreException {
+  protected void clean(final IProgressMonitor monitor) {
     log.debug("Cleaning project {}", getProject().getName()); //$NON-NLS-1$
     final long start = System.currentTimeMillis();
 
     try {
       methodClean.execute(CLEAN_BUILD, Collections.emptyMap(), monitor);
-    } finally {
       log.debug("Cleaned project {} in {} ms", getProject().getName(), System.currentTimeMillis() - start); //$NON-NLS-1$
+    } catch(CoreException ex) {
+      MavenPluginActivator.getDefault().getLog().error("Cleaning project " + getProject().getName() + " failed", ex);
     }
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -116,7 +116,7 @@ public class MavenExecutionContext implements IMavenExecutionContext {
    */
   public MavenExecutionContext(IComponentLookup lookup, File baseDir,
       Function<? super MavenExecutionContext, MavenProject> projectSupplier) {
-    this(lookup, baseDir, PlexusContainerManager.computeMultiModuleProjectDirectory(baseDir), projectSupplier);
+    this(lookup, baseDir, MavenProperties.computeMultiModuleProjectDirectory(baseDir), projectSupplier);
   }
 
   public MavenExecutionContext(IComponentLookup lookup, File baseDir, File multiModuleProjectDirectory,

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
@@ -21,15 +21,29 @@
 
 package org.eclipse.m2e.core.internal.embedder;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
+import java.util.function.BiConsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+
+import org.apache.maven.cli.CLIManager;
 import org.apache.maven.cli.MavenCli;
 import org.apache.maven.shared.utils.StringUtils;
 
@@ -44,6 +58,8 @@ import org.apache.maven.shared.utils.StringUtils;
  * @since 1.15
  */
 public class MavenProperties {
+
+  private static final String MVN_MAVEN_CONFIG = ".mvn/maven.config";
 
   private static final Logger log = LoggerFactory.getLogger(MavenProperties.class);
 
@@ -131,6 +147,74 @@ public class MavenProperties {
     if(properties != null) {
       properties.setProperty("maven.version", mavenVersion);
       properties.setProperty("maven.build.version", mavenBuildVersion);
+    }
+  }
+
+  /**
+   * @param file a base file or directory, may be <code>null</code>
+   * @return the value for `maven.multiModuleProjectDirectory` as defined in Maven launcher
+   */
+  public static File computeMultiModuleProjectDirectory(File file) {
+    if(file == null) {
+      return null;
+    }
+    final File basedir = file.isDirectory() ? file : file.getParentFile();
+    IWorkspace workspace = ResourcesPlugin.getWorkspace();
+    File workspaceRoot = workspace.getRoot().getLocation().toFile();
+
+    for(File root = basedir; root != null && !root.equals(workspaceRoot); root = root.getParentFile()) {
+      if(new File(root, IMavenPlexusContainer.MVN_FOLDER).isDirectory()) {
+        return root;
+      }
+    }
+    return null;
+  }
+
+  public static File computeMultiModuleProjectDirectory(IResource resource) {
+    if(resource == null) {
+      return null;
+    }
+    IPath location = resource.getLocation();
+    if(location == null) {
+      return null;
+    }
+    return computeMultiModuleProjectDirectory(location.toFile());
+  }
+
+  public static CommandLine getMavenArgs(File multiModuleProjectDirectory) throws IOException, ParseException {
+    if(multiModuleProjectDirectory != null) {
+      File configFile = new File(multiModuleProjectDirectory, MVN_MAVEN_CONFIG);
+      if(configFile.isFile()) {
+        List<String> args = new ArrayList<>();
+        for(String arg : new String(Files.readAllBytes(configFile.toPath())).split("\\s+")) {
+          if(!arg.isEmpty()) {
+            args.add(arg);
+          }
+        }
+        CLIManager manager = new CLIManager();
+        return manager.parse(args.toArray(String[]::new));
+      }
+    }
+    return null;
+  }
+
+  public static void getCliProperties(CommandLine commandLine, BiConsumer<String, String> consumer) {
+    if(commandLine != null && commandLine.hasOption(CLIManager.SET_SYSTEM_PROPERTY)) {
+      String[] defStrs = commandLine.getOptionValues(CLIManager.SET_SYSTEM_PROPERTY);
+      if(defStrs != null) {
+        for(String defStr : defStrs) {
+          MavenProperties.getCliProperty(defStr, consumer);
+        }
+      }
+    }
+  }
+
+  public static void getCliProperty(String property, BiConsumer<String, String> consumer) {
+    int index = property.indexOf('=');
+    if(index <= 0) {
+      consumer.accept(property.trim(), "true");
+    } else {
+      consumer.accept(property.substring(0, index).trim(), property.substring(index + 1).trim());
     }
   }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,11 +35,12 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.cli.CommandLine;
+
 import com.google.inject.AbstractModule;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
@@ -164,7 +166,7 @@ public class PlexusContainerManager {
   }
 
   public IMavenPlexusContainer aquire(File basedir) throws Exception {
-    File directory = computeMultiModuleProjectDirectory(basedir);
+    File directory = MavenProperties.computeMultiModuleProjectDirectory(basedir);
     if(directory == null) {
       return aquire();
     }
@@ -177,13 +179,14 @@ public class PlexusContainerManager {
           plexusContainer = newPlexusContainer(canonicalDirectory, loggerManager, mavenConfiguration);
           containerMap.put(canonicalDirectory, plexusContainer);
         } catch(ExtensionResolutionException e) {
-          //TODO should we fail or should we return the standard container then and for example create an error marker on the project?
+          //TODO how can we create an error marker on the extension file?
           CoreExtension extension = e.getExtension();
+          File file = new File(directory, IMavenPlexusContainer.EXTENSIONS_FILENAME);
           throw new PlexusContainerException(
               "can't create plexus container for basedir = " + basedir.getAbsolutePath() + " because the extension "
                   + extension.getGroupId() + ":" + extension.getArtifactId() + ":" + extension.getVersion()
                   + " can't be loaded (defined in "
-                  + new File(directory, IMavenPlexusContainer.EXTENSIONS_FILENAME).getAbsolutePath() + ").",
+                  + file.getAbsolutePath() + ").",
               e);
         }
       }
@@ -347,6 +350,9 @@ public class PlexusContainerManager {
       container.lookup(MavenExecutionRequestPopulator.class).populateDefaults(request);
       request.setBaseDirectory(multiModuleProjectDirectory);
       request.setMultiModuleProjectDirectory(multiModuleProjectDirectory);
+      CommandLine commandLine = MavenProperties.getMavenArgs(multiModuleProjectDirectory);
+      Properties userProperties = request.getUserProperties();
+      MavenProperties.getCliProperties(commandLine, userProperties::setProperty);
       BootstrapCoreExtensionManager resolver = container.lookup(BootstrapCoreExtensionManager.class);
       return resolver.loadCoreExtensions(request, coreEntry.getExportedArtifacts(), extensions);
     } finally {
@@ -441,26 +447,6 @@ public class PlexusContainerManager {
           : new CoreException(Status.error("container creation failed", exception));
     }
 
-  }
-
-  /**
-   * @param file a base file or directory, may be <code>null</code>
-   * @return the value for `maven.multiModuleProjectDirectory` as defined in Maven launcher
-   */
-  public static File computeMultiModuleProjectDirectory(File file) {
-    if(file == null) {
-      return null;
-    }
-    final File basedir = file.isDirectory() ? file : file.getParentFile();
-    IWorkspace workspace = ResourcesPlugin.getWorkspace();
-    File workspaceRoot = workspace.getRoot().getLocation().toFile();
-
-    for(File root = basedir; root != null && !root.equals(workspaceRoot); root = root.getParentFile()) {
-      if(new File(root, IMavenPlexusContainer.MVN_FOLDER).isDirectory()) {
-        return root;
-      }
-    }
-    return null;
   }
 
   public static IComponentLookup wrap(PlexusContainer container) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
@@ -143,8 +143,7 @@ public class MavenProjectCache {
         return cache.removeProject(pom, key, force);
       }
     } catch(CoreException ex) {
-      // can't really happen
-      throw new AssertionError(ex);
+      // can't do anything then...
     }
     return Collections.emptySet();
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -57,6 +57,7 @@ import org.eclipse.m2e.core.internal.IMavenToolbox;
 import org.eclipse.m2e.core.internal.Messages;
 import org.eclipse.m2e.core.internal.embedder.IMavenPlexusContainer;
 import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
+import org.eclipse.m2e.core.internal.embedder.MavenProperties;
 import org.eclipse.m2e.core.internal.embedder.PlexusContainerManager;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -135,7 +136,7 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     // but https://github.com/eclipse-m2e/m2e-core/issues/904 will add support for a user to specify a custom root directory
     // and then we should really inherit this from the configuration!
     this.resolverConfiguration = new MavenProjectConfiguration(resolverConfiguration,
-        PlexusContainerManager.computeMultiModuleProjectDirectory(pomFile));
+        MavenProperties.computeMultiModuleProjectDirectory(pomFile));
 
     this.artifactKey = new ArtifactKey(mavenProject.getArtifact());
     this.packaging = mavenProject.getPackaging();
@@ -649,6 +650,8 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
 
     private final String profiles;
 
+    private final Map<String, String> userProperties;
+
     public MavenProjectConfiguration(IProjectConfiguration baseConfiguration, File multiModuleProjectDirectory) {
       if(baseConfiguration == null) {
         //we should really forbid this but some test seem to pass null!
@@ -657,6 +660,7 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
       this.multiModuleProjectDirectory = multiModuleProjectDirectory;
       this.mappingId = baseConfiguration.getLifecycleMappingId();
       this.properties = Map.copyOf(baseConfiguration.getConfigurationProperties());
+      this.userProperties = Map.copyOf(baseConfiguration.getUserProperties());
       this.resolveWorkspace = baseConfiguration.isResolveWorkspaceProjects();
       this.profiles = baseConfiguration.getSelectedProfiles();
     }
@@ -664,6 +668,11 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     @Override
     public Map<String, String> getConfigurationProperties() {
       return properties;
+    }
+
+    @Override
+    public Map<String, String> getUserProperties() {
+      return userProperties;
     }
 
     @Override
@@ -688,7 +697,8 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
 
     @Override
     public int hashCode() {
-      return Objects.hash(mappingId, multiModuleProjectDirectory, profiles, properties, resolveWorkspace);
+      return Objects.hash(mappingId, multiModuleProjectDirectory, profiles, properties, resolveWorkspace,
+          userProperties);
     }
 
     @Override
@@ -706,6 +716,7 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
       return Objects.equals(this.mappingId, other.mappingId)
           && Objects.equals(this.multiModuleProjectDirectory, other.multiModuleProjectDirectory)
           && Objects.equals(this.profiles, other.profiles) && Objects.equals(this.properties, other.properties)
+          && Objects.equals(this.userProperties, other.userProperties)
           && this.resolveWorkspace == other.resolveWorkspace;
     }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
@@ -26,7 +26,21 @@ import java.util.Map;
  */
 public interface IProjectConfiguration {
 
+  /**
+   * Additional properties of a project can be stored in the org.eclipse.m2e.core.prefs file under the key
+   * <code>properties</code>, will be handled as user-properties
+   * 
+   * @return return project configuration properties
+   */
   Map<String, String> getConfigurationProperties();
+
+  /**
+   * User properties are stored in the <code>.mvn/maven.config</code> file with <code>-Dkey=value</code>, they are
+   * therefore not persisted in the project configuration
+   * 
+   * @return the user properties
+   */
+  Map<String, String> getUserProperties();
 
   boolean isResolveWorkspaceProjects();
 


### PR DESCRIPTION
The project config already accounts for the MultiModuleProjectDirectory and project configured properties.

This enhances this facility by also taking into account user properties from the .mvn/maven.config and make them available.