### PR TITLE
Don't show the DiscoveryWizard if nothing new was discovered

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/MavenProjectConfigurator.java
@@ -65,7 +65,7 @@ public class MavenProjectConfigurator implements ProjectConfigurator {
         }
 
         private CumulativeMappingDiscoveryJob() {
-            super(Collections.<IProject>emptyList());
+          super(Collections.<IProject> emptyList(), true);
             this.toProcess = Collections.synchronizedSet(new HashSet<IProject>());
         }
 

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/ImportMavenProjectsJob.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/ImportMavenProjectsJob.java
@@ -79,7 +79,7 @@ public class ImportMavenProjectsJob extends MavenWorkspaceJob {
     try {
       importOperation.run(monitor);
       List<IProject> createdProjects = importOperation.getCreatedProjects();
-      MappingDiscoveryJob discoveryJob = new MappingDiscoveryJob(createdProjects);
+      MappingDiscoveryJob discoveryJob = new MappingDiscoveryJob(createdProjects, true);
       discoveryJob.schedule();
     } catch(InvocationTargetException e) {
       return AbstractCreateMavenProjectsOperation.toStatus(e);

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenProjectWizard.java
@@ -264,7 +264,7 @@ public class MavenProjectWizard extends AbstractMavenProjectWizard implements IN
               NLS.bind(Messages.wizardProjectJobFailed, projectName), result.getMessage()));
         }
 
-        MappingDiscoveryJob discoveryJob = new MappingDiscoveryJob(job.getCreatedProjects());
+        MappingDiscoveryJob discoveryJob = new MappingDiscoveryJob(job.getCreatedProjects(), true);
         discoveryJob.schedule();
 
       }

--- a/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/markers/DiscoveryWizardResolution.java
+++ b/org.eclipse.m2e.discovery/src/org/eclipse/m2e/internal/discovery/markers/DiscoveryWizardResolution.java
@@ -68,7 +68,7 @@ public class DiscoveryWizardResolution extends MavenProblemResolution {
   public void fix(IMarker[] markers, IDocument document, IProgressMonitor monitor) {
     Set<IProject> projects = Stream.of(markers).map(m -> m.getResource().getProject()).collect(Collectors.toSet());
 
-    MappingDiscoveryJob discoveryJob = new MappingDiscoveryJob(projects);
+    MappingDiscoveryJob discoveryJob = new MappingDiscoveryJob(projects, false);
     discoveryJob.schedule();
   }
 }

--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Profiles Management
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.1.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",


### PR DESCRIPTION
Currently we show a DiscoveryWizard after project import, even if no new items are discovered. This is not really helpful for the user, as the only thing one can do is to completely ignore an execution (what is always possible from the pom afterwards) or cancel the dialog.

This changes the project import to not show the dialog if nothing was found, but shows the full dialog if the user manually triggers the discovery.