### PR TITLE
Do not "warn" on incomplete mappings

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/UserInterfacePreferencePage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/UserInterfacePreferencePage.java
@@ -47,8 +47,5 @@ public class UserInterfacePreferencePage extends FieldEditorPreferencePage imple
     parent = getFieldEditorParent();
     addField(new BooleanFieldEditor(MavenPreferenceConstants.P_DEFAULT_POM_EDITOR_PAGE, Messages.pomEditorDefaultPage,
         parent));
-
-    addField(new BooleanFieldEditor(MavenPreferenceConstants.P_WARN_INCOMPLETE_MAPPING,
-        Messages.MavenPreferencePage_warnIncompleteMapping, getFieldEditorParent()));
   }
 }

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
@@ -35,13 +35,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.Wizard;
-import org.eclipse.swt.SWT;
 import org.eclipse.ui.IImportWizard;
 import org.eclipse.ui.IWorkbench;
 
@@ -55,7 +51,6 @@ import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.IMavenDiscoveryP
 import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.LifecycleMappingDiscoveryRequest;
 import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.MojoExecutionMappingConfiguration.MojoExecutionMappingRequirement;
 import org.eclipse.m2e.core.internal.lifecyclemapping.model.LifecycleMappingMetadataSource;
-import org.eclipse.m2e.core.internal.preferences.MavenPreferenceConstants;
 import org.eclipse.m2e.core.lifecyclemapping.model.PluginExecutionAction;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
@@ -114,7 +109,7 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
 
   @Override
   public boolean performFinish() {
-    if(lifecycleMappingPage != null && !lifecycleMappingPage.isMappingComplete() && !warnIncompleteMapping()) {
+    if(lifecycleMappingPage != null && !lifecycleMappingPage.isMappingComplete()) {
       return false;
     }
 
@@ -249,23 +244,4 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
     return mappingDiscoveryRequest;
   }
 
-  private boolean skipIncompleteWarning() {
-    return M2EUIPluginActivator.getDefault().getPreferenceStore()
-        .getBoolean(MavenPreferenceConstants.P_WARN_INCOMPLETE_MAPPING);
-  }
-
-  private boolean warnIncompleteMapping() {
-    if(!skipIncompleteWarning()) {
-      MessageDialogWithToggle dialog = MessageDialogWithToggle.open(MessageDialog.CONFIRM, getShell(),
-          Messages.MavenImportWizard_titleIncompleteMapping, Messages.MavenImportWizard_messageIncompleteMapping,
-          Messages.MavenImportWizard_hideWarningMessage, false, null, null, SWT.SHEET);
-      if(dialog.getReturnCode() == Window.OK) {
-        M2EUIPluginActivator.getDefault().getPreferenceStore()
-            .setValue(MavenPreferenceConstants.P_WARN_INCOMPLETE_MAPPING, dialog.getToggleState());
-        return true;
-      }
-      return false;
-    }
-    return true;
-  }
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants.java
@@ -93,8 +93,6 @@ public interface MavenPreferenceConstants {
   /** boolean */
   String P_FULL_INDEX = PREFIX + "fullIndex"; //$NON-NLS-1$
 
-  String P_WARN_INCOMPLETE_MAPPING = PREFIX + "warn_incomplete_mapping"; //$NON-NLS-1$
-
   /** boolean **/
   String P_DEFAULT_POM_EDITOR_PAGE = "eclipse.m2.defaultPomEditorPage"; //$NON-NLS-1$
 


### PR DESCRIPTION
M2E has had a dialog that warns the user if there are "incomplete" mappings, but actually the user can't do anything useful. Also m2e for a while handles missing mappings with reduced severity (e.g. by just add a warning marker) and now even executes them by default.

Because of this, the preference an dialog has even lesser value and only disturbs the user and is therefore obsolete.