### PR TITLE
Optimize the layout of the DiscoveryDialog

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
@@ -32,10 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jface.dialogs.Dialog;
-import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.TreeColumnLayout;
-import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
@@ -52,16 +49,19 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.events.ExpandEvent;
+import org.eclipse.swt.events.ExpandListener;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.FontMetrics;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.BorderData;
+import org.eclipse.swt.layout.BorderLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.ExpandBar;
+import org.eclipse.swt.widgets.ExpandItem;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
@@ -125,8 +125,6 @@ public class LifecycleMappingPage extends WizardPage {
 
   private final Set<ILifecycleMappingLabelProvider> ignoreWorkspace = new HashSet<>();
 
-  private Label errorCountLabel;
-
   /**
    * Create the wizard.
    */
@@ -145,12 +143,55 @@ public class LifecycleMappingPage extends WizardPage {
   @Override
   public void createControl(Composite parent) {
     Composite container = new Composite(parent, SWT.NULL);
-
     setControl(container);
-    container.setLayout(new GridLayout(1, false));
+    container.setLayout(new BorderLayout());
+    BorderData tableBorderData = new BorderData(SWT.CENTER);
+    tableBorderData.hHint = 300;
+    tableBorderData.wHint = 800;
+    createMappingTree(container).setLayoutData(tableBorderData);
+    createDescription(container).setLayoutData(new BorderData(SWT.BOTTOM));
+  }
+
+  private Control createDescription(Composite parent) {
+    ExpandBar bar = new ExpandBar(parent, SWT.NONE);
+    Composite container = new Composite(bar, SWT.NULL);
+    container.setLayout(new BorderLayout());
+    details = new Text(container, SWT.WRAP | SWT.READ_ONLY | SWT.V_SCROLL);
+    details.setLayoutData(new BorderData(SWT.CENTER));
+    Composite licenseContainer = new Composite(container, SWT.NULL);
+    new Label(licenseContainer, SWT.NONE).setText(Messages.LifecycleMappingPage_licenseLabel);
+    license = new Text(licenseContainer, SWT.READ_ONLY);
+    license.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+    licenseContainer.setLayout(new GridLayout(2, false));
+    licenseContainer.setLayoutData(new BorderData(SWT.BOTTOM));
+
+    ExpandItem expandItem = new ExpandItem(bar, SWT.NONE, 0);
+    expandItem.setText(Messages.LifecycleMappingPage_descriptionLabel);
+    expandItem.setHeight(120);
+    expandItem.setControl(container);
+    expandItem.setExpanded(true);
+    //Workaround for https://github.com/eclipse-platform/eclipse.platform.swt/issues/551 
+    bar.addExpandListener(new ExpandListener() {
+
+      @Override
+      public void itemExpanded(ExpandEvent e) {
+        itemCollapsed(e);
+      }
+
+      @Override
+      public void itemCollapsed(ExpandEvent e) {
+        bar.requestLayout();
+      }
+    });
+    return bar;
+  }
+
+  private Composite createMappingTree(Composite parent) {
+    Composite container = new Composite(parent, SWT.NULL);
+    container.setLayout(new BorderLayout());
 
     Composite treeViewerContainer = new Composite(container, SWT.NULL);
-    GridDataFactory.fillDefaults().grab(true, false).applyTo(treeViewerContainer);
+    treeViewerContainer.setLayoutData(new BorderData(SWT.CENTER));
     TreeColumnLayout treeColumnLayout = new TreeColumnLayout();
     treeViewerContainer.setLayout(treeColumnLayout);
 
@@ -209,7 +250,6 @@ public class LifecycleMappingPage extends WizardPage {
             }
           }
           getViewer().refresh(true);
-          updateErrorCount();
           getContainer().updateButtons();
         }
       }
@@ -466,14 +506,11 @@ public class LifecycleMappingPage extends WizardPage {
       }
     });
 
-    Composite composite = new Composite(container, SWT.NONE);
-    composite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-    composite.setLayout(new GridLayout(3, false));
-
-    errorCountLabel = new Label(composite, SWT.NONE);
-    errorCountLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-
-    Button btnNewButton_1 = new Button(composite, SWT.NONE);
+    Composite buttons = new Composite(container, SWT.NONE);
+    buttons.setLayoutData(new BorderData(SWT.BOTTOM));
+    buttons.setLayout(new GridLayout(3, false));
+    new Label(buttons, SWT.NONE).setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+    Button btnNewButton_1 = new Button(buttons, SWT.NONE);
     btnNewButton_1.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
       mappingConfiguration.clearSelectedProposals();
       ignore.clear();
@@ -481,11 +518,10 @@ public class LifecycleMappingPage extends WizardPage {
       ignoreWorkspace.clear();
       treeViewer.refresh();
       getWizard().getContainer().updateButtons(); // needed to enable/disable Finish button
-      updateErrorCount();
     }));
     btnNewButton_1.setText(Messages.LifecycleMappingPage_deselectAllButton);
 
-    autoSelectButton = new Button(composite, SWT.NONE);
+    autoSelectButton = new Button(buttons, SWT.NONE);
     autoSelectButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
       resetDetails();
       ignore.clear();
@@ -494,34 +530,7 @@ public class LifecycleMappingPage extends WizardPage {
       discoverProposals();
     }));
     autoSelectButton.setText(Messages.LifecycleMappingPage_autoSelectButton);
-
-    // Provide a reasonable height for the details box
-    GC gc = new GC(container);
-    gc.setFont(JFaceResources.getDialogFont());
-    FontMetrics fontMetrics = gc.getFontMetrics();
-    gc.dispose();
-
-    Group grpDetails = new Group(container, SWT.NONE);
-    grpDetails.setLayout(new GridLayout(1, false));
-    grpDetails.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
-    grpDetails.setText(Messages.LifecycleMappingPage_descriptionLabel);
-
-    details = new Text(grpDetails, SWT.WRAP | SWT.READ_ONLY | SWT.V_SCROLL);
-    GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
-    gd.heightHint = Dialog.convertHeightInCharsToPixels(fontMetrics, 3);
-    gd.minimumHeight = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
-    details.setLayoutData(gd);
-
-    Group grpLicense = new Group(container, SWT.NONE);
-    grpLicense.setLayout(new GridLayout(1, false));
-    grpLicense.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
-    grpLicense.setText(Messages.LifecycleMappingPage_licenseLabel);
-
-    license = new Text(grpLicense, SWT.READ_ONLY);
-    gd = new GridData(SWT.FILL, SWT.FILL, true, true);
-    gd.heightHint = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
-    gd.minimumHeight = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
-    license.setLayoutData(gd);
+    return container;
   }
 
   /**
@@ -559,7 +568,6 @@ public class LifecycleMappingPage extends WizardPage {
     loading = false;
     treeViewer.refresh();
     getWizard().getContainer().updateButtons(); // needed to enable/disable Finish button
-    updateErrorCount();
   }
 
   @Override
@@ -574,7 +582,6 @@ public class LifecycleMappingPage extends WizardPage {
         mappingConfiguration.autoCompleteMapping();
       }
       treeViewer.setInput(mappingConfiguration);
-      updateErrorCount();
     }
   }
 
@@ -632,24 +639,6 @@ public class LifecycleMappingPage extends WizardPage {
    */
   public Collection<ILifecycleMappingLabelProvider> getIgnoreWorkspace() {
     return ignoreWorkspace;
-  }
-
-  /*
-   * Update the error summary
-   */
-  private void updateErrorCount() {
-    int count = 0;
-    for(TreeItem item : treeViewer.getTree().getItems()) {
-      ILifecycleMappingLabelProvider prov = (ILifecycleMappingLabelProvider) item.getData();
-      if(!isHandled(prov)) {
-        if(prov instanceof AggregateMappingLabelProvider aggProv) {
-          count += aggProv.getChildren().length;
-        } else {
-          ++count;
-        }
-      }
-    }
-    errorCountLabel.setText(NLS.bind(Messages.LifecycleMappingPage_numErrors, String.valueOf(count)));
   }
 
   /*

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
@@ -88,7 +88,7 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
       LifecycleMappingDiscoveryRequest mappingDiscoveryRequest) {
     this.projects = projects;
     this.mappingDiscoveryRequest = mappingDiscoveryRequest;
-    setNeedsProgressMonitor(true);
+    setNeedsProgressMonitor(false);
     setWindowTitle(Messages.MavenDiscoveryProposalWizard_title);
   }
 


### PR DESCRIPTION
Currently the DiscoveryLayout reacts very bad to size changes:
- if just a few items are to be displayed, the dialog is shrinked and content is hard to read
- if there are a lot of items the dialog grows very high but is till hard to read

This changes the layout and makes it much more lighter:
- no groups
- grow and shrink when window size changes
- use a collapsible area for the description
- make the initial dialog larger

## Before
![discover_layout_before](https://user-images.githubusercontent.com/1331477/218717837-e92e79ed-5682-4fb0-b198-c9e03db35eaf.png)

## After

![grafik](https://user-images.githubusercontent.com/1331477/219002686-5552ccee-c15f-4f47-8c1d-f60e510e9873.png)

