### PR TITLE
Add verify shortcut and sort shortcuts by their phase

### DIFF
--- a/org.eclipse.m2e.launching/plugin.properties
+++ b/org.eclipse.m2e.launching/plugin.properties
@@ -12,12 +12,14 @@ m2.popup.pomFileWithDialog.label=Maven build...
 
 m2.popup.lifecycle.install=Maven install
 m2.popup.lifecycle.clean=Maven clean
+m2.popup.lifecycle.verify=Maven verify
 m2.popup.lifecycle.test=Maven test
 m2.popup.lifecycle.generate-sources=Maven generate-sources
 
 m2.shortcut.description.run=Run Maven Build
 m2.shortcut.description.install=Run Maven Install
 m2.shortcut.description.clean=Run Maven Clean
+m2.shortcut.description.verify=Run Maven Verify
 m2.shortcut.description.test=Run Maven Test
 m2.shortcut.description.generate-sources=Run Maven Generate Sources
 

--- a/org.eclipse.m2e.launching/plugin.xml
+++ b/org.eclipse.m2e.launching/plugin.xml
@@ -94,6 +94,56 @@
            </enablement>
         </contextualLaunch>
      </shortcut>
+     <shortcut id="org.eclipse.m2e.actions.LifeCycleClean"
+               class="org.eclipse.m2e.actions.ExecutePomAction:clean"
+               icon="icons/m2.gif"
+               label="%m2.popup.lifecycle.clean"
+               modes="run,debug">
+        <contextualLaunch>
+           <contextLabel label="%m2.popup.lifecycle.clean" mode="run"/>
+           <contextLabel label="%m2.popup.lifecycle.clean" mode="debug"/>
+           <enablement>
+              <count value="1"/>
+              <iterate>
+                 <or>
+                    <adapt type="org.eclipse.core.resources.IFile">
+                       <test property="org.eclipse.core.resources.name" value="pom.xml"/>
+                    </adapt>
+                    <adapt type="org.eclipse.core.resources.IProject">
+                       <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
+                    </adapt>
+                    <adapt type="org.eclipse.m2e.core.embedder.IMavenExecutableLocation">
+                    </adapt>
+                 </or>
+              </iterate>
+           </enablement>
+        </contextualLaunch>
+     </shortcut>
+     <shortcut id="org.eclipse.m2e.actions.LifeCycleGenerateSources"
+           class="org.eclipse.m2e.actions.ExecutePomAction:generate-sources"
+           icon="icons/m2.gif"
+           label="%m2.popup.lifecycle.generate-sources"
+           modes="run,debug">
+        <contextualLaunch>
+           <contextLabel label="%m2.popup.lifecycle.generate-sources" mode="run"/>
+           <contextLabel label="%m2.popup.lifecycle.generate-sources" mode="debug"/>
+           <enablement>
+              <count value="1"/>
+              <iterate>
+                 <or>
+                    <adapt type="org.eclipse.core.resources.IFile">
+                       <test property="org.eclipse.core.resources.name" value="pom.xml"/>
+                    </adapt>
+                    <adapt type="org.eclipse.core.resources.IProject">
+                       <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
+                    </adapt>
+                    <adapt type="org.eclipse.m2e.core.embedder.IMavenExecutableLocation">
+                    </adapt>
+                 </or>
+              </iterate>
+           </enablement>
+        </contextualLaunch>
+     </shortcut>
      <shortcut id="org.eclipse.m2e.actions.LifeCycleInstall"
                class="org.eclipse.m2e.actions.ExecutePomAction:install"
                icon="icons/m2.gif"
@@ -144,39 +194,14 @@
            </enablement>
         </contextualLaunch>
      </shortcut>
-     <shortcut id="org.eclipse.m2e.actions.LifeCycleGenerateSources"
-           class="org.eclipse.m2e.actions.ExecutePomAction:generate-sources"
-           icon="icons/m2.gif"
-           label="%m2.popup.lifecycle.generate-sources"
-           modes="run,debug">
-        <contextualLaunch>
-           <contextLabel label="%m2.popup.lifecycle.generate-sources" mode="run"/>
-           <contextLabel label="%m2.popup.lifecycle.generate-sources" mode="debug"/>
-           <enablement>
-              <count value="1"/>
-              <iterate>
-                 <or>
-                    <adapt type="org.eclipse.core.resources.IFile">
-                       <test property="org.eclipse.core.resources.name" value="pom.xml"/>
-                    </adapt>
-                    <adapt type="org.eclipse.core.resources.IProject">
-                       <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
-                    </adapt>
-                    <adapt type="org.eclipse.m2e.core.embedder.IMavenExecutableLocation">
-                    </adapt>
-                 </or>
-              </iterate>
-           </enablement>
-        </contextualLaunch>
-     </shortcut>
-     <shortcut id="org.eclipse.m2e.actions.LifeCycleClean"
-               class="org.eclipse.m2e.actions.ExecutePomAction:clean"
+     <shortcut id="org.eclipse.m2e.actions.LifeCycleVerify"
+               class="org.eclipse.m2e.actions.ExecutePomAction:verify"
                icon="icons/m2.gif"
-               label="%m2.popup.lifecycle.clean"
+               label="%m2.popup.lifecycle.verify"
                modes="run,debug">
         <contextualLaunch>
-           <contextLabel label="%m2.popup.lifecycle.clean" mode="run"/>
-           <contextLabel label="%m2.popup.lifecycle.clean" mode="debug"/>
+           <contextLabel label="%m2.popup.lifecycle.verify" mode="run"/>
+           <contextLabel label="%m2.popup.lifecycle.verify" mode="debug"/>
            <enablement>
               <count value="1"/>
               <iterate>


### PR DESCRIPTION
Currently one can clean, generate-resources, test, install, but integration tests and additional checks usually run in the verify phase.

This adds a new shortcut "Maven verify" and also sort the shortcuts by their lifcycle-phases order.