### PR TITLE
[TP] Revert to gson 2.9.1

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -51,7 +51,7 @@ MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.core
 Import-Package: com.google.common.base;version="30.1.0",
  com.google.common.cache,
- com.google.gson;version="[2.10.0,3.0.0)",
+ com.google.gson;version="[2.9.0,3.0.0)",
  javax.inject;version="1.0.0",
  org.apache.commons.cli;version="1.4.0",
  org.apache.commons.codec.digest;version="[1.14.0,2.0.0)",

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenArtifactIdentifier.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/MavenArtifactIdentifier.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleEvent;
@@ -114,7 +115,7 @@ public class MavenArtifactIdentifier {
       HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
       JsonObject container = new Gson().fromJson(response.body(), JsonObject.class);
       JsonArray docs = container.get("response").getAsJsonObject().get("docs").getAsJsonArray();
-      return docs.asList().stream().map(JsonElement::getAsJsonObject).map(obj -> {
+      return StreamSupport.stream(docs.spliterator(), false).map(JsonElement::getAsJsonObject).map(obj -> {
         String g = obj.get("g").getAsString();
         String a = obj.get("a").getAsString();
         String v = obj.get("v").getAsString();

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -82,7 +82,7 @@
 				<dependency>
 					<groupId>com.google.code.gson</groupId>
 					<artifactId>gson</artifactId>
-					<version>2.10.1</version>
+					<version>2.9.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
Currently gson 2.10.1 causes trouble in the SimRel. To not further contribute one more possible source of trouble, revert to gson 2.9.