### PR TITLE
Only trigger (incremental) builds if there are relevant changes

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -70,6 +70,12 @@ public interface IMavenProjectFacade extends IMavenExecutableLocation {
   IPath getProjectRelativePath(String resourceLocation);
 
   /**
+   * @return the full, absolute path of this project where build results are placed relative to the workspace or
+   *         <code>null</code> if the directory cannot be determined or is outside of the workspace.
+   */
+  IPath getBuildOutputLocation();
+
+  /**
    * Returns the full, absolute path of this project maven build output directory relative to the workspace or null if
    * maven build output directory cannot be determined or outside of the workspace.
    */


### PR DESCRIPTION
Currently any file change in a project can trigger a rebuild of that project, even if it is from the build-output or from child modules. This can produces "endless" loops of the build and produces a lot of build rush if automatic refresh is activated for the workspace or resources are refreshed on access. On the other hand, without autorefresh some changes are never detected.

This changes the following:
- check if a delta only contains irrelevant deltas and then do not trigger an incremental maven build
- refresh the whole project first to discover new files generated
- if auto refresh is enabled, do not manually refresh but use the native refresh events

This can considerably reduce the number of rebuilds happening.

Fix https://github.com/eclipse-m2e/m2e-core/issues/1275