### PR TITLE
Release M2E 2.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## 2.2.0
 
-* 📅 Release Date: _expected_ end of Februar 2023
+* 📅 Release Date: 28th February 2023
 
 ### Mojos without a mapping are now executed by default in incremental builds
 


### PR DESCRIPTION
The value of `<M2E_RELEASE>` is `2.2.0`.
The value of `<M2E_PREVIOUS_RELEASE>` is `2.1.2` and the value of `<M2E_RELEASE_WO_DOTS>` is `220`
The value of `<CONTAINING_SIMREL>` is `2023_-03`

## Release process steps:
- [ ] Add/finalize and submit an entry in the `RELEASE_NOTES.md` dedicated to this release (done with this PR).
- [x] Run `m2e-promote-snapshots-to-release` M2E Jenkins job with parameter `releaseVersion` value `<M2E_RELEASE>`
- [x] Update M2E's contribution to the Eclipse Simultaneous Release:
https://git.eclipse.org/c/simrel/org.eclipse.simrel.build.git/tree/m2e.aggrcon, usually it is sufficient to update the repo URL and description.
- [ ] Create and push git tag `<M2E_RELEASE>` on the release commit (usually this PR's commit).
- [x] `Create a new Release` at the M2E project website: https://projects.eclipse.org/projects/technology.m2e
Name: <M2E_RELEASE>, Release date: default is today, which is usually fine.
In the `Review Documentation` section add the `New & Notworthy URL`:
https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS>
- [ ] Create a new GitHub release, based on the just pushed `<M2E_RELEASE>-tag
- [ ] Send the following announcement to the [M2E-dev mailing-list](https://accounts.eclipse.org/mailing-list/m2e-dev):
```
M2E <M2E_RELEASE> is released!

📥 P2 repository is available at https://download.eclipse.org/technology/m2e/releases/<M2E_RELEASE>
(and it also mirrored at https://download.eclipse.org/technology/m2e/releases/latest/ and referenced by Marketplace Entry https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide until a newer release is promoted)
🏷️ Git tag is <M2E_RELEASE>: https://github.com/eclipse-m2e/m2e-core/tree/<M2E_RELEASE>
📝 Release notes are available in https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS> ; full changelog is https://github.com/eclipse-m2e/m2e-core/compare/<M2E_PREVIOUS_RELEASE>...<M2E_RELEASE>
👔 PMI Release entry is at https://projects.eclipse.org/projects/technology.m2e/releases/<M2E_RELEASE>
🧑‍🤝‍🧑 M2E <M2E_RELEASE> will be part of Eclipse SimRel <CONTAINING_SIMREL>
🙏 Special thanks to to everybody who contributed to this release!

Greetings
```
