### PR TITLE
Slightly adjust the build files

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,10 +41,11 @@ jobs:
       with:
        run: mvn clean verify -Pits -Dtycho.p2.baselineMode=failCommon --batch-mode
     - name: Upload Test Results
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.os }}
-        if-no-files-found: error
+        if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
   event_file:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -2,5 +2,6 @@
 --errors
 --update-snapshots
 --no-transfer-progress
--Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true
+--fail-at-end
 -Dtycho.resolver.classic=false
+-Dtycho.localArtifacts=ignore


### PR DESCRIPTION
Local artifacts should be ignored, test failures should *not* be ignored instead adjust the action to always upload the test results and let the build just fail at the end.