### PR TITLE
Remove unactionable warnings when a plugin is ignored

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.0.6.qualifier
+Bundle-Version: 2.0.7.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml
+++ b/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml
@@ -59,9 +59,7 @@
         <versionRange>[3.4,)</versionRange>
       </pluginExecutionFilter>
       <action>
-        <ignore>
-          <message>maven-dependency-plugin (some goals) are ignored by m2e.</message>
-        </ignore>
+        <ignore />
       </action>
     </pluginExecution>
     <pluginExecution>
@@ -127,9 +125,7 @@
         <versionRange>[1.0-alpha-1,)</versionRange>
       </pluginExecutionFilter>
       <action>
-        <ignore>
-          <message>maven-enforcer-plugin (goal "enforce") is ignored by m2e.</message>
-        </ignore>
+        <ignore />
       </action>
     </pluginExecution>
     <pluginExecution>
@@ -142,9 +138,7 @@
         <versionRange>[1.6-SONATYPE-r940877,)</versionRange>
       </pluginExecutionFilter>
       <action>
-        <ignore>
-          <message>maven-invoker-plugin (goal "install") is ignored by m2e.</message>
-        </ignore>
+        <ignore />
       </action>
     </pluginExecution>
     <pluginExecution>
@@ -157,9 +151,7 @@
         </goals>
       </pluginExecutionFilter>
       <action>
-        <ignore>
-          <message>maven-remote-resources-plugin (goal "process") is ignored by m2e.</message>
-        </ignore>
+        <ignore />
       </action>
     </pluginExecution>
     <pluginExecution>

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core</artifactId>
-	<version>2.0.6-SNAPSHOT</version>
+	<version>2.0.7-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>


### PR DESCRIPTION
Fixes #1298

Those messages appear as warnings in the editor and in the problems view, but there is nothing the user can do to fix them. So we just remove them.