### PR TITLE
[Launch] Only display JRE version if IProject is existing IJavaProject

### DIFF
--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenJRETab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenJRETab.java
@@ -59,7 +59,7 @@ public class MavenJRETab extends JavaJRETab {
     File pomDir = MavenLaunchDelegate.getPomDirectory(getLaunchConfiguration());
     return MavenLaunchDelegate.getContainer(pomDir) //
         .map(IContainer::getProject).filter(IProject::exists) //
-        .map(JavaCore::create).orElse(null);
+        .map(JavaCore::create).filter(IJavaProject::exists).orElse(null);
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/eclipse-m2e/m2e-core/issues/1293 respectively the missing part https://github.com/eclipse-m2e/m2e-core/issues/1293#issuecomment-1454513474

@laeubi FYI, do you want to check this?