### PR TITLE
Disable "Add ... dependency" quick fix due to bad user feedback

### DIFF
--- a/org.eclipse.m2e.jdt.ui/plugin.xml
+++ b/org.eclipse.m2e.jdt.ui/plugin.xml
@@ -336,6 +336,7 @@
             label="java">
       </keyword>
    </extension>
+   <!--
    <extension
          point="org.eclipse.jdt.ui.quickFixProcessors">
       <quickFixProcessor
@@ -343,7 +344,8 @@
             id="org.eclipse.m2e.jdt.ui.quickFixProcessor1"
             name="M2Eclipse">
       </quickFixProcessor>
-   </extension>   
+   </extension>
+   -->
 	<extension point="org.eclipse.ui.perspectiveExtensions">
 	   <perspectiveExtension
 	         targetID="org.eclipse.jdt.ui.JavaPerspective">


### PR DESCRIPTION
The m2e _"Add ... dependency"_ quick fix seems to have some issues that should be fixed before re-enabling it: see issue https://github.com/eclipse-m2e/m2e-core/issues/1328

Feedback from dissatisfied users:
- https://github.com/eclipse-m2e/m2e-core/issues/879#issuecomment-1470177817
- https://github.com/eclipse-m2e/m2e-core/issues/879#issuecomment-1478251753
- https://stackoverflow.com/q/75817981/6505250