### PR TITLE
Always add resource folders with optional attribute

### DIFF
--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.0.6.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",
@@ -13,7 +13,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.launching,
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)"
-Service-Component: OSGI-INF/org.eclipse.m2e.jdt.internal.JavaProjectAdapterFactory.xml
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.m2e.jdt.MavenJdtPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
@@ -22,3 +21,4 @@ Import-Package: com.google.gson;version="[2.9.1,3.0.0)",
  org.apache.commons.codec.digest;version="[1.14.0,2.0.0)",
  org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.m2e.jdt
+Service-Component: OSGI-INF/org.eclipse.m2e.jdt.internal.JavaProjectAdapterFactory.xml


### PR DESCRIPTION
Resource folders should be handled like a source folder that is always added with optional=true (even if the folder is not present yet) so they appear in the project as soon as they are created.

Fix https://github.com/eclipse-m2e/m2e-core/issues/1353