### PR TITLE
Support slf4j.api version 2 in m2e.maven.runtime

### DIFF
--- a/m2e-maven-runtime/.gitignore
+++ b/m2e-maven-runtime/.gitignore
@@ -1,4 +1,3 @@
 .classpath
 .settings/
 .project
-META-INF/

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -118,6 +118,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+			<version>2.0.7</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -173,8 +174,7 @@
 								org.eclipse.sisu.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version}
 							Import-Package: \
 								org.slf4j;version="[1.7.31,3.0.0)",\
-								org.slf4j.spi;version="[1.7.31,3.0.0)",\
-								org.slf4j.helpers;version="[1.7.31,3.0.0)",\
+								org.slf4j.*;version="[1.7.31,3.0.0)",\
 								javax.inject;version="1.0.0",\
 								javax.annotation;version="[1.2.0,2.0.0)", \
 								org.apache.commons.cli;version="[1.4.0,2.0.0)"

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/java/org/eclipse/m2e/slf4j2/provider/MavenSLF4JProvider.java
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/java/org/eclipse/m2e/slf4j2/provider/MavenSLF4JProvider.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2023, 2023 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.slf4j2.provider;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.helpers.NOPMDCAdapter;
+import org.slf4j.impl.SimpleLoggerFactory;
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+public class MavenSLF4JProvider implements SLF4JServiceProvider {
+	// Based on org.slf4j.simple.SimpleServiceProvider from org.slf4j:slf4j-simple
+
+	private ILoggerFactory loggerFactory;
+	private final IMarkerFactory markerFactory = new BasicMarkerFactory();
+	private final MDCAdapter mdcAdapter = new NOPMDCAdapter();
+
+	@Override
+	public ILoggerFactory getLoggerFactory() {
+		return loggerFactory;
+	}
+
+	@Override
+	public IMarkerFactory getMarkerFactory() {
+		return markerFactory;
+	}
+
+	@Override
+	public MDCAdapter getMDCAdapter() {
+		return mdcAdapter;
+	}
+
+	@Override
+	public String getRequestedApiVersion() {
+		// Declare the version of the maximum SLF4J API this implementation is
+		// compatible with. The value of this field is modified with each major release.
+		return "2.0.99";
+	}
+
+	@Override
+	public void initialize() {
+		loggerFactory = new SimpleLoggerFactory();
+	}
+
+}

--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+org.eclipse.m2e.slf4j2.provider.MavenSLF4JProvider

--- a/m2e-maven-runtime/pom.xml
+++ b/m2e-maven-runtime/pom.xml
@@ -66,7 +66,7 @@
 								-nouses: true
 								-nodefaultversion: true
 								-noextraheaders: true
-								-snapshot: ${buildQualifier}
+								-snapshot: ${def;buildQualifier;qualifier}
 								-removeheaders: Private-Package
 
 								Import-Package: !*

--- a/org.eclipse.m2e.core/.project
+++ b/org.eclipse.m2e.core/.project
@@ -21,12 +21,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.ds.core.builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.pde.ds.core.builder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/org.eclipse.m2e.rcptt.tests/.project
+++ b/org.eclipse.m2e.rcptt.tests/.project
@@ -6,12 +6,12 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.rcptt.core.builder.q7Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.rcptt.core.builder.q7Builder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>


### PR DESCRIPTION
As part of the new SLF4J-2 major version the mechanism to connect the slf4j.api with a logging back-end has been changed from the static-binding mechanism to Java's ServiceLoader mechanism [1].

In order to support slf4j.api-2 a provider for the maven-slf4j-provider (the logging backend provided/used by Maven based on slf4j-simple) is needed. Because maven-slf4j-provider does not provide it itself we have to supply it for m2e.maven.runtime.

Additionally make the qualifier computation more robust in the workspace.

[1] - https://www.slf4j.org/faq.html#changesInVersion200
