### PR TITLE
Unify, fix and add missing license headers in m2e.pde Plug-ins

### DIFF
--- a/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/BNDConnectorTest.java
+++ b/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/BNDConnectorTest.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
  * Copyright (c) 2022, 2022 Hannes Wellmann and others
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Hannes Wellmann - initial API and implementation
+ *   Hannes Wellmann - initial API and implementation
  *******************************************************************************/
 
 package org.eclipse.m2e.pde.connector.tests;

--- a/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/FelixConnectorTest.java
+++ b/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/FelixConnectorTest.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
  * Copyright (c) 2022, 2022 Hannes Wellmann and others
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Hannes Wellmann - initial API and implementation
+ *   Hannes Wellmann - initial API and implementation
  *******************************************************************************/
 
 package org.eclipse.m2e.pde.connector.tests;

--- a/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/TychoConnectorTest.java
+++ b/org.eclipse.m2e.pde.connector.tests/src/org/eclipse/m2e/pde/connector/tests/TychoConnectorTest.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
  * Copyright (c) 2022, 2022 Hannes Wellmann and others
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Hannes Wellmann - initial API and implementation
+ *   Hannes Wellmann - initial API and implementation
  *******************************************************************************/
 
 package org.eclipse.m2e.pde.connector.tests;

--- a/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Connector
 Bundle-SymbolicName: org.eclipse.m2e.pde.connector;singleton:=true
-Bundle-Version: 2.1.2.qualifier
+Bundle-Version: 2.1.300.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.connector
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEBuildProjectFileResolver.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEBuildProjectFileResolver.java
@@ -3,7 +3,7 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEMavenBundlePluginConfigurator.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEMavenBundlePluginConfigurator.java
@@ -1,12 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Sonatype, Inc.
+ * Copyright (c) 2008, 2022 Sonatype, Inc. and others
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sonatype, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.connector;
 

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEProjectHelper.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEProjectHelper.java
@@ -1,12 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Sonatype, Inc.
+ * Copyright (c) 2011, 2022 Sonatype, Inc. and others
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sonatype, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.connector;
 

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/TychoDSConfigurator.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/TychoDSConfigurator.java
@@ -1,15 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2022 Konrad Windszus
+ * Copyright (c) 2022 Konrad Windszus and others
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Konrad Windszus
+ *   Konrad Windszus - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.connector;
 

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/TychoLifecycleMapping.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/TychoLifecycleMapping.java
@@ -1,15 +1,14 @@
 /*******************************************************************************
  * Copyright (c) 2022 Christoph Läubrich and others
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - Initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.connector;
 

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.2.0.qualifier"
+      version="2.2.100.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.400.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/Activator.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/Activator.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/BNDInstructions.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/BNDInstructions.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020, 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/CacheManager.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/CacheManager.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/DependencyDepth.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/DependencyDepth.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/DependencyNodeGenerator.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/DependencyNodeGenerator.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/DomXmlFeature.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/DomXmlFeature.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenFeaturePlugin.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenFeaturePlugin.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenPluginSourcePathLocator.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenPluginSourcePathLocator.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 
 import java.io.File;

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenPomFeatureModel.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenPomFeatureModel.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetDependency.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetDependency.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021, 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetDependencyFilter.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetDependencyFilter.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetFeature.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetFeature.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 
 package org.eclipse.m2e.pde.target;

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
- *      Patrick Ziegler - Support contribution of Eclipse features via Maven repositories
+ *   Christoph Läubrich - initial API and implementation
+ *   Patrick Ziegler - Support contribution of Eclipse features via Maven repositories
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocationFactory.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocationFactory.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetRepository.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetRepository.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MissingMetadataMode.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MissingMetadataMode.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/TargetBundles.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/TargetBundles.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/TemplateFeatureModel.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/TemplateFeatureModel.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/WorkspaceArtifact.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/WorkspaceArtifact.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.0.200.qualifier
+Bundle-Version: 2.0.300.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/DependencyNodeAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/DependencyNodeAdapterFactory.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.adapter;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetAdapterFactory.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.adapter;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetBundleAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetBundleAdapterFactory.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2020 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.adapter;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetDependencyAdapterFactory.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/adapter/MavenTargetDependencyAdapterFactory.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.adapter;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/AbstractFeatureSpecPage.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/AbstractFeatureSpecPage.java
@@ -1,16 +1,15 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2021 IBM Corporation and others.
+ *  Copyright (c) 2000, 2021 IBM Corporation and others
  *
- *  This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License 2.0
- *  which accompanies this distribution, and is available at
- *  https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
- *  SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0
  *
- *  Contributors:
- *     IBM Corporation - initial API and implementation
- *     Christoph Läubrich - adjust for m2e-pde usage
+ * Contributors:
+ *   IBM Corporation - initial API and implementation
+ *   Christoph Läubrich - adjust for m2e-pde usage
  *******************************************************************************/
 
 package org.eclipse.m2e.pde.ui.target.editor;

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/ClipboardParser.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/ClipboardParser.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020, 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/FeatureSpecPage.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/FeatureSpecPage.java
@@ -1,16 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2021 IBM Corporation and others
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *     Christoph Läubrich - adjust for m2e-pde usage
+ *   IBM Corporation - initial API and implementation
+ *   Christoph Läubrich - adjust for m2e-pde usage
  *******************************************************************************/
 
 package org.eclipse.m2e.pde.ui.target.editor;

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenArtifactInstructionsWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenArtifactInstructionsWizard.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2020, 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetDependencyEditor.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetDependencyEditor.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021, 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationEditor.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationEditor.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationWizard.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2018, 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetRepositoryEditor.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetRepositoryEditor.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
+ * Copyright (c) 2021 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Christoph Läubrich - initial API and implementation
+ *   Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/Messages.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/Messages.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2023 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/PluginListPage.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/PluginListPage.java
@@ -1,18 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2021 IBM Corporation and others
  *
- * This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 487943
- *     Martin Karpisek <martin.karpisek@gmail.com> - Bug 247265
- *     Christoph Läubrich - adjust for m2e-pde usage
+ *   IBM Corporation - initial API and implementation
+ *   Lars Vogel <Lars.Vogel@vogella.com> - Bug 487943
+ *   Martin Karpisek <martin.karpisek@gmail.com> - Bug 247265
+ *   Christoph Läubrich - adjust for m2e-pde usage
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui.target.editor;
 


### PR DESCRIPTION
Unify license header in accordance to the Eclipse Committer handbook at https://www.eclipse.org/projects/handbook/#ip-copyright-headers
- Remove the unnecessary 'All rights reserved' clause
- Remove false 'accompanies this distribution' clause, the license file is not distributed with the jars
- Add 'and others' clause

Add missing license headers.