### PR TITLE
[Maven-Target] Fix detection of changed BND-Instructions and move wrapped artifact cache to workspace

### DIFF
--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/CacheManager.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/CacheManager.java
@@ -161,7 +161,7 @@ class CacheManager {
 			if (bundle == null) {
 				throw new IllegalStateException(CacheManager.class.getSimpleName() + " not loaded from a bundle");
 			}
-			baseDir = bundle.getDataFile("").toPath();
+			baseDir = Platform.getStateLocation(bundle).toFile().toPath();
 			// clear all locations older than 14 days, this can be improved by
 			// 1) watch for changes in the workspace -> if target is deleted/removed from
 			// workspace we can clear the cache

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
@@ -162,7 +162,7 @@ public class MavenTargetBundle extends TargetBundle {
 				try (FileInputStream stream = new FileInputStream(file)) {
 					oldProperties.loadFromXML(stream);
 				}
-				return oldProperties.equals(properties);
+				return !oldProperties.equals(properties);
 			} catch (IOException e) {
 				// fall through and assume changed then
 			}


### PR DESCRIPTION
This consist of two changes:

1. Fix detection of changed BND-Instructions
2. Move cache for OSGi-wrapped Maven artifacts to workspace
The mentioned cache is bound to a workspace resource and therefore it makes sense to locate in the workspace's scope. This also has the advantage that the cache is deleted automatically if the workspace is deleted.

@laeubi any objections against moving the cache?