### PR TITLE
Maven target clean ups and test about consideration of changed BND-instructions

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -187,7 +187,47 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 		assertNull(sourceAttributes.getValue(Constants.EXPORT_PACKAGE));
 		assertNull(sourceAttributes.getValue(Constants.REQUIRE_BUNDLE));
 		assertNull(sourceAttributes.getValue(Constants.DYNAMICIMPORT_PACKAGE));
+	}
 
+	@Test
+	public void testNonOSGiArtifact_missingArtifactGenerate_changedCustomInstructions() throws Exception {
+		String targetXML = """
+				<location includeDependencyDepth="none" includeDependencyScopes="" includeSource="true" missingManifest="generate" type="Maven">
+					<dependencies>
+						<dependency>
+							<groupId>com.google.errorprone</groupId>
+							<artifactId>error_prone_annotations</artifactId>
+							<version>2.18.0</version>
+							<type>jar</type>
+						</dependency>
+					</dependencies>
+					<instructions><![CDATA[
+						Bundle-Name:           Bundle in Test from artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}:${mvnClassifier}
+						version:               ${version_cleanup;${mvnVersion}}
+						Bundle-SymbolicName:   %s
+						Bundle-Version:        ${version}
+						Import-Package:        *
+						Export-Package:        *;version="${version}";-noimport:=true
+					]]></instructions>
+				</location>
+				""";
+		ITargetDefinition target = resolveMavenTarget(targetXML.formatted("m2e.wrapped.${mvnArtifactId}"));
+		assertTrue(target.getStatus().isOK());
+		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertEquals(2, target.getAllBundles().length);
+		assertEquals("m2e.wrapped.error_prone_annotations",
+				getGeneratedBundle(target).getBundleInfo().getSymbolicName());
+		assertEquals("m2e.wrapped.error_prone_annotations.source",
+				getGeneratedSourceBundle(target).getBundleInfo().getSymbolicName());
+
+		setMavenTargetLocationAndResolver(target, targetXML.formatted("others.wrapped.${mvnArtifactId}"));
+		assertTrue(target.getStatus().isOK());
+		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertEquals(2, target.getAllBundles().length);
+		assertEquals("others.wrapped.error_prone_annotations",
+				getGeneratedBundle(target).getBundleInfo().getSymbolicName());
+		assertEquals("others.wrapped.error_prone_annotations.source",
+				getGeneratedSourceBundle(target).getBundleInfo().getSymbolicName());
 	}
 	
 	@Test

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -247,7 +247,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 			}
 			SubMonitor split = subMonitor.split(20);
 			if (depth == DependencyDepth.DIRECT || depth == DependencyDepth.INFINITE) {
-				ICallable<PreorderNodeListGenerator> callable = new DependencyNodeGenerator(root, artifact, depth,
+				ICallable<PreorderNodeListGenerator> callable = DependencyNodeGenerator.create(root, artifact, depth,
 						dependencyScopes, repositories, this);
 				PreorderNodeListGenerator dependecies;
 				if (workspaceProject == null) {
@@ -383,9 +383,6 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	/**
 	 * Internal method that lookup the instructions in the map with a fallback to
 	 * the default specified instructions of the location.
-	 * 
-	 * @param artifact
-	 * @return
 	 */
 	BNDInstructions getInstructionsForArtifact(Artifact artifact) {
 		BNDInstructions bndInstructions = instructionsMap.get(getKey(artifact));

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/WorkspaceArtifact.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/WorkspaceArtifact.java
@@ -16,8 +16,6 @@ import java.io.File;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.util.artifact.DelegatingArtifact;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 public class WorkspaceArtifact extends DelegatingArtifact {
@@ -45,12 +43,6 @@ public class WorkspaceArtifact extends DelegatingArtifact {
 
 	public IMavenProjectFacade getMavenProject() {
 		return mavenProject;
-	}
-
-	@SuppressWarnings("restriction")
-	public IFile getManifest() {
-		IProject project = mavenProject.getProject();
-		return org.eclipse.pde.internal.core.project.PDEProject.getManifest(project);
 	}
 
 }

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/ProcessingMessage.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/ProcessingMessage.java
@@ -17,31 +17,10 @@ import org.eclipse.aether.artifact.Artifact;
 /**
  * represents a message that occurred while processing the jar.
  */
-public final class ProcessingMessage {
+public record ProcessingMessage(Artifact artifact, Type type, String message) {
 
-	private Artifact artifact;
-	private Type type;
-	private String message;
-
-	ProcessingMessage(Artifact artifact, Type type, String message) {
-		this.artifact = artifact;
-		this.type = type;
-		this.message = message;
+	public enum Type {
+		ERROR, WARN 
 	}
 
-	public static enum Type {
-		ERROR, WARN
-	}
-
-	public Artifact getArtifact() {
-		return artifact;
-	}
-
-	public String getMessage() {
-		return message;
-	}
-	
-	public Type getType() {
-		return type;
-	}
 }

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/README.MD
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/README.MD
@@ -2,8 +2,8 @@
 
 This package is meant to build a common shared codebase that might be reused by other implementation (especially Tycho).
 
-Therfore there are some restrictions:
+Therefore there are some restrictions:
 
 1. no references to any m2e / pde specific classes beside from this package
-2. If anything changes here, and unless Tycho can use the artifact directly (see https://github.com/eclipse-m2e/m2e-core/discussions/1388) any codechanges here must possibly synced with Tycho
-3. Keep dependecies low, currently only BND, maven/aether and of course java itself should be used here
+2. If anything changes here, and unless Tycho can use the artifact directly (see https://github.com/eclipse-m2e/m2e-core/discussions/1388) any code changes here must possibly synchronized with Tycho
+3. Keep dependencies low, currently only BND, maven/aether and of course java itself should be used here

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/WrappedBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/WrappedBundle.java
@@ -23,12 +23,12 @@ import aQute.bnd.osgi.Jar;
 
 public final class WrappedBundle {
 
-	private DependencyNode node;
-	private List<WrappedBundle> depends;
-	private String instructionsKey;
-	private Path file;
-	private Jar jar;
-	private List<ProcessingMessage> messages;
+	private final DependencyNode node;
+	private final List<WrappedBundle> depends;
+	private final String instructionsKey;
+	private final Path file;
+	private final Jar jar;
+	private final List<ProcessingMessage> messages;
 
 	WrappedBundle(DependencyNode node, List<WrappedBundle> depends, String key, Path file, Jar jar,
 			List<ProcessingMessage> messages) {
@@ -48,16 +48,12 @@ public final class WrappedBundle {
 		return jar;
 	}
 
-	/**
-	 * @return the file where the wrappes bundle is located
-	 */
+	/** @return the location of the wrapped bundle's files */
 	public Path getFile() {
 		return file;
 	}
 
-	/**
-	 * @return the messages that where produced
-	 */
+	/** @return the messages that where produced */
 	public Stream<ProcessingMessage> messages() {
 		return Stream.concat(messages.stream(), depends.stream().flatMap(dep -> dep.messages()));
 	}
@@ -72,14 +68,9 @@ public final class WrappedBundle {
 		if (this == obj) {
 			return true;
 		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		WrappedBundle other = (WrappedBundle) obj;
-		return Objects.equals(instructionsKey, other.instructionsKey) && Objects.equals(node, other.node);
+		return obj instanceof WrappedBundle other //
+				&& Objects.equals(instructionsKey, other.instructionsKey) //
+				&& Objects.equals(node, other.node);
 	}
 
 }


### PR DESCRIPTION
This PR adds the test-case initially created for https://github.com/eclipse-m2e/m2e-core/pull/1386 about consideration of changed BND-instructions.
Furthermore it cleans up the code added in https://github.com/eclipse-m2e/m2e-core/pull/1387 a bit and fixes two deprection warnings.