### PR TITLE
Do not embed guice in the runtime bundle

### DIFF
--- a/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/m2e-maven-runtime/org.eclipse.m2e.maven.runtime/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-	<version>3.9.100-SNAPSHOT</version>
+	<version>3.9.200-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>M2E Embedded Maven Runtime (includes Incubating components)</name>
@@ -52,6 +52,10 @@
 					<groupId>org.checkerframework</groupId>
 					<artifactId>checker-compat-qual</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -61,6 +65,10 @@
 				<exclusion>
 					<groupId>commons-cli</groupId>
 					<artifactId>commons-cli</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -169,13 +177,13 @@
 								org.codehaus.plexus.*;provider=m2e;mandatory:=provider,\
 								org.sonatype.plexus.*;provider=m2e;mandatory:=provider,\
 								org.eclipse.aether.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version},\
-								com.google.inject.*;provider=m2e;mandatory:=provider,\
 								io.takari.*;provider=m2e;mandatory:=provider,\
 								org.eclipse.sisu.*;provider=m2e;mandatory:=provider;version=${maven-resolver.version}
 							Import-Package: \
 								org.slf4j;version="[1.7.31,3.0.0)",\
 								org.slf4j.*;version="[1.7.31,3.0.0)",\
 								javax.inject;version="1.0.0",\
+								com.google.inject.*,
 								javax.annotation;version="[1.2.0,2.0.0)", \
 								org.apache.commons.cli;version="[1.4.0,2.0.0)"
 							Require-Bundle: \

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.eclipse.m2e</groupId>
 			<artifactId>org.eclipse.m2e.maven.runtime</artifactId>
-			<version>3.9.100-SNAPSHOT</version>
+			<version>3.9.200-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -98,6 +98,12 @@
 					<type>jar</type>
 				</dependency>
 				<dependency>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
+					<version>5.1.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
 					<groupId>commons-cli</groupId>
 					<artifactId>commons-cli</artifactId>
 					<version>1.5.0</version>
@@ -120,6 +126,26 @@
 					<type>jar</type>
 				</dependency>
 			</dependencies>
+		</location>
+		<location includeDependencyDepth="none" includeSource="true" label="Wrapped" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+					<version>2.19.1</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+			<instructions>
+			<![CDATA[
+				Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion} provided by m2eclipse
+				version:               ${version_cleanup;${mvnVersion}}
+				Bundle-SymbolicName:   m2e.wrapped.${mvnGroupId}.${mvnArtifactId}
+				Bundle-Version:        ${version}
+				Import-Package:        *
+				Export-Package:        *;version="${version}";-noimport:=true
+			]]>
+			</instructions>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
google guice is already a bundle, it should therefore not be required to embed it into the m2e.runtime, especially as we then export a package again.

This will reduce the size of m2e runtime, allows reuse of exiting guice bundles and prevents us from the need to bump the bundle less often in case of updates.