### PR TITLE
Include org.apache.commons.cli into m2e's p2 repository

### DIFF
--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -26,6 +26,8 @@
    <bundle id="ch.qos.logback.classic.source"/>
    <bundle id="com.google.gson"/>
    <bundle id="com.google.gson.source"/>
+   <bundle id="org.apache.commons.cli"/>
+   <bundle id="org.apache.commons.cli.source"/>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
    <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4j/updates/releases/0.20.1/" enabled="true" />


### PR DESCRIPTION
The bundle org.apache.commons.cli is from a Maven-Target in m2e's target-platform and not available from any other p2-repo.

Fixes https://github.com/eclipse-m2e/m2e-core/issues/1390