### PR TITLE
Allow configuring the console filter threshold with system property.

### DIFF
--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.logback.feature"
       label="%featureName"
-      version="2.1.1.qualifier"
+      version="2.1.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.logback;singleton:=true
-Bundle-Version: 2.1.100.qualifier
+Bundle-Version: 2.1.200.qualifier
 Bundle-Name: M2E Logback Appender and Configuration
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.m2e.logback/defaultLogbackConfiguration/logback.xml
+++ b/org.eclipse.m2e.logback/defaultLogbackConfiguration/logback.xml
@@ -4,7 +4,7 @@
       <pattern>%date [%thread] %-5level %logger{35} - %msg%n</pattern>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>OFF</level> <!-- change to DEBUG to mimic '-consolelog' behaviour -->
+      <level>${org.eclipse.m2e.log.console.threshold:-OFF}</level> <!-- change to DEBUG to mimic '-consolelog' behaviour -->
     </filter>
   </appender>
 
@@ -31,7 +31,7 @@
 
   <appender name="MavenConsoleLog" class="org.eclipse.m2e.logback.appender.MavenConsoleAppender">
   </appender>
-        
+
   <root level="INFO">
     <appender-ref ref="FILE" />
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
This PR contains the part of https://github.com/eclipse-m2e/m2e-core/pull/1366 that only changes the configuration to consider the Java system-property `org.eclipse.m2e.log.console.threshold` when configuring the standard console appender.
This is the minimally required change in m2e in order to achieve the desired goal.
