### PR TITLE
Make the target test plugable so they can be reused (e.g. by Tycho)

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/META-INF/services/org.eclipse.m2e.pde.target.tests.spi.TargetLocationLoader
+++ b/org.eclipse.m2e.pde.target.tests/META-INF/services/org.eclipse.m2e.pde.target.tests.spi.TargetLocationLoader
@@ -1,0 +1,1 @@
+org.eclipse.m2e.pde.target.tests.spi.M2ETargetLocationLoader

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ArtifactKey.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ArtifactKey.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2022 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Sonatype, Inc. - initial API and implementation
+ *      Hannes Wellmann - Convert to record
+ *******************************************************************************/
+
+package org.eclipse.m2e.pde.target.tests;
+
+import java.io.Serializable;
+
+import org.eclipse.osgi.util.NLS;
+
+public record ArtifactKey(String groupId, String artifactId, String version, String classifier)
+    implements Serializable {
+	public static ArtifactKey fromPortableString(String str) {
+		int p = 0;
+		int c = nextColonIndex(str, p);
+		String groupId = substring(str, p, c);
+
+		p = c + 1;
+		c = nextColonIndex(str, p);
+		String artifactId = substring(str, p, c);
+
+		p = c + 1;
+		c = nextColonIndex(str, p);
+		String version = substring(str, p, c);
+
+		p = c + 1;
+		c = nextColonIndex(str, p);
+		String classifier = substring(str, p, c);
+
+		return new ArtifactKey(groupId, artifactId, version, classifier);
+	}
+
+	private static String substring(String str, int start, int end) {
+		String substring = str.substring(start, end);
+		return "".equals(substring) ? null : substring; //$NON-NLS-1$
+	}
+
+	private static int nextColonIndex(String str, int pos) {
+		int idx = str.indexOf(':', pos);
+		if (idx < 0) {
+			throw new IllegalArgumentException(NLS.bind("Invalid portable string: {0}", str));
+		}
+		return idx;
+	}
+}

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/DependencyExclusionTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/DependencyExclusionTest.java
@@ -13,11 +13,10 @@
 package org.eclipse.m2e.pde.target.tests;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetLocation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,7 +35,7 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 
 	@Test
 	public void testExclusionOfDirectRequirement() throws Exception {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+		ITargetLocation target = resolveMavenTarget(String.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<dependencies>
@@ -51,15 +50,16 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
-		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
 		List<ExpectedBundle> expectedBundles = List.of(junitPlatformCommons("1.9.3"));
 		assertTargetBundles(target, includeSource ? withSourceBundles(expectedBundles) : expectedBundles);
 	}
 
 	@Test
 	public void testExclusionOfDirectAndTransitivRequirement() throws Exception {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<dependencies>
@@ -74,8 +74,8 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
-		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
 		List<ExpectedBundle> expectedBundles = List.of(//
 				junitJupiterAPI(), //
 				junitPlatformCommons("1.9.3"), //
@@ -86,7 +86,8 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 
 	@Test
 	public void testExclusionOfMultipleVersions() throws Exception {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<dependencies>
@@ -108,8 +109,8 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
-		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
 		List<ExpectedBundle> expectedBundles = List.of(//
 				junitJupiterAPI(), //
 				junitPlatformCommons("1.9.3"), //
@@ -120,7 +121,8 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 
 	@Test
 	public void testExclusionOfDifferentVersions() throws Exception {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<dependencies>
@@ -141,8 +143,8 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
-		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
 		List<ExpectedBundle> expectedBundles = List.of(//
 				junitJupiterAPI(), //
 				junitPlatformCommons("1.9.3"), //

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ExpectedBundle.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ExpectedBundle.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.tests;
+
+public record ExpectedBundle(String bsn, String version, boolean isSourceBundle, boolean isOriginal,
+		ArtifactKey key) implements ExpectedUnit {
+
+	@Override
+	public String id() {
+		return bsn();
+	}
+
+	@Override
+	public String toString() {
+		return bsn + ":" + version;
+	}
+}

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ExpectedFeature.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ExpectedFeature.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.tests;
+
+import java.util.List;
+
+import org.eclipse.pde.core.target.NameVersionDescriptor;
+
+public record ExpectedFeature(String id, String version, boolean isSourceBundle, boolean isOriginal,
+		ArtifactKey key, List<NameVersionDescriptor> containedPlugins) implements ExpectedUnit {
+
+	@Override
+	public String toString() {
+		return id + ":" + version;
+	}
+}

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ExpectedUnit.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/ExpectedUnit.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.tests;
+interface ExpectedUnit {
+
+	String id();
+
+	boolean isSourceBundle();
+
+	boolean isOriginal();
+
+	ArtifactKey key();
+}

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/MavenFeatureTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/MavenFeatureTest.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.target.tests;
 
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetLocation;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,8 +33,9 @@ public class MavenFeatureTest extends AbstractMavenTargetTest {
 	}
 
 	@Test
-	public void testLocationContentFeatureGeneration() throws CoreException {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+	public void testLocationContentFeatureGeneration() throws Exception {
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<feature id="my.junit.feature" label="My Junit Feature" provider-name="Me Inc." version="1.2.3.qualifier">
@@ -63,7 +61,7 @@ public class MavenFeatureTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
+		assertStatusOk(target.getStatus());
 		List<ExpectedBundle> expectedBundles = List.of( //
 				junitJupiterAPI(), //
 				junitPlatformCommons(), //
@@ -89,8 +87,9 @@ public class MavenFeatureTest extends AbstractMavenTargetTest {
 	}
 
 	@Test
-	public void testPomArtifactFeatureGeneration() throws CoreException {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+	public void testPomArtifactFeatureGeneration() throws Exception {
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<dependencies>
@@ -104,7 +103,7 @@ public class MavenFeatureTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
+		assertStatusOk(target.getStatus());
 		List<ExpectedBundle> expectedBundles = List.of( //
 				originalOSGiBundle("com.sun.xml.bind.jaxb-core", "4.0.2", "com.sun.xml.bind:jaxb-core"),
 				originalOSGiBundle("com.sun.xml.bind.jaxb-impl", "4.0.2", "com.sun.xml.bind:jaxb-impl"),
@@ -131,11 +130,12 @@ public class MavenFeatureTest extends AbstractMavenTargetTest {
 	}
 
 	@Test
-	public void testFeatureArtifact() throws CoreException {
+	public void testFeatureArtifact() throws Exception {
 		// TODO: For real feature artifacts, which don't have a source-artifact, a
 		// source feature is not generated (yet).
 		Assume.assumeFalse(includeSource);
-		ITargetDefinition target = resolveMavenTarget(String.format(
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
 							<dependencies>
@@ -149,7 +149,7 @@ public class MavenFeatureTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
+		assertStatusOk(target.getStatus());
 		assertTargetBundles(target, List.of());
 		List<ExpectedFeature> expectedFeature = List.of(generatedFeature("org.eclipse.vorto.feature", "1.0.0", List.of(//
 				featurePlugin("org.eclipse.vorto.core", "1.0.0"), //

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/MavenTargetsTransitiveDependenciesTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/MavenTargetsTransitiveDependenciesTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertArrayEquals;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetLocation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -133,8 +133,8 @@ public class MavenTargetsTransitiveDependenciesTest extends AbstractMavenTargetT
 				</location>
 				"""
 				.formatted(dependencyDepth, dependencyScopes, sources);
-		ITargetDefinition target = resolveMavenTarget(targetDefinition);
+		ITargetLocation target = resolveMavenTarget(targetDefinition);
 		assertTargetBundles(target, expectedBundles);
-		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertArrayEquals(EMPTY, target.getFeatures());
 	}
 }

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/MixedCasesTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/MixedCasesTest.java
@@ -13,11 +13,10 @@
 package org.eclipse.m2e.pde.target.tests;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetLocation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,7 +35,8 @@ public class MixedCasesTest extends AbstractMavenTargetTest {
 
 	@Test
 	public void testMultipleArtifactsWithWrappingAndExclusion() throws Exception {
-		ITargetDefinition target = resolveMavenTarget(String.format(
+		ITargetLocation target = resolveMavenTarget(String
+				.format(
 				"""
 						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="generate" type="Maven">
 							<dependencies>
@@ -75,8 +75,8 @@ public class MixedCasesTest extends AbstractMavenTargetTest {
 						</location>
 						""",
 				includeSource));
-		assertTrue(target.getStatus().isOK());
-		assertArrayEquals(EMPTY, target.getAllFeatures());
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
 		List<ExpectedBundle> expectedBundles = List.of(//
 				originalOSGiBundle("com.google.inject", "5.1.0", "com.google.inject:guice"),
 				originalOSGiBundle("com.google.guava", "30.1.0.jre", "com.google.guava:guava", "30.1-jre"),

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/spi/M2ETargetLocationLoader.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/spi/M2ETargetLocationLoader.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Hannes Wellmann and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - extraction from AbstractMavenTargetTest
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.tests.spi;
+
+import java.io.File;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.m2e.pde.target.MavenTargetLocationFactory;
+import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetLocation;
+import org.eclipse.pde.core.target.ITargetPlatformService;
+
+public class M2ETargetLocationLoader implements TargetLocationLoader {
+
+	@Override
+	public int getPriority() {
+		// we use default priority here...
+		return 0;
+	}
+
+	@Override
+	public ITargetLocation resolveMavenTarget(String targetXML, File tempDir) throws Exception {
+		// temp dir is not used here, but we probably should configure m2e to use a
+		// separate folder for each test to prevent items from one test to drip into
+		// another (especially when wrapping is involved or custom repositories)
+		@SuppressWarnings("restriction")
+		ITargetPlatformService s = org.eclipse.pde.internal.core.PDECore.getDefault()
+				.acquireService(ITargetPlatformService.class);
+		ITargetDefinition target = s.newTarget();
+		ITargetLocation targetLocation = new MavenTargetLocationFactory().getTargetLocation(MAVEN_LOCATION_TYPE,
+				targetXML);
+		target.setTargetLocations(new ITargetLocation[] { targetLocation });
+		targetLocation.resolve(target, new NullProgressMonitor());
+		return targetLocation;
+	}
+
+}

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/spi/TargetLocationLoader.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/spi/TargetLocationLoader.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.tests.spi;
+
+import java.io.File;
+
+import org.eclipse.pde.core.target.ITargetLocation;
+
+/**
+ * In cases where we want to reuse the test-cases (specifically Tycho), one can plug in an own
+ * loader that transform the xml into a suitable location for the tests.
+ *
+ */
+public interface TargetLocationLoader extends Comparable<TargetLocationLoader> {
+
+    static final String MAVEN_LOCATION_TYPE = "Maven";
+
+    /**
+     * @return the priority of this loader in case there are multiple ones, the one with the highest
+     *         priority will be chosen for the test
+     */
+    int getPriority();
+
+    /**
+     * Resolve the given target xml fragment into a resolved location, the expectation is that:
+     * <ul>
+     * <li>The location is resolved</li>
+     * <li>The status can be queried and return a result reflecting the outcome of< the
+     * operation</li>
+     * <li>getBundles() / getFeatures() return the appropriate items</li>
+     * </ul>
+     * 
+     * @param targetXML
+     * @return the resolved location
+     * @throws Exception
+     */
+    ITargetLocation resolveMavenTarget(String targetXML, File tempDir) throws Exception;
+
+    @Override
+    default int compareTo(TargetLocationLoader o) {
+        return Integer.compare(o.getPriority(), getPriority());
+    }
+
+}


### PR DESCRIPTION
One of the important parts is that Tycho+m2e behave the same in regard to the m2e target support so that if something works in the IDE it also works in the build.

This is an attempt to generlaize the tests in a way so they can be reused at Tycho by providing a small loader that transform the Tycho content into something understood by the test, so ideally we can run the same tests in Tycho as in m2e.