### PR TITLE
Add JVM according to toolchains

### DIFF
--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.3.0.qualifier"
+      version="2.3.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.1.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/LookupJDKToolchainsJob.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/LookupJDKToolchainsJob.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.m2e.jdt;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.maven.cli.MavenCli;
+import org.apache.maven.toolchain.io.DefaultToolchainsReader;
+import org.apache.maven.toolchain.io.ToolchainsReader;
+import org.apache.maven.toolchain.java.JavaToolchainImpl;
+import org.apache.maven.toolchain.model.PersistedToolchains;
+import org.apache.maven.toolchain.model.ToolchainModel;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.internal.launching.StandardVMType;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
+import org.eclipse.jdt.launching.IVMInstallType;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.VMStandin;
+
+public class LookupJDKToolchainsJob extends Job {
+
+	private final IVMInstallType standardType;
+
+	public LookupJDKToolchainsJob() {
+		super(LookupJDKToolchainsJob.class.getSimpleName());
+		this.standardType = JavaRuntime.getVMInstallType(StandardVMType.ID_STANDARD_VM_TYPE);
+	}
+
+	@Override
+	protected IStatus run(IProgressMonitor monitor) {
+		ToolchainsReader reader = new DefaultToolchainsReader();
+		try {
+			PersistedToolchains toolchains = reader.read(MavenCli.DEFAULT_USER_TOOLCHAINS_FILE, null);
+			for (ToolchainModel toolchain : toolchains.getToolchains()) {
+				if (monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
+				}
+				addToolchain(toolchain);
+			}
+			return Status.OK_STATUS;
+		} catch(IOException e) {
+			return Status.error(e.getMessage(), e);
+		}
+	}
+
+	private Optional<File> getVMInstallation(ToolchainModel toolchain) {
+		return Optional.ofNullable(toolchain)
+			.filter(t -> "jdk".equals(t.getType()))
+			.map(ToolchainModel::getConfiguration)
+			.filter(Xpp3Dom.class::isInstance)
+			.map(Xpp3Dom.class::cast)
+			.map(dom -> dom.getChild(JavaToolchainImpl.KEY_JAVAHOME))
+			.map(Xpp3Dom::getValue)
+			.map(File::new)
+			.filter(File::isDirectory);
+	}
+
+	private void addToolchain(ToolchainModel toolchain) {
+		getVMInstallation(toolchain)
+			.filter(f -> standardType.validateInstallLocation(f).isOK())
+			.ifPresent(candidate -> {
+				if (Arrays.stream(standardType.getVMInstalls()) //
+					.map(IVMInstall::getInstallLocation) //
+					.filter(Objects::nonNull)
+					.noneMatch(install -> isSameCanonicalFile(candidate, install))) {
+					VMStandin workingCopy = new VMStandin(standardType, candidate.getAbsolutePath());
+					workingCopy.setInstallLocation(candidate);
+					if (workingCopy.getJavaVersion() != null) {
+						String name = candidate.getName();
+						int i = 1;
+						while (isDuplicateName(name)) {
+							name = candidate.getName() + '(' + i++ + ')';
+						}
+						workingCopy.setName(name);
+						IVMInstall newVM = workingCopy.convertToRealVM();
+						// next lines workaround https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/248
+						if (!(newVM instanceof IVMInstall2 newVM2 && newVM2.getJavaVersion() != null)) {
+							standardType.disposeVMInstall(newVM.getId());
+						}
+					}
+				}
+			});
+	}
+
+	private static boolean isDuplicateName(String name) {
+		return Stream.of(JavaRuntime.getVMInstallTypes()) //
+			.flatMap(vmType -> Arrays.stream(vmType.getVMInstalls())) //
+			.map(IVMInstall::getName) //
+			.anyMatch(name::equals);
+	}
+
+	private static boolean isSameCanonicalFile(File f1, File f2) {
+		try {
+			return Objects.equals(f1.getCanonicalFile(), f2.getCanonicalFile());
+		} catch (IOException ex) {
+			return false;
+		}
+	}
+}

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/MavenJdtPlugin.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/MavenJdtPlugin.java
@@ -69,6 +69,7 @@ public class MavenJdtPlugin extends Plugin {
   public static final String PLUGIN_ID = "org.eclipse.m2e.jdt"; //$NON-NLS-1$
 
   public static final String PREFERENCES_JRE_SYSTEM_LIBRARY_VERSION = "jreSystemLibraryVersion"; //$NON-NLS-1$
+  private static final String PREFERENCE_LOOKUP_JVM_IN_TOOLCHAINS = "lookupJVMInToolchains"; //$NON-NLS-1$
 
   private static MavenJdtPlugin instance;
 
@@ -154,6 +155,11 @@ public class MavenJdtPlugin extends Plugin {
     this.launchConfigurationListener = new MavenLaunchConfigurationListener();
     DebugPlugin.getDefault().getLaunchManager().addLaunchConfigurationListener(launchConfigurationListener);
     projectManager.addMavenProjectChangedListener(launchConfigurationListener);
+
+    String lookupPref = preferencesService.get(PREFERENCE_LOOKUP_JVM_IN_TOOLCHAINS, Boolean.TRUE.toString(), preferencesLookup);
+    if (lookupPref == null || Boolean.parseBoolean(lookupPref)) {
+        new LookupJDKToolchainsJob().schedule();
+    }
 
     this.mavenClassifierManager = new MavenClassifierManager();
   }


### PR DESCRIPTION
This is current not functional as toolchains is not set in the MavenExecutionRequest.
This would require all consumers of MavenExecutionRequestPopulator in m2e to also invoke the `populateToolchains` method.

Or alternatively, we can rewrite all this code to bypass the execution request and just read the toolchains.xml file to retrieve the model and use it directly.

See https://github.com/eclipse-m2e/m2e-core/issues/939