### PR TITLE
Do not prevent finish for "incomplete" mappings

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/LifecycleMappingPage.java
@@ -67,7 +67,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
-import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.PlatformUI;
 
 import org.apache.maven.project.MavenProject;
@@ -598,18 +597,6 @@ public class LifecycleMappingPage extends WizardPage {
       return Collections.emptyList();
     }
     return mappingConfiguration.getSelectedProposals();
-  }
-
-  /*
-   * Mapping is complete when mappings are handled (a proposal has been selected, or if it is an uninteresting phase).
-   */
-  public boolean isMappingComplete() {
-    for(TreeItem item : treeViewer.getTree().getItems()) {
-      if(!isHandled((ILifecycleMappingLabelProvider) item.getData())) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /*

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/wizards/MavenDiscoveryProposalWizard.java
@@ -109,10 +109,6 @@ public class MavenDiscoveryProposalWizard extends Wizard implements IImportWizar
 
   @Override
   public boolean performFinish() {
-    if(lifecycleMappingPage != null && !lifecycleMappingPage.isMappingComplete()) {
-      return false;
-    }
-
     final List<IMavenDiscoveryProposal> proposals = getMavenDiscoveryProposals();
 
     boolean doIgnore = !lifecycleMappingPage.getIgnore().isEmpty() || !lifecycleMappingPage.getIgnoreParent().isEmpty()


### PR DESCRIPTION
Currently in #finish of the wizard it can happen that the wizard do not finish if m2e thinks the mapping is incomplete, but this is a very bad user experience as there is not indication of what has to be done.

Instead a page should set its completion status (in this case the button is disabled) and instruct the user what to do instead.

Fix https://github.com/eclipse-m2e/m2e-core/issues/1371