### PR TITLE
Export the entries of transitive dependencies

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DefaultClasspathManagerDelegate.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/DefaultClasspathManagerDelegate.java
@@ -148,6 +148,7 @@ public class DefaultClasspathManagerDelegate implements IClasspathManagerDelegat
         entry.setArtifactKey(new ArtifactKey(a.getGroupId(), a.getArtifactId(), a.getBaseVersion(), a.getClassifier()));
         entry.setScope(a.getScope());
         entry.setOptionalDependency(a.isOptional());
+        entry.setExported(isExportedArtifact(a));
       }
     }
 
@@ -159,6 +160,19 @@ public class DefaultClasspathManagerDelegate implements IClasspathManagerDelegat
       descriptor.setClasspathAttribute(IClasspathManager.WITHOUT_TEST_CODE,
           (testAttributes.excludeTestSources) ? "true" : null);
     });
+  }
+
+  private boolean isExportedArtifact(Artifact a) {
+    if(Artifact.SCOPE_PROVIDED.equals(a.getScope())) {
+      //provided items are not transitive
+      return false;
+    }
+    if(a.isOptional()) {
+      //optional artifacts are also not transitive
+      return false;
+    }
+    //everything else is considered transitive
+    return true;
   }
 
   private boolean isOnlyVisibleByTests(Artifact a) {


### PR DESCRIPTION
JDT has a concept of exporting classpath entries that can be used when referencing a project in the remote-debugger, currently no entries are exported.

![grafik](https://github.com/eclipse-m2e/m2e-core/assets/1331477/c78ce9a6-a417-4e24-9835-7898ebde57c3)

This sets the exported flag for all items that are normally transitive in maven.