### PR TITLE
[TP] update to Eclipse 4.28 and latest versions of other dependencies

### DIFF
--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.logback.feature"
       label="%featureName"
-      version="2.1.2.qualifier"
+      version="2.2.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.logback;singleton:=true
-Bundle-Version: 2.1.200.qualifier
+Bundle-Version: 2.2.0.qualifier
 Bundle-Name: M2E Logback Appender and Configuration
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Fragment-Host: ch.qos.logback.classic;bundle-version="1.2.0"
+Fragment-Host: ch.qos.logback.classic;bundle-version="[1.3.0,1.5.0)"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.ui.console,

--- a/org.eclipse.m2e.logback/src/org/eclipse/m2e/logback/configuration/M2ELogbackConfigurator.java
+++ b/org.eclipse.m2e.logback/src/org/eclipse/m2e/logback/configuration/M2ELogbackConfigurator.java
@@ -52,7 +52,7 @@ public class M2ELogbackConfigurator extends BasicConfigurator implements Configu
   private static final String PROPERTY_LOG_DIRECTORY = "org.eclipse.m2e.log.dir"; //$NON-NLS-1$
 
   @Override
-  public void configure(LoggerContext lc) {
+  public ExecutionStatus configure(LoggerContext lc) {
     // Bug 337167: Configuring Logback requires the state-location. If not yet initialized it will be initialized to the default value, 
     // but this prevents the workspace-chooser dialog to show up in a stand-alone Eclipse-product. Therefore we have to wait until the resources plug-in has started.
     // This happens if a Plug-in that uses SLF4J is started before the workspace has been selected.
@@ -65,6 +65,7 @@ public class M2ELogbackConfigurator extends BasicConfigurator implements Configu
     } else {
       configureLogback(lc);
     }
+    return ExecutionStatus.NEUTRAL;
   }
 
   private synchronized void configureLogback(LoggerContext lc) {

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.2.101.qualifier"
+      version="2.2.200.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -51,8 +51,8 @@
    </iu>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
    <category-def name="m2e.runtimes" label="Maven Runtimes"/>
-   <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.0/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/lsp4j/updates/releases/0.20.1/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.1/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.23.0/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/eclipse/updates/4.27/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/eclipse/updates/4.28/" enabled="true" />
 </site>

--- a/products/m2e-ide/Eclipse-M2E-IDE.launch
+++ b/products/m2e-ide/Eclipse-M2E-IDE.launch
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
     <setAttribute key="additional_plugins">
-        <setEntry value="org.apache.felix.scr:2.2.4:default:true:2:true"/>
+        <setEntry value="ch.qos.logback.classic:1.4.8:default:true:default:true"/>
+        <setEntry value="jakarta.servlet-api:5.0.0:default:true:default:default"/>
+        <setEntry value="org.apache.aries.spifly.dynamic.bundle:1.3.6:default:true:2:true"/>
+        <setEntry value="org.apache.felix.scr:2.2.6:default:true:2:true"/>
         <setEntry value="org.apache.xml.resolver:1.2.0.v20220715-1206:default:true:default:default"/>
-        <setEntry value="org.eclipse.core.runtime:3.26.100.v20221021-0005:default:true:default:true"/>
-        <setEntry value="org.eclipse.equinox.common:3.17.0.v20221108-1156:default:true:2:true"/>
-        <setEntry value="org.eclipse.equinox.event:1.6.100.v20211021-1418:default:true:2:true"/>
+        <setEntry value="org.eclipse.core.runtime:3.27.0.v20230515-1719:default:true:default:true"/>
+        <setEntry value="org.eclipse.equinox.common:3.18.0.v20230523-2142:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.event:1.6.200.v20230120-0604:default:true:2:true"/>
         <setEntry value="org.eclipse.equinox.simpleconfigurator:1.4.200.v20221111-1340:default:true:1:true"/>
     </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
@@ -41,7 +44,7 @@
         <setEntry value="org.eclipse.m2e.pde.feature:default"/>
         <setEntry value="org.eclipse.sdk:default"/>
     </setAttribute>
-    <booleanAttribute key="show_selected_only" value="false"/>
+    <booleanAttribute key="show_selected_only" value="true"/>
     <booleanAttribute key="tracing" value="false"/>
     <booleanAttribute key="useCustomFeatures" value="true"/>
     <booleanAttribute key="useDefaultConfig" value="true"/>

--- a/products/m2e-ide/m2e-ide.product
+++ b/products/m2e-ide/m2e-ide.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="M2Eclipse IDE" uid="m2e-ide" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="2.0.0" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="M2Eclipse IDE" uid="m2e-ide" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="2.0.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -27,6 +27,7 @@
    </vm>
 
    <plugins>
+      <plugin id="jakarta.servlet-api" version="5.0.0"/>
    </plugins>
 
    <features>
@@ -38,6 +39,8 @@
    </features>
 
    <configurations>
+      <plugin id="ch.qos.logback.classic" autoStart="true" startLevel="0" />
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -4,35 +4,36 @@
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.27/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.28/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-06/"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+			<unit id="org.apache.aries.spifly.dynamic.bundle" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/egit/updates-6.5/"/>
+			<repository location="https://download.eclipse.org/egit/updates-6.6/"/>
 			<unit id="org.eclipse.jgit" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.33.0"/>
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.34.0"/>
 			<unit id="org.eclipse.emf.edit.ui.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.ecore.edit.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.29.0/R-3.29.0-20230303230236/repository/"/>
+			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.30.0/R-3.30.0-20230603084739/repository/"/>
 			<unit id="org.eclipse.wst.common.uriresolver" version="0.0.0"/>
 			<unit id="org.eclipse.wst.common.emf" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.1/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/lsp4e/releases/0.23.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
-			<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.20.1/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -44,13 +45,13 @@
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bnd.util</artifactId>
-					<version>6.4.0</version>
+					<version>6.4.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
-					<version>6.4.0</version>
+					<version>6.4.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -66,13 +67,20 @@
 				<dependency>
 					<groupId>ch.qos.logback</groupId>
 					<artifactId>logback-classic</artifactId>
-					<version>1.2.12</version>
+					<version>1.4.8</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<!-- Logback provides a Servlet Container service which is also loaded and that needs servlet (by default optional) -->
+					<groupId>jakarta.servlet</groupId>
+					<artifactId>jakarta.servlet-api</artifactId>
+					<version>5.0.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
-					<version>1.7.36</version>
+					<version>2.0.7</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>
@@ -94,7 +102,7 @@
 				<dependency>
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
-					<version>31.1-jre</version>
+					<version>32.0.1-jre</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -116,12 +124,12 @@
 				<dependency>
 					<groupId>org.mockito</groupId>
 					<artifactId>mockito-core</artifactId>
-					<version>5.3.0</version>
+					<version>5.4.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>
 		</location>
-		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="maven-archetype" missingManifest="generate" type="Maven">
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Maven-archetype" missingManifest="generate" type="Maven">
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.maven.archetype</groupId>


### PR DESCRIPTION
At the moment there is a problem in connecting the slf4j-api bundle and the logback provider in the m2e-sdk product, which I want to solve before this is merged.