### PR TITLE
Revert "Move to use the platform license check"

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   call-license-check:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: technology.m2e
       setupScript: 'cd m2e-maven-runtime && mvn generate-resources'


### PR DESCRIPTION
Now that https://github.com/eclipse/dash-licenses/pull/247 is merged I think we can use the original workflow again.

This reverts commit 8c6d5719b8a4a2b4261c0d8c96fec6e087b26726.