### PR TITLE
Use p2.inf to generate installable maven runtimes and add release note

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # Eclipse m2e - Release notes
 
+## 2.4.0
+
+### Support for multiple mebedded runtimes
+
+You can now install additional embedded Maven Runtimes using the m2eclipse update site
+
+![grafik](https://github.com/eclipse-m2e/m2e-core/assets/1331477/8ef45a1b-e2bf-46e3-909e-275ac3c21510)
+
+After the installation you can now select the desired default runtime, keep in mind that m2e internally still uses the `EMBEDDED` runtime even if another is selected. 
+
+![grafik](https://github.com/eclipse-m2e/m2e-core/assets/1331477/a849a70c-e7a6-4049-ac55-3338596dca7b)
+
+If you want to switch back to an older runtime you currently need to modify you eclipse installation:
+
+- Make sure the older runtime is already installed
+- close eclipse (and maybe make a backup)
+- go to the `plugins` folder and locate the folders starting with `org.eclipse.m2e.maven.runtime_<version>`
+- delete higher runtime versions (e.g. 3.9)
+- start eclipse and check that now an older runtime is used by default
+
+![grafik](https://github.com/eclipse-m2e/m2e-core/assets/1331477/ef04e7f4-e36b-4bbc-a4d3-ff92e6a5f9f4)
+
 ## 2.3.0
 
 * 📅 Release Date: 23th May 2023

--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -47,10 +47,8 @@
        </expression>
        <param>org.eclipse.m2e.maven.runtime</param>
      </query>
-     <category name="m2e.runtimes"/>
    </iu>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
-   <category-def name="m2e.runtimes" label="Maven Runtimes"/>
    <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.1/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.23.0/" enabled="true" />

--- a/org.eclipse.m2e.repository/p2.inf
+++ b/org.eclipse.m2e.repository/p2.inf
@@ -1,0 +1,48 @@
+# Define IU for Maven 3.8
+units.0.id = org.eclipse.m2e.maven.runtime.38.iu
+units.0.version = 1.0.0
+units.0.properties.1.name=org.eclipse.equinox.p2.name
+units.0.properties.1.value=Maven 3.8.x
+units.0.provides.0.namespace=org.eclipse.equinox.p2.iu
+units.0.provides.0.name=org.eclipse.m2e.maven.runtime.38.iu
+units.0.provides.0.version=1.0.0
+units.0.requires.0.namespace = osgi.bundle
+units.0.requires.0.name = org.eclipse.m2e.maven.runtime
+units.0.requires.0.range = [3.8.0,3.9.0)
+units.0.requires.0.greedy = true
+units.0.requires.0.optional = false
+units.0.update.id = org.eclipse.m2e.maven.runtime.38.iu
+units.0.update.range = [1.0.0,1.0.0]
+
+# Define IU for Maven 3.9
+units.1.id = org.eclipse.m2e.maven.runtime.39.iu
+units.1.version = 1.0.0
+units.1.properties.1.name=org.eclipse.equinox.p2.name
+units.1.properties.1.value=Maven 3.9.x
+units.1.provides.0.namespace=org.eclipse.equinox.p2.iu
+units.1.provides.0.name=org.eclipse.m2e.maven.runtime.39.iu
+units.1.provides.0.version=1.0.0
+units.1.requires.0.namespace = osgi.bundle
+units.1.requires.0.name = org.eclipse.m2e.maven.runtime
+units.1.requires.0.range = [3.9.0,3.10.0)
+units.1.requires.0.greedy = true
+units.1.requires.0.optional = false
+units.1.update.id = org.eclipse.m2e.maven.runtime.39.iu
+units.1.update.range = [1.0.0,1.0.0]
+
+# Define Category for runtimes and include them
+units.100.id=org.eclipse.m2e.runtimes.category
+units.100.version=1.0.0
+units.100.provides.0.namespace=org.eclipse.equinox.p2.iu
+units.100.provides.0.name=org.eclipse.m2e.runtimes.category
+units.100.provides.0.version=1.0.0
+units.100.properties.0.name=org.eclipse.equinox.p2.type.category
+units.100.properties.0.value=true
+units.100.properties.1.name=org.eclipse.equinox.p2.name
+units.100.properties.1.value=Maven Embedded Runtimes
+units.100.requires.0.namespace=org.eclipse.equinox.p2.iu
+units.100.requires.0.name=org.eclipse.m2e.maven.runtime.38.iu
+units.100.requires.0.range=[1.0.0,1.0.0]
+units.100.requires.1.namespace=org.eclipse.equinox.p2.iu
+units.100.requires.1.name=org.eclipse.m2e.maven.runtime.39.iu
+units.100.requires.1.range=[1.0.0,1.0.0]


### PR DESCRIPTION
This adds two new units that can be used to install additional runtimes into m2eclipse and a release note that explains how to use this.