### PR TITLE
Remove Maven Build shortcut

### DIFF
--- a/org.eclipse.m2e.launching/plugin.xml
+++ b/org.eclipse.m2e.launching/plugin.xml
@@ -46,29 +46,6 @@
   </extension>
 
    <extension point="org.eclipse.debug.ui.launchShortcuts">
-      <shortcut id="org.eclipse.m2e.core.pomFileAction"
-                class="org.eclipse.m2e.actions.ExecutePomAction"
-                icon="icons/m2.gif"
-                label="%m2.popup.pomFile.label"
-                modes="run,debug">
-         <contextualLaunch>
-           <contextLabel label="%m2.popup.pomFile.label" mode="run"/>
-           <contextLabel label="%m2.popup.pomFile.label" mode="debug"/>
-           <enablement>
-              <count value="1"/>
-              <iterate>
-                 <or>
-                    <adapt type="org.eclipse.core.resources.IFile">
-                       <test property="org.eclipse.core.resources.name" value="pom.xml"/>
-                    </adapt>
-                    <adapt type="org.eclipse.core.resources.IProject">
-                       <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
-                    </adapt>
-                 </or>
-              </iterate>
-           </enablement>
-       </contextualLaunch>
-     </shortcut>
      <shortcut id="org.eclipse.m2e.core.pomFileActionWithDialog"
                class="org.eclipse.m2e.actions.ExecutePomAction:WITH_DIALOG"
                icon="icons/m2.gif"

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
@@ -83,7 +83,6 @@ public class ExecutePomAction implements ILaunchShortcut, IExecutableExtension, 
   private String goalName = null;
 
   public void setInitializationData(IConfigurationElement config, String propertyName, Object data) {
-    System.out.println("ExecutePomAction.setInitializationData()");
     if("WITH_DIALOG".equals(data)) { //$NON-NLS-1$
       this.showDialog = true;
     } else {


### PR DESCRIPTION
Now we show the launch configs in the menu already, the Run As > Maven Build can be removed as it is obsolete now:

- if no config is there it is equivalent to the dialog variant
- if there is a config it is already shown as menu item