### PR TITLE
Fix bad casting causing all entries to be unknown

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/preferences/LifecycleMappingsViewer.java
@@ -444,7 +444,8 @@ public class LifecycleMappingsViewer {
     LinkedHashSet<String> sources = new LinkedHashSet<>();
     if(mappings != null && !mappings.isEmpty()) {
       for(IPluginExecutionMetadata mapping : mappings) {
-        if(mapping instanceof LifecycleMappingMetadataSource metadata) {
+        LifecycleMappingMetadataSource metadata = ((PluginExecutionMetadata) mapping).getSource();
+        if(metadata != null) {
           Object source = metadata.getSource();
           if(source instanceof String s) {
             sources.add(s);


### PR DESCRIPTION
A change made by https://github.com/eclipse-m2e/m2e-core/commit/6eb17dbe07be05d3f237cf8288b070fd3731f1ff#diff-28403ac299e4b874aaf674d927c7a0fa60fe79ea6fbfd07a5b827e51d84684e6L446 causes the Lifecycle Mappings preferences to show everything is "unknown" because `IPluginExecutionMetadata` and `LifecycleMappingMetadataSource` do not share a common base class and thus could never be `instanceof`. 

Current behavior as of 2.2.0:
![Screenshot 2023-06-29 at 15 02 21](https://github.com/eclipse-m2e/m2e-core/assets/136501322/01add1d6-86a7-4255-acee-ddad8fbe5baf)

Fix:
![Screenshot 2023-06-29 at 15 04 20](https://github.com/eclipse-m2e/m2e-core/assets/136501322/23d558b6-ae43-481c-a6b6-1fe504b1c2a2)
