### PR TITLE
[Setup] Remove disable P2-director and set id for worksing sets

### DIFF
--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -13,7 +13,7 @@
     xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
     xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore http://www.eclipse.org/oomph/setup/pde/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/maven/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Maven.ecore http://www.eclipse.org/oomph/setup/pde/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
     name="m2e"
     label="m2e">
   <annotation
@@ -96,19 +96,6 @@
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask
-      xsi:type="setup.p2:P2Task"
-      disabled="true"
-      label="m2e - connectors">
-    <requirement
-        name="org.sonatype.m2e.modello.feature.feature.group"/>
-    <requirement
-        name="com.ianbrandt.tools.m2e.mdp.feature.feature.group"/>
-    <repository
-        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-modello/0.16.0/N/LATEST/"/>
-    <repository
-        url="https://ianbrandt.github.io/m2e-maven-dependency-plugin/"/>
-  </setupTask>
-  <setupTask
       xsi:type="git:GitCloneTask"
       id="git.clone.m2e.core"
       remoteURI="eclipse-m2e/m2e-core"
@@ -169,7 +156,8 @@
         locateNestedProjects="true"/>
   </setupTask>
   <setupTask
-      xsi:type="setup.workingsets:WorkingSetTask">
+      xsi:type="setup.workingsets:WorkingSetTask"
+      id="m2e.workingsets">
     <workingSet
         name="m2e-core"
         id="m2e.core">
@@ -181,7 +169,7 @@
             includeNestedRepositories="true"/>
         <operand
             xsi:type="workingsets:ExclusionPredicate"
-            excludedWorkingSet="//@setupTasks.11/@workingSets[name='m2e-core-tests'] //@setupTasks.11/@workingSets[name='m2e-maven-runtime']"/>
+            excludedWorkingSet="//'m2e.workingsets'/@workingSets[name='m2e-core-tests'] //'m2e.workingsets'/@workingSets[name='m2e-maven-runtime']"/>
       </predicate>
     </workingSet>
     <workingSet


### PR DESCRIPTION
The connectors defined in the disabled P2-director are not compatible with m2e and are unlikely to become compatible in the future (project seems abandoned) and are actually not necessary anymore.