### PR TITLE
Abstract the delta handling from the resource API

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/IIncrementalBuildFramework.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/IIncrementalBuildFramework.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 
 
@@ -47,13 +46,21 @@ public interface IIncrementalBuildFramework {
 
   /**
    * @experimental this interface is part of work in progress and can be changed or removed without notice.
+   * @since 2.4
+   */
+  public interface BuildDelta {
+    boolean hasDelta(File file);
+  }
+
+  /**
+   * @experimental this interface is part of work in progress and can be changed or removed without notice.
    * @since 1.6
    */
   public interface BuildContext {
     void release();
   }
 
-  BuildContext setupProjectBuildContext(IProject project, int kind, IResourceDelta delta,
-      BuildResultCollector results) throws CoreException;
+  BuildContext setupProjectBuildContext(IProject project, int kind, BuildDelta delta, BuildResultCollector results)
+      throws CoreException;
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/InternalBuildParticipant.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/InternalBuildParticipant.java
@@ -24,7 +24,6 @@ import org.apache.maven.execution.MavenSession;
 
 import org.sonatype.plexus.build.incremental.BuildContext;
 
-import org.eclipse.m2e.core.internal.builder.plexusbuildapi.AbstractEclipseBuildContext;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 
 
@@ -36,7 +35,7 @@ public abstract class InternalBuildParticipant {
 
   private MavenSession session;
 
-  private AbstractEclipseBuildContext buildContext;
+  private BuildContext buildContext;
 
   protected IMavenProjectFacade getMavenProjectFacade() {
     return facade;
@@ -71,7 +70,7 @@ public abstract class InternalBuildParticipant {
 
   public abstract boolean callOnEmptyDelta();
 
-  void setBuildContext(AbstractEclipseBuildContext buildContext) {
+  void setBuildContext(BuildContext buildContext) {
     this.buildContext = buildContext;
   }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/EclipseResourceBuildDelta.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/EclipseResourceBuildDelta.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2023 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Sonatype, Inc. - initial API and implementation
+ *      Christoph Läubrich - extracted and implement wrapper API
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal.builder.plexusbuildapi;
+
+import java.io.File;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+import org.eclipse.m2e.core.internal.builder.IIncrementalBuildFramework;
+
+
+public final class EclipseResourceBuildDelta implements IIncrementalBuildFramework.BuildDelta, IAdaptable {
+  private final IResource resource;
+
+  private final IResourceDelta delta;
+
+  /**
+   * @param resource
+   * @param delta
+   */
+  public EclipseResourceBuildDelta(IResourceDelta delta) {
+    this.resource = delta != null ? delta.getResource() : null;
+    this.delta = delta;
+  }
+
+  @Override
+  public boolean hasDelta(File file) {
+    return hasDelta(getRelativePath(file));
+  }
+
+  private boolean hasDelta(IPath path) {
+    return path == null || this.delta.findMember(path) != null;
+  }
+
+  /**
+   * Returns path relative to delta resource location.
+   */
+  private IPath getRelativePath(File file) {
+    IPath basepath = this.resource.getLocation();
+    IPath path = Path.fromOSString(file.getAbsolutePath());
+
+    if(!basepath.isPrefixOf(path)) {
+      return null;
+    }
+
+    return path.removeFirstSegments(basepath.segmentCount());
+  }
+
+  @Override
+  public <T> T getAdapter(Class<T> adapter) {
+    if(adapter.isInstance(delta)) {
+      return adapter.cast(delta);
+    }
+    if(adapter.isInstance(resource)) {
+      return adapter.cast(resource);
+    }
+    return null;
+  }
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/PlexusBuildAPI.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/plexusbuildapi/PlexusBuildAPI.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
 
@@ -39,13 +38,13 @@ public class PlexusBuildAPI implements IIncrementalBuildFramework {
   public static QualifiedName BUILD_CONTEXT_KEY = new QualifiedName(IMavenConstants.PLUGIN_ID, "BuildContext"); //$NON-NLS-1$
 
   @Override
-  public AbstractEclipseBuildContext setupProjectBuildContext(IProject project, int kind, IResourceDelta delta,
+  public BuildContext setupProjectBuildContext(IProject project, int kind, BuildDelta delta,
       IIncrementalBuildFramework.BuildResultCollector results) throws CoreException {
     @SuppressWarnings("unchecked")
     Map<String, Object> contextState = (Map<String, Object>) project.getSessionProperty(BUILD_CONTEXT_KEY);
-    AbstractEclipseBuildContext buildContext;
+    BuildContext buildContext;
     if(delta != null && contextState != null && (INCREMENTAL_BUILD == kind || AUTO_BUILD == kind)) {
-      buildContext = new EclipseIncrementalBuildContext(delta, contextState, results);
+      buildContext = new EclipseIncrementalBuildContext(delta, contextState, results, project.getLocation().toFile());
     } else if(CLEAN_BUILD == kind) {
       project.setSessionProperty(BUILD_CONTEXT_KEY, null); // clean context state
       buildContext = new EclipseBuildContext(project, new HashMap<String, Object>(), results);
@@ -59,7 +58,7 @@ public class PlexusBuildAPI implements IIncrementalBuildFramework {
         buildContext = new EclipseBuildContext(project, contextState, results);
       }
     }
-    ThreadBuildContext.setThreadBuildContext(buildContext);
+    ThreadBuildContext.setThreadBuildContext((org.sonatype.plexus.build.incremental.BuildContext) buildContext);
     return buildContext;
   }
 


### PR DESCRIPTION
Currently m2e is directly wired to the resource delta API, while this seems good in the context of eclipse for m2e this imposes to restrictive API as it is all noimplement/extend interfaces and offer much more than m2e actually using.

This aims to implement a thin wrapper for further improvement of delta detection especially when it comes to resource see for example https://github.com/eclipse-m2e/m2e-core/issues/1302

This will not fix anything but is an important first step to ensure things are still working as before.