### PR TITLE
Configure start behavior of logback-class through m2e.logback.feature

### DIFF
--- a/org.eclipse.m2e.logback.feature/build.properties
+++ b/org.eclipse.m2e.logback.feature/build.properties
@@ -1,2 +1,3 @@
 bin.includes = feature.xml,\
-               feature.properties
+               feature.properties,\
+               p2.inf

--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -16,6 +16,12 @@
       %copyright
    </copyright>
 
+   <requires>
+      <!-- This is only necessary until Aries can handle the absence of the servlet-api for logback:
+        https://github.com/apache/aries/pull/233 -->
+      <import plugin="jakarta.servlet-api" version="5.0.0" match="compatible"/>
+   </requires>
+
    <plugin
          id="org.eclipse.m2e.logback"
          download-size="0"

--- a/org.eclipse.m2e.logback.feature/p2.inf
+++ b/org.eclipse.m2e.logback.feature/p2.inf
@@ -1,0 +1,25 @@
+#The purpose of the following advices is to configure ch.qos.logback.classic as auto-started with start-level 2 when installing this feature 
+#Create a requirement on the fragment we are creating
+requires.0.namespace=org.eclipse.equinox.p2.iu
+requires.0.name=configure.logback.classic
+requires.0.range=[$version$,$version$]
+requires.0.greedy=true
+
+#Create a IU fragment named configure.logback.classic
+units.0.id=configure.logback.classic
+units.0.version=$version$
+units.0.provides.0.namespace=org.eclipse.equinox.p2.iu
+units.0.provides.0.name=configure.logback.classic
+units.0.provides.0.version=$version$
+units.0.instructions.install=org.eclipse.equinox.p2.touchpoint.eclipse.installBundle(bundle:${artifact});
+units.0.instructions.uninstall=org.eclipse.equinox.p2.touchpoint.eclipse.uninstallBundle(bundle:${artifact});
+units.0.instructions.configure= \
+  org.eclipse.equinox.p2.touchpoint.eclipse.setStartLevel(startLevel:2); \
+  org.eclipse.equinox.p2.touchpoint.eclipse.markStarted(started:true);
+units.0.instructions.unconfigure= \
+  org.eclipse.equinox.p2.touchpoint.eclipse.setStartLevel(startLevel:-1); \
+  org.eclipse.equinox.p2.touchpoint.eclipse.markStarted(started:false);
+units.0.hostRequirements.0.namespace=osgi.bundle
+units.0.hostRequirements.0.name=ch.qos.logback.classic
+units.0.hostRequirements.0.range=[1.3,1.5]
+units.0.hostRequirements.0.greedy=false

--- a/products/m2e-ide/Eclipse-M2E-IDE.launch
+++ b/products/m2e-ide/Eclipse-M2E-IDE.launch
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
     <setAttribute key="additional_plugins">
-        <setEntry value="ch.qos.logback.classic:1.4.8:default:true:default:true"/>
-        <setEntry value="jakarta.servlet-api:5.0.0:default:true:default:default"/>
+        <setEntry value="ch.qos.logback.classic:1.4.11:default:true:default:true"/>
         <setEntry value="org.apache.aries.spifly.dynamic.bundle:1.3.6:default:true:2:true"/>
         <setEntry value="org.apache.felix.scr:2.2.6:default:true:2:true"/>
         <setEntry value="org.apache.xml.resolver:1.2.0.v20220715-1206:default:true:default:default"/>

--- a/products/m2e-ide/m2e-ide.product
+++ b/products/m2e-ide/m2e-ide.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="M2Eclipse IDE" uid="m2e-ide" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="2.0.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="M2Eclipse IDE" uid="m2e-ide" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="2.0.0" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -23,13 +23,6 @@
       </win>
    </launcher>
 
-   <vm>
-   </vm>
-
-   <plugins>
-      <plugin id="jakarta.servlet-api" version="5.0.0"/>
-   </plugins>
-
    <features>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>
@@ -39,7 +32,6 @@
    </features>
 
    <configurations>
-      <plugin id="ch.qos.logback.classic" autoStart="true" startLevel="0" />
       <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />


### PR DESCRIPTION
and add 'jakarta.servlet-api' as requirement to ensure its present until Aries can handle its absense for logback:
https://github.com/apache/aries/pull/233

Fixes https://github.com/eclipse-m2e/m2e-core/issues/1481