### PR TITLE
Add jakarta.servlet-api required for logback to m2e-repo

### DIFF
--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -28,6 +28,7 @@
    <bundle id="com.google.gson.source"/>
    <bundle id="org.apache.commons.cli"/>
    <bundle id="org.apache.commons.cli.source"/>
+   <bundle id="jakarta.servlet-api"/>
    <bundle id="org.eclipse.m2e.archetype.jdom2"/>
    <bundle id="org.eclipse.m2e.archetype.jdom2.source"/>
    <bundle id="org.eclipse.m2e.archetype.archetype-catalog"/>


### PR DESCRIPTION
This should have been done as part of https://github.com/eclipse-m2e/m2e-core/pull/1512.