### PR TITLE
Make sure the last modified timestamp is set correctly

### DIFF
--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
@@ -147,7 +147,7 @@ public class MavenTargetBundle extends TargetBundle {
 					wrap.messages(true).map(ProcessingMessage::message).distinct().forEach(msg -> {
 						bundleStatus.add(Status.warning(msg));
 					});
-					return wrap.getFile();
+					return wrap.getFile().get();
 				}
 				if (directErrors.size() == 1) {
 					throw new CoreException(Status.error(directErrors.get(0).message()));

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -136,10 +136,7 @@ public class MavenBundleWrapper {
 			Map<DependencyNode, WrappedBundle> visited = new HashMap<>();
 			WrappedBundle wrappedNode = getWrappedNode(node, instructionsLookup, visited);
 			for (WrappedBundle wrap : visited.values()) {
-				Jar jar = wrap.getJar();
-				if (jar != null) {
-					jar.close();
-				}
+				wrap.getJar().ifPresent(jar -> jar.close());
 			}
 			return wrappedNode;
 		}
@@ -195,6 +192,7 @@ public class MavenBundleWrapper {
 			if (cached == null) {
 				List<ProcessingMessage> messages = new ArrayList<>();
 				wrapArtifactFile.getParentFile().mkdirs();
+				boolean hasErrors = false;
 				try (Analyzer analyzer = new Analyzer(analyzerJar);) {
 					analyzer.setProperty("mvnGroupId", artifact.getGroupId());
 					analyzer.setProperty("mvnArtifactId", artifact.getArtifactId());
@@ -208,7 +206,7 @@ public class MavenBundleWrapper {
 						analyzer.setProperty(property, trimValue);
 					}
 					for (WrappedBundle dep : depends) {
-						Jar depJar = dep.getJar();
+						Jar depJar = dep.getJar().orElse(null);
 						if (depJar == null) {
 							messages.add(new ProcessingMessage(artifact, Type.WARN,
 									"Dependency " + dep.getNode().getDependency() + " was ignored!"));
@@ -225,14 +223,21 @@ public class MavenBundleWrapper {
 							continue;
 						}
 						messages.add(new ProcessingMessage(artifact, Type.ERROR, err));
+						hasErrors = true;
 					}
 					for (String warn : analyzer.getWarnings()) {
 						messages.add(new ProcessingMessage(artifact, Type.WARN, warn));
 					}
 				}
-				wrapArtifactFile.setLastModified(originalFile.lastModified());
-				visited.put(node, wrappedNode = new WrappedBundle(node, depends, key, wrapArtifactFile.toPath(),
-						new Jar(wrapArtifactFile), messages));
+				if (hasErrors) {
+					Files.deleteIfExists(wrapArtifactFile.toPath());
+					visited.put(node, wrappedNode = new WrappedBundle(node, depends, key, null, null, messages));
+				} else {
+					Files.setLastModifiedTime(wrapArtifactFile.toPath(),
+							Files.getLastModifiedTime(originalFile.toPath()));
+					visited.put(node, wrappedNode = new WrappedBundle(node, depends, key, wrapArtifactFile.toPath(),
+							new Jar(wrapArtifactFile), messages));
+				}
 			} else {
 				visited.put(node, wrappedNode = new WrappedBundle(node, depends, key, wrapArtifactFile.toPath(),
 						new Jar(wrapArtifactFile), List.of()));
@@ -291,7 +296,7 @@ public class MavenBundleWrapper {
 		if (Files.exists(cacheFile)) {
 			FileTime sourceTimeStamp = Files.getLastModifiedTime(sourceFile);
 			FileTime cacheTimeStamp = Files.getLastModifiedTime(cacheFile);
-			return sourceTimeStamp.compareTo(cacheTimeStamp) > 0;
+			return sourceTimeStamp.toMillis() > cacheTimeStamp.toMillis();
 		}
 		return true;
 	}

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/WrappedBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/WrappedBundle.java
@@ -15,6 +15,7 @@ package org.eclipse.m2e.pde.target.shared;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.eclipse.aether.graph.DependencyNode;
@@ -26,8 +27,8 @@ public final class WrappedBundle {
 	private final DependencyNode node;
 	private final List<WrappedBundle> depends;
 	private final String instructionsKey;
-	private final Path file;
-	private final Jar jar;
+	private final Optional<Path> file;
+	private final Optional<Jar> jar;
 	private final List<ProcessingMessage> messages;
 
 	WrappedBundle(DependencyNode node, List<WrappedBundle> depends, String key, Path file, Jar jar,
@@ -35,8 +36,8 @@ public final class WrappedBundle {
 		this.node = node;
 		this.depends = depends;
 		this.instructionsKey = key;
-		this.file = file;
-		this.jar = jar;
+		this.file = Optional.ofNullable(file);
+		this.jar = Optional.ofNullable(jar);
 		this.messages = messages;
 	}
 
@@ -44,7 +45,7 @@ public final class WrappedBundle {
 		return instructionsKey;
 	}
 
-	Jar getJar() {
+	Optional<Jar> getJar() {
 		return jar;
 	}
 
@@ -52,8 +53,12 @@ public final class WrappedBundle {
 		return node;
 	}
 
-	/** @return the location of the wrapped bundle's files */
-	public Path getFile() {
+	/**
+	 * 
+	 * @return an optional describing the wrapped bundle, or an empty optional if
+	 *         the bundle was not wrapped because of errors in the generation phase.
+	 */
+	public Optional<Path> getFile() {
 		return file;
 	}
 


### PR DESCRIPTION
Linux stores modification time with nano-seconds precision, but we currently set the timestamp of the cached file only in milliseconds. This can lead to the situation that the source is considered a few nanoseconds older than the cache file and therefore the cache is regenerated every time.