### PR TITLE
Add latest tm4e release (0.8) to m2e's TP directly

### DIFF
--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -50,8 +50,9 @@
      </query>
    </iu>
    <category-def name="m2e" label="Maven Integration for Eclipse"/>
+   <repository-reference location="https://download.eclipse.org/eclipse/updates/4.28/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.0/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/tm4e/releases/0.8.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.23.0/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/eclipse/updates/4.28/" enabled="true" />
 </site>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -5,7 +5,6 @@
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/eclipse/updates/4.28/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-06/"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
@@ -30,11 +29,10 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
-			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tm4e/releases/0.8.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<repository location="https://download.eclipse.org/lsp4e/releases/0.23.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
 			<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
This allows to use snakeyaml from Maven-Central which is included in tm4e's repo. Therefore we can now drop the Orbit repo, which only served as provider of the old snakeyaml verson.

@vrubezhny as you suggested in https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/pull/1252#issuecomment-1685037743. Do you see any potential problem with this?
This will also help in https://github.com/eclipse-m2e/m2e-core/pull/1494, because the latest version of tm4e can use the latest snakeyaml 2 version (or one of its dependencies, not sure which one is causing the trouble), which the release included in wildwebdeveloper can't.