### PR TITLE
[Maven-Runtime] Ensure Guava is just referenced and not embedded

### DIFF
--- a/org.eclipse.m2e.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.feature/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Update build-qualifier because maven-runtime components currently use the commit
 Update build-qualifier because maven-runtime components now use again UTC+0-based qualifiers.
 Move o.e.m2e.maven.runtime to m2e's git-repo root 
 Update build-qualifier because maven-runtime version update to Maven 3.9.4
+Ensure Guava is not embedded but referenced by the m2e.maven.runtime

--- a/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/org.eclipse.m2e.maven.runtime/pom.xml
@@ -50,10 +50,6 @@
 				<!-- Excluded dependencies are fulfilled via the OSGi requirements specified below as Import-Package/Require-Bundle and
 					therefore don't have to be embedded. Or they are not required. -->
 				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>org.checkerframework</groupId>
 					<artifactId>checker-compat-qual</artifactId>
 				</exclusion>
@@ -126,6 +122,16 @@
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
 			<version>[1.0.0,)</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>failureaccess</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Since version 3.9 org.apache.maven:maven-embedder also references guava and therefore guava slipped again into the m2e.maven.runtime unnoticed. This change removes it again and ensures it cannot come back. This reduces the size of the (unzipped) m2e.maven.runtime about 3MB.