### PR TITLE
Add artifacts from SimRel-Orbit to m2e's p2-repository directly

### DIFF
--- a/org.eclipse.m2e.repository/category.xml
+++ b/org.eclipse.m2e.repository/category.xml
@@ -29,7 +29,10 @@
    <bundle id="org.apache.commons.cli"/>
    <bundle id="org.apache.commons.cli.source"/>
    <bundle id="jakarta.servlet-api"/>
-   <bundle id="com.google.guava" />
+   <bundle id="com.google.guava"/>
+   <bundle id="org.jdom2"/>
+   <bundle id="jaxen"/>
+   <bundle id="org.jdom"/>
    <iu>
      <query> 
        <expression type="match">
@@ -46,5 +49,4 @@
    <repository-reference location="https://download.eclipse.org/tm4e/releases/0.8.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.23.0/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09/" enabled="true" />
 </site>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -13,7 +13,7 @@
 			<unit id="org.mockito.mockito-core" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09/"/><!--Keep in sync with repo-ref in org.eclipse.m2e.repository/category.xml-->
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09/"/>
 			<unit id="org.jdom2" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
The content of
https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation is not contributed to SimRel and projects using artifacts from it are told to add the needed artifacts to their p2 repos.

For some context https://git.eclipse.org/r/c/simrel/org.eclipse.simrel.build/+/203841
I verified it locally and could install m2e into a sdk just with the m2e repository.