### PR TITLE
Change Micro-Version schema in wrapped archetype artifacts to 100-steps

### DIFF
--- a/org.eclipse.m2e.feature/build.properties
+++ b/org.eclipse.m2e.feature/build.properties
@@ -13,4 +13,3 @@
 bin.includes = feature.xml,\
                feature.properties,\
                p2.inf
-pom.model.property.tycho.baseline.skip = true

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -123,7 +123,8 @@
 Bundle-Name:           M2Eclipse's ${mvnArtifactId}
 version:               ${version_cleanup;${mvnVersion}}
 Bundle-SymbolicName:   org.eclipse.m2e.archetype.common
-Bundle-Version:        ${version}.1
+# Change the following value to '${version}' once the next minor version of archetype is availble
+Bundle-Version:        ${versionmask;==;${version}}.104
 Bundle-Vendor: 	       Eclipse.org - m2e
 Eclipse-ExtensibleAPI: true
 Export-Package:        META-INF.plexus;-noimport:=true;x-internal:=true, \
@@ -157,9 +158,10 @@ Import-Package:        org.jdom2*
 Bundle-Name:           M2Eclipse's ${mvnArtifactId}
 version:               ${version_cleanup;${mvnVersion}}
 Bundle-SymbolicName:   org.eclipse.m2e.archetype.${replacestring;${mvnArtifactId};archetype-}
-Bundle-Version:        ${version}.1
+# Change the following value to '${version}' once the next minor version of archetype is availble
+Bundle-Version:        ${version}.2
 Bundle-Vendor: 	       Eclipse.org - m2e
-Fragment-Host:         org.eclipse.m2e.archetype.common;bundle-version="${range;[===,+);3.2.1}"
+Fragment-Host:         org.eclipse.m2e.archetype.common;bundle-version="${range;[===,+);3.2.104}"
 Export-Package:        org.apache.maven.*;-noimport:=true;provider=m2e;mandatory:=provider;version="${version}";x-friends:="org.eclipse.m2e.core.ui"
 Import-Package:        !*
 ]]></instructions>


### PR DESCRIPTION
Before the Maven-archetype artifacts where obtained and wrapped in the TP, when they were embedded in a single 'o.e.m2e.archetype.common' bundle, said bundle had the version 3.2.104 and used 100er step as micro version where the hundreds matched the version of the original maven artifact's version.
This schema should be preserved for now to not have back-steps in versions until the next minor of Maven archetype is available.

This also caused problems in SimRel: https://git.eclipse.org/r/c/simrel/org.eclipse.simrel.build/+/203841

This is currently a draft since it requires some fine-tuning for maven-artifact-transfer.