### PR TITLE
Remove erroneous fragment attribute in m2e.feautre

### DIFF
--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.4.100.qualifier"
+      version="2.4.200.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"
@@ -27,7 +27,6 @@
          download-size="0"
          install-size="0"
          version="0.0.0"
-         fragment="true"
          unpack="false"/>
 
    <plugin


### PR DESCRIPTION
The Plug-in `org.eclipse.m2e.archetype.common` is not a Fragment and the corresponding attribute was added erroneously.

This was accidentally added in https://github.com/eclipse-m2e/m2e-core/pull/1494

Reported in https://github.com/eclipse-m2e/m2e-core/issues/1537