### PR TITLE
[Maven-Targets] update to biz.aQute.bndlib 7.0.0

### DIFF
--- a/org.eclipse.m2e.pde.feature/build.properties
+++ b/org.eclipse.m2e.pde.feature/build.properties
@@ -1,2 +1,3 @@
 bin.includes = feature.xml,\
                feature.properties
+pom.model.property.tycho.baseline.mode = warn

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.2.200.qualifier"
+      version="2.3.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"
@@ -24,27 +24,6 @@
       <import plugin="org.eclipse.m2e.core"/>
       <import plugin="org.eclipse.jface"/>
    </requires>
-
-   <plugin
-         id="biz.aQute.bnd.util"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="biz.aQute.bndlib"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.osgi.service.repository"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
 
    <plugin
          id="org.eclipse.m2e.pde.target"

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.0.401.qualifier
+Bundle-Version: 2.0.500.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
 Export-Package: org.eclipse.m2e.pde.target;x-friends:="org.eclipse.m2e.pde.ui",
  org.eclipse.m2e.pde.target.shared;x-internal:=true
 Bundle-ActivationPolicy: lazy
-Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)",
+Import-Package: aQute.bnd.osgi;version="[5.5.0,8.0.0)",
  aQute.bnd.version;version="[2.2.0,3.0.0)",
  org.apache.commons.codec.digest;version="1.14.0",
  org.apache.commons.io;version="2.6.0",

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.400.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",
  org.eclipse.ui.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org - m2e
-Import-Package: aQute.bnd.osgi;version="[5.5.0,6.0.0)"
+Import-Package: aQute.bnd.osgi;version="[5.5.0,8.0.0)"
 Service-Component: OSGI-INF/org.eclipse.m2e.pde.ui.target.adapter.DependencyNodeAdapterFactory.xml,
  OSGI-INF/org.eclipse.m2e.pde.ui.target.adapter.MavenTargetAdapterFactory.xml,
  OSGI-INF/org.eclipse.m2e.pde.ui.target.adapter.MavenTargetBundleAdapterFactory.xml,

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -48,13 +48,13 @@
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bnd.util</artifactId>
-					<version>6.4.1</version>
+					<version>7.0.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>biz.aQute.bndlib</artifactId>
-					<version>6.4.1</version>
+					<version>7.0.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
Prepare for the upcoming BND-lib 7.1 release.

Lets see if widening the version range is sufficient. Locally it at least compiled successfully.

In the context of https://github.com/eclipse-pde/eclipse.pde/discussions/774.

