### PR TITLE
Use SPDX identifier for license

### DIFF
--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -34,7 +34,7 @@
 	</organization>
 	<licenses>
 		<license>
-			<name>Eclipse Public License - v 2.0</name>
+			<name>EPL-2.0</name>
 			<url>https://www.eclipse.org/legal/epl-v20.html</url>
 		</license>
 	</licenses>


### PR DESCRIPTION
Recommended by Maven documentation and Eclipse EMO.