### PR TITLE
Make LookupJDKToolchainsJob detection less prone to failures

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/LookupJDKToolchainsJob.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/LookupJDKToolchainsJob.java
@@ -58,7 +58,7 @@ public class LookupJDKToolchainsJob extends Job {
 						}
 						addToolchain(toolchain);
 					}
-				} catch(IOException e) {
+				} catch(Exception e) {
 					return Status.error(e.getMessage(), e);
 				}
 			}


### PR DESCRIPTION
Detection should ignore errors like

```
!MESSAGE Process returned with error code "1".
Command line arguments: /opt/tools/java/oracle/jdk-5/latest/bin/java -Xmx16m -classpath /home/jenkins/agent/workspace/m2e-wtp_PR-28/org.eclipse.m2e.wtp.tests/target/work/configuration/org.eclipse.osgi/15/0/.cp/lib/launchingsupport.jar org.eclipse.jdt.internal.launching.support.LibraryDetector
Output: Standard output:
There was an error trying to initialize the HPI library.
Please check your installation, HotSpot does not work correctly
when installed in the JDK 1.2 Linux Production Release, or
with any JDK 1.1.x release.

Standard error:
Could not create the Java virtual machine.

!STACK 0
java.lang.IllegalStateException: Process returned with error code "1".
Command line arguments: /opt/tools/java/oracle/jdk-5/latest/bin/java -Xmx16m -classpath /home/jenkins/agent/workspace/m2e-wtp_PR-28/org.eclipse.m2e.wtp.tests/target/work/configuration/org.eclipse.osgi/15/0/.cp/lib/launchingsupport.jar org.eclipse.jdt.internal.launching.support.LibraryDetector
Output: Standard output:
There was an error trying to initialize the HPI library.
Please check your installation, HotSpot does not work correctly
when installed in the JDK 1.2 Linux Production Release, or
with any JDK 1.1.x release.

Standard error:
Could not create the Java virtual machine.

	at org.eclipse.jdt.internal.launching.StandardVMType.checkProcessResult(StandardVMType.java:932)
	at org.eclipse.jdt.internal.launching.StandardVMType.generateLibraryInfo(StandardVMType.java:730)
	at org.eclipse.jdt.internal.launching.StandardVMType.getLibraryInfo(StandardVMType.java:240)
	at org.eclipse.jdt.internal.launching.StandardVMType.getDefaultLibraryLocations(StandardVMType.java:457)
	at org.eclipse.jdt.internal.launching.StandardVMType.canDetectDefaultSystemLibraries(StandardVMType.java:267)
	at org.eclipse.jdt.internal.launching.StandardVMType.validateInstallLocation(StandardVMType.java:663)
	at org.eclipse.m2e.jdt.LookupJDKToolchainsJob.lambda$8(LookupJDKToolchainsJob.java:83)
```

Seen in https://ci.eclipse.org/m2e/job/m2e-wtp/view/change-requests/job/PR-28/13/artifact/org.eclipse.m2e.wtp.tests/target/work/data/.metadata/.log

Relates to https://github.com/eclipse-m2e/m2e-wtp/pull/28
