### PR TITLE
Bump bundle versions for License change

### DIFF
--- a/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.apt.core;singleton:=true
-Bundle-Version: 2.2.100.qualifier
+Bundle-Version: 2.2.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.apt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.apt.ui;singleton:=true
-Bundle-Version: 2.0.400.qualifier
+Bundle-Version: 2.0.401.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject.ui;singleton:=true
-Bundle-Version: 2.0.100.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Binary Project UI
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.binaryproject/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.binaryproject;singleton:=true
-Bundle-Version: 2.1.201.qualifier
+Bundle-Version: 2.1.202.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Binary Project Core
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",

--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 2.0.6.qualifier
+Bundle-Version: 2.0.7.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.4.0.qualifier
+Bundle-Version: 2.4.1.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>

--- a/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.discovery;singleton:=true
-Bundle-Version: 2.0.200.qualifier
+Bundle-Version: 2.0.201.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, LemMinX and Maven LS extension (requires Incubating components)
 Bundle-SymbolicName: org.eclipse.m2e.editor.lemminx;singleton:=true
-Bundle-Version: 2.0.4.qualifier
+Bundle-Version: 2.0.5.qualifier
 Automatic-Module-Name: org.eclipse.m2e.xmlls.extension
 Import-Package: javax.inject;version="[1.0.0,2.0.0)",
  org.eclipse.core.runtime;version="3.5.0",

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -24,7 +24,7 @@
 	<artifactId>org.eclipse.m2e.editor.lemminx</artifactId>
 	<name>M2E Maven POM File Editor (Wild Web Developer, LemMinX, LS)</name>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.4-SNAPSHOT</version>
+	<version>2.0.5-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.editor;singleton:=true
-Bundle-Version: 2.0.301.qualifier
+Bundle-Version: 2.0.302.qualifier
 Bundle-Activator: org.eclipse.m2e.editor.MavenEditorPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt.ui;singleton:=true
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.400.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt.ui.internal;x-internal:=true,
  org.eclipse.m2e.jdt.ui.internal.actions;x-internal:=true,

--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="2.0.5.qualifier"
+      version="2.0.6.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.logback.feature/feature.xml
+++ b/org.eclipse.m2e.logback.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.logback.feature"
       label="%featureName"
-      version="2.2.0.qualifier"
+      version="2.2.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"
@@ -17,8 +17,6 @@
    </copyright>
 
    <requires>
-      <!-- This is only necessary until Aries can handle the absence of the servlet-api for logback:
-        https://github.com/apache/aries/pull/233 -->
       <import plugin="jakarta.servlet-api" version="5.0.0" match="compatible"/>
    </requires>
 

--- a/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.logback/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.logback;singleton:=true
-Bundle-Version: 2.2.0.qualifier
+Bundle-Version: 2.2.1.qualifier
 Bundle-Name: M2E Logback Appender and Configuration
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.m2e.mavenarchiver/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.mavenarchiver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: m2e connector for the mavenarchiver and pom properties
 Bundle-SymbolicName: org.eclipse.m2e.mavenarchiver;singleton:=true
-Bundle-Version: 2.0.400.qualifier
+Bundle-Version: 2.0.401.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",

--- a/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: M2E Maven Project Model Edit
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.400.qualifier
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.model.edit;singleton:=true
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Connector
 Bundle-SymbolicName: org.eclipse.m2e.pde.connector;singleton:=true
-Bundle-Version: 2.1.400.qualifier
+Bundle-Version: 2.1.500.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.connector
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org - m2e

--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Profiles Management
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
-Bundle-Version: 2.1.200.qualifier
+Bundle-Version: 2.1.201.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",

--- a/org.eclipse.m2e.profiles.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.profiles.ui;singleton:=true
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.301.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.m2e.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.m2e.refactoring;singleton:=true
-Bundle-Version: 2.0.301.qualifier
+Bundle-Version: 2.0.302.qualifier
 Bundle-Activator: org.eclipse.m2e.refactoring.internal.Activator
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",

--- a/org.eclipse.m2e.scm/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.scm/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.scm;singleton:=true
-Bundle-Version: 2.0.200.qualifier
+Bundle-Version: 2.0.201.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.sourcelookup.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.sourcelookup.ui;singleton:=true
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.400.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Source Lookup UI
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.sourcelookup/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.sourcelookup;singleton:=true
-Bundle-Version: 2.0.300.qualifier
+Bundle-Version: 2.0.301.qualifier
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-Name: M2E Source Lookup Core
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Testing Helpers
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 2.0.4.qualifier
+Bundle-Version: 2.0.5.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",


### PR DESCRIPTION
License in pom.xml has caused MANIFEST.MF to change. Some bundles need to be touched to properly reflect this change.