### PR TITLE
fix(utils): Improve robustness in createFolder

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
@@ -61,7 +61,8 @@ public class M2EUtils {
         }
       } catch(CoreException ex) {
         //Don't fail if the resource already exists, in case of a race condition
-        if(ex.getStatus().getCode() != IResourceStatus.RESOURCE_EXISTS) {
+        int code = ex.getStatus().getCode();
+        if(code != IResourceStatus.RESOURCE_EXISTS && code != IResourceStatus.PATH_OCCUPIED) {
           throw ex;
         }
       }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/M2EUtils.java
@@ -61,8 +61,7 @@ public class M2EUtils {
         }
       } catch(CoreException ex) {
         //Don't fail if the resource already exists, in case of a race condition
-        int code = ex.getStatus().getCode();
-        if(code != IResourceStatus.RESOURCE_EXISTS && code != IResourceStatus.PATH_OCCUPIED) {
+        if (!folder.exists()) {
           throw ex;
         }
       }


### PR DESCRIPTION
The `createFolder` util method should not throw an Exception when the folder already exists.

A first step toward this behavior has been added with https://github.com/eclipse-m2e/m2e-core/commit/00ca0dfed8127cbbaae96e061f2e195f056e258d

It looks however incomplete as I have a case in my integration of me where an ResourceException is thrown like below:

```
org.eclipse.core.internal.resources.ResourceException(/procurement-app/target)[374]:
java.lang.Exception: Resource '/procurement-app/target' already exists.
 	at org.eclipse.core.internal.resources.ResourceException.provideStackTrace(ResourceException.java:42)
 	at org.eclipse.core.internal.resources.ResourceException.<init>(ResourceException.java:38)
 	at org.eclipse.core.internal.resources.Resource.checkDoesNotExist(Resource.java:346)
 	at org.eclipse.core.internal.resources.Resource.checkDoesNotExist(Resource.java:333)
 	at org.eclipse.core.internal.resources.Folder.assertCreateRequirements(Folder.java:40)
 	at org.eclipse.core.internal.resources.Folder.create(Folder.java:101)
 	at org.eclipse.core.internal.resources.Folder.create(Folder.java:129)
 	at org.eclipse.m2e.core.internal.M2EUtils.createFolder(M2EUtils.java:61)
 	at org.eclipse.m2e.core.project.configurator.AbstractLifecycleMapping.configure(AbstractLifecycleMapping.java:87)
 	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.lambda$6(ProjectConfigurationManager.java:504)
 	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:394)
 	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:275)
 	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.updateProjectConfiguration(ProjectConfigurationManager.java:498)
 	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.configureNewMavenProjects(ProjectConfigurationManager.java:279)
 	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.lambda$1(ProjectConfigurationManager.java:166)
 	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:394)
 	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:275)
 	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:214)
 	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.importProjects(ProjectConfigurationManager.java:139)
 	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.importProjects(ProjectConfigurationManager.java:130)
```

`374` is the code status for `PATH_OCCUPIED` which is used [here](https://github.com/eclipse-platform/eclipse.platform/blob/master/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java#L345)

Also ignoring this status should improve robustness.