### PR TITLE
Removes "only" in contributing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,4 +122,4 @@ The delta for version bumps are:
 
 ### ➕ Submit changes
 
-m2e only accepts contributions via GitHub Pull Requests against [https://github.com/eclipse-m2e/m2e-core](https://github.com/eclipse-m2e/m2e-core) repository.
+m2e accepts contributions via GitHub Pull Requests against [https://github.com/eclipse-m2e/m2e-core](https://github.com/eclipse-m2e/m2e-core) repository.


### PR DESCRIPTION
"m2e only accepts contributions" has been replaced with "m2e accepts contributions". Only sounds like a restriction which I think it not necessary.