### PR TITLE
Fix "m2e plugin sometimes 'loses' resources" (#1511)

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.4.1.qualifier
+Bundle-Version: 2.4.2.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core</artifactId>
-	<version>2.4.1-SNAPSHOT</version>
+	<version>2.4.2-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilderImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilderImpl.java
@@ -226,7 +226,7 @@ public class MavenBuilderImpl {
         if(buildOutputLocation.isPrefixOf(fullPath)) {
           //anything in the build output is not interesting for a change as it is produced by the build
           // ... unless a classpath resource that existed before has been deleted, possibly by another builder
-          if(!resource.exists() && isOutputOrTestOutput.test(fullPath)) {
+          if(isOutputOrTestOutput.test(fullPath) && !resource.exists()) {
             hasRelevantDelta.set(true);
             return false;
           }


### PR DESCRIPTION
The Java Builder may delete files from the project output directory that need to be re-created by the m2e Maven Builder.

With commit 8e5cd4967eaca2698e8f7109461320e11a11d4d7 (a fix for #1275), any changes to the project output directory were ignored, leading to unexpected errors when running an application after modifying the project POM: resources were missing from the target classpath, leading all sorts of unexpected program behavior.

This change allows marking these changes as relevant, as long as the following conditions are met:

- The expected resource no longer exists (i.e., it was deleted by another builder, plugin or outside process)
- The modification applies to a resource in the classes or test-classes folder (i.e., outputLocation/testOutputLocation)

https://github.com/eclipse-m2e/m2e-core/issues/1511 https://github.com/eclipse-m2e/m2e-core/issues/1275