### PR TITLE
MavenTargetLocation equals comparison never returns true

### DIFF
--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.0.500.qualifier
+Bundle-Version: 2.0.600.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -514,7 +514,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(roots, dependencyScopes, failedArtifacts, metadataMode);
+		return serialize().hashCode();
 	}
 
 	@Override
@@ -523,9 +523,8 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 			return true;
 		}
 		return obj instanceof MavenTargetLocation other //
-				&& Objects.equals(roots, other.roots)//
-				&& Objects.equals(dependencyScopes, other.dependencyScopes)
-				&& Objects.equals(failedArtifacts, other.failedArtifacts);
+				// check each and every relevant attribute, including nested ones
+				&& serialize().equals(other.serialize());
 	}
 
 	public boolean isIncludeSource() {


### PR DESCRIPTION
In the TargetPlatformPreferencePage, upon the Apply button, some target definition containing some MavenTargetLocation always is rewritten to it's .target file, when MavenTargetDependency lacks an impl of equals(), causing MavenTargetLocation.roots to never be equal.