### PR TITLE
Don't set target feature version to default if it is already set

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.3.0.qualifier"
+      version="2.3.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.0.400.qualifier
+Bundle-Version: 2.0.401.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.19.0",

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/FeatureSpecPage.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/FeatureSpecPage.java
@@ -53,7 +53,9 @@ public class FeatureSpecPage extends AbstractFeatureSpecPage {
 
 	@Override
 	protected void initialize() {
-		fFeatureVersionText.setText("1.0.0.qualifier"); //$NON-NLS-1$
+		if (fFeatureVersionText != null && fFeatureVersionText.getText().isEmpty()) {
+			fFeatureVersionText.setText("1.0.0.qualifier"); //$NON-NLS-1$
+		}
 		setMessage(PDEUIMessages.NewFeatureWizard_MainPage_desc);
 	}
 


### PR DESCRIPTION
Previously, editing a target feature location would always set the version to `1.0.0.qualifier`, even if the version was set already. This is because this `initialize()` method is called _after_ the feature details are filled in.

Now, editing an existing feature will fill in the details as shown in the target file. New features will continue to be set to `1.0.0.qualifier`.