### PR TITLE
Make automatic configuration updates configurable per project

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,13 @@
 
 Updated the embedded Maven from version 3.9.5 to 3.9.6; [Maven 3.9.6 Release Notes](https://maven.apache.org/docs/3.9.6/release-notes.html).
 
+### New project preference for automated Maven project configuration updates
+
+Automatic configuration updates for Maven projects can now be disabled the in the project preferences.
+This allows to disable these updates individually per project and to store the setting in a preference-file under version control,
+which is useful for projects that require special workspace configuration that doesn't exactly match the configuration in the `pom.xml`.
+
+![grafik](https://github.com/eclipse-m2e/m2e-core/assets/44067969/7d27ceda-5d13-4f0e-97f0-ff34c94d7493)
 
 ## 2.5.0
 

--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 2.0.8.qualifier
+Bundle-Version: 2.0.800.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
@@ -56,3 +56,9 @@ Service-Component: OSGI-INF/component.xml,
  OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypeGenerator.xml,
  OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypePlugin.xml
 Automatic-Module-Name: org.eclipse.m2e.core.ui
+Service-Component: OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypeGenerator.xml,
+ OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypePlugin.xml
+Bundle-ActivationPolicy: lazy
+Service-Component: OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypeGenerator.xml,
+ OSGI-INF/org.eclipse.m2e.core.ui.internal.archetype.ArchetypePlugin.xml
+Bundle-ActivationPolicy: lazy

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/OutOfDateConfigurationDeltaVisitor.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/project/OutOfDateConfigurationDeltaVisitor.java
@@ -35,7 +35,7 @@ import org.eclipse.m2e.core.internal.Messages;
  */
 public class OutOfDateConfigurationDeltaVisitor implements IResourceDeltaVisitor {
 
-  List<IProject> outOfDateProjects = new ArrayList<>();
+  final List<IProject> outOfDateProjects = new ArrayList<>();
 
   @Override
   public boolean visit(IResourceDelta delta) throws CoreException {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceInitializer.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenPreferenceInitializer.java
@@ -27,6 +27,8 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
  */
 public class MavenPreferenceInitializer extends AbstractPreferenceInitializer {
 
+  public static final boolean P_AUTO_UPDATE_CONFIGURATION_DEFAULT = true;
+
   @Override
   public void initializeDefaultPreferences() {
     IEclipsePreferences store = DefaultScope.INSTANCE.getNode(IMavenConstants.PLUGIN_ID);
@@ -63,7 +65,7 @@ public class MavenPreferenceInitializer extends AbstractPreferenceInitializer {
     // set to null since the plugin state location is not available by the time execution reaches here
     store.remove(MavenPreferenceConstants.P_WORKSPACE_MAPPINGS_LOCATION);
 
-    store.putBoolean(MavenPreferenceConstants.P_AUTO_UPDATE_CONFIGURATION, true);
+    store.putBoolean(MavenPreferenceConstants.P_AUTO_UPDATE_CONFIGURATION, P_AUTO_UPDATE_CONFIGURATION_DEFAULT);
 
     store.putBoolean(MavenPreferenceConstants.P_ENABLE_SNAPSHOT_ARCHETYPES, false);
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -885,12 +885,16 @@ public class ProjectConfigurationManager
 
         if(facade != null) {
           ProblemSeverity outOfDateSeverity = ProblemSeverity.get(mavenConfiguration.getOutOfDateProjectSeverity());
-          mavenMarkerManager.deleteMarkers(facade.getProject(), IMavenConstants.MARKER_CONFIGURATION_ID);
+          IProject project = facade.getProject();
+          mavenMarkerManager.deleteMarkers(project, IMavenConstants.MARKER_CONFIGURATION_ID);
           if(!ProblemSeverity.ignore.equals(outOfDateSeverity)) {
             LifecycleMappingConfiguration oldConfiguration = LifecycleMappingConfiguration.restore(facade, monitor);
             if(oldConfiguration != null
                 && LifecycleMappingFactory.isLifecycleMappingChanged(facade, oldConfiguration, monitor)) {
-              mavenMarkerManager.addMarker(facade.getProject(), IMavenConstants.MARKER_CONFIGURATION_ID,
+              if(!ResolverConfigurationIO.isAutomaticallyUpdateConfiguration(project)) {
+                outOfDateSeverity = ProblemSeverity.info;
+              }
+              mavenMarkerManager.addMarker(project, IMavenConstants.MARKER_CONFIGURATION_ID,
                   Messages.ProjectConfigurationUpdateRequired, -1, outOfDateSeverity.getSeverity());
             }
           }


### PR DESCRIPTION
And degrade problems about out-dated project configuration to severity 'info', if automatic updates are disabled for a project.

![grafik](https://github.com/eclipse-m2e/m2e-core/assets/44067969/7d27ceda-5d13-4f0e-97f0-ff34c94d7493)


Fixes https://github.com/eclipse-m2e/m2e-core/issues/1661

@laeubi what do you think?
I'm not sure adding API methods is really necessary (for now I just added it for completes/symmetry) but it is probably sufficient to have this internal.