### PR TITLE
Consider the settings files location in project configuration

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
@@ -237,6 +237,20 @@ public class MavenProperties {
     }
   }
 
+  public static String getAlternateGlobalToolchainsFile(CommandLine commandline) {
+    if(commandline != null && commandline.hasOption(CLIManager.ALTERNATE_GLOBAL_TOOLCHAINS)) {
+      return commandline.getOptionValue(CLIManager.ALTERNATE_USER_SETTINGS);
+    }
+    return null;
+  }
+
+  public static String getAlternateUserToolchainsFile(CommandLine commandline) {
+    if(commandline != null && commandline.hasOption(CLIManager.ALTERNATE_USER_TOOLCHAINS)) {
+      return commandline.getOptionValue(CLIManager.ALTERNATE_USER_TOOLCHAINS);
+    }
+    return null;
+  }
+
   public static void getCliProperty(String property, BiConsumer<String, String> consumer) {
     int index = property.indexOf('=');
     if(index <= 0) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -664,6 +664,10 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
 
     private List<String> inactiveProfiles;
 
+    private String globalSettingsFile;
+
+    private String userSettingsFile;
+
     private MavenProjectConfiguration(IProjectConfiguration baseConfiguration) {
       if(baseConfiguration == null) {
         //we should really forbid this but some test seem to pass null!
@@ -677,6 +681,8 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
       this.profiles = baseConfiguration.getSelectedProfiles();
       this.activeProfiles = List.copyOf(baseConfiguration.getActiveProfileList());
       this.inactiveProfiles = List.copyOf(baseConfiguration.getInactiveProfileList());
+      this.globalSettingsFile = baseConfiguration.getGlobalSettingsFile();
+      this.userSettingsFile = baseConfiguration.getUserSettingsFile();
     }
 
     @Override
@@ -733,6 +739,16 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
     @Override
     public List<String> getInactiveProfileList() {
       return inactiveProfiles;
+    }
+
+    @Override
+    public String getGlobalSettingsFile() {
+      return globalSettingsFile;
+    }
+
+    @Override
+    public String getUserSettingsFile() {
+      return userSettingsFile;
     }
 
   }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IProjectConfiguration.java
@@ -54,6 +54,10 @@ public interface IProjectConfiguration {
 
   File getMultiModuleProjectDirectory();
 
+  String getGlobalSettingsFile();
+
+  String getUserSettingsFile();
+
   /**
    * Computes a hashcode over the contents of the given configuration, that is a semantic hash-code that can be used in
    * combination of {@link #contentsEquals(IProjectConfiguration, IProjectConfiguration)}
@@ -65,7 +69,8 @@ public interface IProjectConfiguration {
     return Objects.hash(configuration.isResolveWorkspaceProjects(), configuration.getActiveProfileList(),
         configuration.getInactiveProfileList(), configuration.getLifecycleMappingId(),
         configuration.getConfigurationProperties(), configuration.getUserProperties(),
-        configuration.getMultiModuleProjectDirectory());
+        configuration.getMultiModuleProjectDirectory(), configuration.getGlobalSettingsFile(),
+        configuration.getUserSettingsFile());
   }
 
   public static boolean contentsEquals(IProjectConfiguration configuration, IProjectConfiguration other) {
@@ -81,7 +86,9 @@ public interface IProjectConfiguration {
         && Objects.equals(configuration.getInactiveProfileList(), other.getInactiveProfileList())
         && Objects.equals(configuration.getConfigurationProperties(), other.getConfigurationProperties())
         && Objects.equals(configuration.getUserProperties(), other.getUserProperties())
-        && Objects.equals(configuration.getMultiModuleProjectDirectory(), other.getMultiModuleProjectDirectory());
+        && Objects.equals(configuration.getMultiModuleProjectDirectory(), other.getMultiModuleProjectDirectory())
+        && Objects.equals(configuration.getGlobalSettingsFile(), other.getGlobalSettingsFile())
+        && Objects.equals(configuration.getUserSettingsFile(), other.getUserSettingsFile());
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/ResolverConfiguration.java
@@ -66,6 +66,10 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
 
   private List<String> userInactiveProfiles;
 
+  private String globalSettingsFile;
+
+  private String userSettingsFile;
+
   public ResolverConfiguration() {
   }
 
@@ -79,9 +83,9 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
   public ResolverConfiguration(IProjectConfiguration resolverConfiguration) {
     setLifecycleMappingId(resolverConfiguration.getLifecycleMappingId());
     setMultiModuleProjectDirectory(resolverConfiguration.getMultiModuleProjectDirectory());
-    Properties properties2 = new Properties();
-    properties2.putAll(resolverConfiguration.getConfigurationProperties());
-    setProperties(properties2);
+    Properties properties = new Properties();
+    properties.putAll(resolverConfiguration.getConfigurationProperties());
+    setProperties(properties);
     setResolveWorkspaceProjects(resolverConfiguration.isResolveWorkspaceProjects());
     setSelectedProfiles(resolverConfiguration.getSelectedProfiles());
   }
@@ -195,6 +199,16 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
     return multiModuleProjectDirectory;
   }
 
+  @Override
+  public String getGlobalSettingsFile() {
+    return globalSettingsFile;
+  }
+
+  @Override
+  public String getUserSettingsFile() {
+    return userSettingsFile;
+  }
+
   /**
    * @param multiModuleProjectDirectory The multiModuleProjectDirectory to set.
    */
@@ -209,6 +223,8 @@ public class ResolverConfiguration implements Serializable, IProjectConfiguratio
         userActiveProfiles = new ArrayList<>();
         userInactiveProfiles = new ArrayList<>();
         MavenProperties.getProfiles(commandLine, userActiveProfiles::add, userInactiveProfiles::add);
+        globalSettingsFile = MavenProperties.getAlternateGlobalToolchainsFile(commandLine);
+        userSettingsFile = MavenProperties.getAlternateUserToolchainsFile(commandLine);
       } catch(IOException | ParseException ex) {
         //can't use it then... :-(
         MavenPluginActivator.getDefault().getLog().error("can't read maven args from " + multiModuleProjectDirectory,


### PR DESCRIPTION
Currently the settings files are not considered when grouping projects by there project configuration.

As the settings files can have an impact they should be considered when grouping projects.

This is part of 
- https://github.com/eclipse-m2e/m2e-core/pull/1673

after further investigation I'm not sure if it is required or useful at all and if not 
- https://github.com/eclipse-m2e/m2e-core/pull/1674

is actually enough, because if the multi module basedir is the same the settings needs also be the same, the same is true as well for profiles and user properties, so the main question would be if there are cases where the settings are defined differently other than `maven.config` or m2e preferences.
