### PR TITLE
Support loading of settings from other locations

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -187,6 +187,8 @@ public interface IMaven extends IComponentLookup {
    */
   Settings getSettings() throws CoreException;
 
+  Settings getSettings(MavenSettingsLocations locations) throws CoreException;
+
   String getLocalRepositoryPath();
 
   ArtifactRepository getLocalRepository() throws CoreException;
@@ -209,6 +211,10 @@ public interface IMaven extends IComponentLookup {
 
   List<ArtifactRepository> getPluginArtifactRepositories(boolean injectSettings) throws CoreException;
 
+  /**
+   * @deprecated use {@link #getSettings(MavenSettingsLocations)} instead
+   */
+  @Deprecated(forRemoval = true)
   Settings buildSettings(String globalSettings, String userSettings) throws CoreException;
 
   void writeSettings(Settings settings, OutputStream out) throws CoreException;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java
@@ -134,6 +134,8 @@ public interface IMavenConfiguration {
    */
   boolean buildWithNullSchedulingRule();
 
+  MavenSettingsLocations getSettingsLocations();
+
   static IMavenConfiguration getWorkspaceConfiguration() {
     MavenPluginActivator activator = MavenPluginActivator.getDefault();
     if(activator == null) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenSettingsLocations.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/MavenSettingsLocations.java
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.m2e.core.embedder;
+
+import java.io.File;
+
+
+/**
+ * This recored encapsulates the combination of a global and a user settings files as defined in
+ * https://maven.apache.org/settings.html
+ */
+public record MavenSettingsLocations(File globalSettings, File userSettings) {
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenConfigurationImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/preferences/MavenConfigurationImpl.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.m2e.core.internal.preferences;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,10 +42,12 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.runtime.preferences.PreferenceFilterEntry;
 
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.cli.configuration.SettingsXmlConfigurationProcessor;
 
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.embedder.IMavenConfigurationChangeListener;
 import org.eclipse.m2e.core.embedder.MavenConfigurationChangeEvent;
+import org.eclipse.m2e.core.embedder.MavenSettingsLocations;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory;
@@ -204,6 +207,25 @@ public class MavenConfigurationImpl implements IMavenConfiguration, IPreferenceC
         log.error("Could not deliver maven configuration change event", e);
       }
     }
+  }
+
+  @Override
+  public MavenSettingsLocations getSettingsLocations() {
+    File userSettings;
+    File globalSettings;
+    String configSettingsFile = getUserSettingsFile();
+    if (configSettingsFile==null) {
+      userSettings = SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE;
+    } else {
+      userSettings = new File(configSettingsFile);
+    }
+    String configGlobalSettingsFile = getGlobalSettingsFile();
+    if(configGlobalSettingsFile == null) {
+      globalSettings = null;
+    } else {
+      globalSettings = new File(configGlobalSettingsFile);
+    }
+    return new MavenSettingsLocations(globalSettings, userSettings);
   }
 
   @Override


### PR DESCRIPTION
Currently there is only one cached settings object for the all projects but it is possible for projects to carry individual settings.

This now enhances the settings handling in a way to support providing a composite key of global and local settings to be loaded an cached.

This is split up from this:
- https://github.com/eclipse-m2e/m2e-core/pull/1673

to keep changes small in the actual PR