### PR TITLE
Use preferences in property tester

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/actions/MavenPropertyTester.java
@@ -18,8 +18,8 @@ import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.ui.IFileEditorInput;
@@ -27,9 +27,9 @@ import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.project.ResolverConfigurationIO;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
-import org.eclipse.m2e.core.project.IProjectConfiguration;
 import org.eclipse.m2e.core.project.MavenProjectUtils;
 
 
@@ -60,19 +60,11 @@ public class MavenPropertyTester extends PropertyTester {
   @Override
   public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
     if(WORKSPACE_RESULUTION_ENABLE.equals(property)) {
-      boolean enableWorkspaceResolution = true;
-      IAdaptable adaptable = (IAdaptable) receiver;
-
-      IProject projectAdapter = adaptable.getAdapter(IProject.class);
+      IProject projectAdapter = Adapters.adapt(receiver, IProject.class);
       if(projectAdapter != null) {
-        IMavenProjectRegistry projectManager = MavenPlugin.getMavenProjectRegistry();
-        IMavenProjectFacade projectFacade = projectManager.create(projectAdapter, new NullProgressMonitor());
-        if(projectFacade != null) {
-          IProjectConfiguration configuration = projectFacade.getConfiguration();
-          return !configuration.isResolveWorkspaceProjects();
-        }
+        return !ResolverConfigurationIO.isResolveWorkspaceProjects(projectAdapter);
       }
-      return enableWorkspaceResolution;
+      return true;
     }
 
     if(HAS_ARTIFACT_KEY.equals(property)) {

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ResolverConfigurationIO.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ResolverConfigurationIO.java
@@ -56,6 +56,8 @@ public class ResolverConfigurationIO {
    */
   private static final String P_RESOLVE_WORKSPACE_PROJECTS = "resolveWorkspaceProjects"; //$NON-NLS-1$
 
+  private static final boolean P_RESOLVE_WORKSPACE_PROJECTS_DEFAULT = false;
+
   private static final String P_AUTO_UPDATE_CONFIGURATION = MavenPreferenceConstants.P_AUTO_UPDATE_CONFIGURATION;
 
   /**
@@ -117,7 +119,8 @@ public class ResolverConfigurationIO {
       return new ResolverConfiguration(project);
     }
     ResolverConfiguration configuration = new ResolverConfiguration();
-    configuration.setResolveWorkspaceProjects(projectNode.getBoolean(P_RESOLVE_WORKSPACE_PROJECTS, false));
+    configuration.setResolveWorkspaceProjects(
+        projectNode.getBoolean(P_RESOLVE_WORKSPACE_PROJECTS, P_RESOLVE_WORKSPACE_PROJECTS_DEFAULT));
     configuration.setSelectedProfiles(projectNode.get(P_SELECTED_PROFILES, "")); //$NON-NLS-1$
     configuration.setLifecycleMappingId(projectNode.get(P_LIFECYCLE_MAPPING_ID, (String) null));
     configuration.setProperties(stringAsProperties(projectNode.get(P_PROPERTIES, null)));
@@ -137,6 +140,14 @@ public class ResolverConfigurationIO {
       preferences.putBoolean(P_AUTO_UPDATE_CONFIGURATION, isAutomaticallyUpdateConfiguration);
       savePreferences(preferences);
     }
+  }
+
+  public static boolean isResolveWorkspaceProjects(IProject project) {
+    IEclipsePreferences preferences = getMavenProjectPreferences(project);
+    if(preferences == null) {
+      return P_RESOLVE_WORKSPACE_PROJECTS_DEFAULT;
+    }
+    return preferences.getBoolean(P_RESOLVE_WORKSPACE_PROJECTS, P_RESOLVE_WORKSPACE_PROJECTS_DEFAULT);
   }
 
   private static IEclipsePreferences getMavenProjectPreferences(IProject project) {


### PR DESCRIPTION
The Maven property tester can hang the IDE as it query the project registry what might be a lengthy task.

To determine if a project has workspace resolution we can simply go directly to the preferences.

This is similar to what we have done previously for automatic project updates.