### PR TITLE
Resolve the local repository path relative to the multi module directory

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -346,7 +346,8 @@ public class PlexusContainerManager {
       IMavenConfiguration workspaceConfiguration = IMavenConfiguration.getWorkspaceConfiguration();
       MavenExecutionRequest request = MavenExecutionContext.createExecutionRequest(mavenConfiguration,
           wrap(container), mavenProperties.map(mavenCfg -> mavenCfg.getSettingsLocations(workspaceConfiguration))
-              .orElseGet(workspaceConfiguration::getSettingsLocations));
+              .orElseGet(workspaceConfiguration::getSettingsLocations),
+          multiModuleProjectDirectory);
       container.lookup(MavenExecutionRequestPopulator.class).populateDefaults(request);
       request.setBaseDirectory(multiModuleProjectDirectory);
       request.setMultiModuleProjectDirectory(multiModuleProjectDirectory);


### PR DESCRIPTION
If a user specify a relative path in the settings.xml this currently leads a bit to unspecified behavior. Java would then resolve it to the current working directory what might give desired results on the commandline (but sometimes also unexpected ones) but in the IDE it is not really controllable.

This now resolves the local repository path against the multi module directory what is the only user controllable constant directory we can offer here at the moment.