### PR TITLE
Update m2e.core and m2e.sdk to 2.6 and add some release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Eclipse m2e - Release notes
 
-## 2.5.1
+## 2.6.0
 
 * 📅 Release Date: _expected_ end February 2024
 
@@ -8,7 +8,16 @@
 
 Updated the embedded Maven from version 3.9.5 to 3.9.6; [Maven 3.9.6 Release Notes](https://maven.apache.org/docs/3.9.6/release-notes.html).
 
-### New project preference for automated Maven project configuration updates
+### Improved toolchain.xml handling
+
+In the Preferences under `Maven -> User Settings` the user `toolchain.xml` used in workspace builds can now be specified explicitly.
+At the same time the `maven-toolchains-plugin` is now disabled by default for workspace builds.
+
+### Improved resource linking
+
+Source or resource folders of Maven-projects outside of the project's base directory are now considered in the workspace and are added to the project as linked resources.
+
+### Project preference for automated Maven project configuration updates
 
 Automatic configuration updates for Maven projects can now be disabled the in the project preferences.
 This allows to disable these updates individually per project and to store the setting in a preference-file under version control,

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.4.2.qualifier
+Bundle-Version: 2.6.0.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/pom.xml
+++ b/org.eclipse.m2e.core/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.m2e.core</artifactId>
-	<version>2.4.2-SNAPSHOT</version>
+	<version>2.6.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<name>Maven Integration for Eclipse Core Plug-in</name>

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.4.300.qualifier"
+      version="2.6.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.5.1.qualifier"
+      version="2.6.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
In this release cycle new API methods were added to m2e.core. 
Consequently the minor version of m2e.core and all containers should be bumped.