### PR TITLE
First check file is already absolute before use basepath

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenExecutionContext.java
@@ -264,9 +264,13 @@ public class MavenExecutionContext implements IMavenExecutionContext {
     if(localRepositoryPath == null) {
       return RepositorySystem.defaultUserLocalRepository;
     }
-      //Actually maven would resolve these against the current working directory, 
-      //as we have no such thing available the best we can use here is the root folder of the multimodule directory
-      return new File(multiModuleProjectDirectory, localRepositoryPath).getAbsoluteFile();
+    File configuredPath = new File(localRepositoryPath);
+    if(configuredPath.isAbsolute()) {
+      return configuredPath;
+    }
+    //Actually maven would resolve these against the current working directory, 
+    //as we have no such thing available the best we can use here is the root folder of the multimodule directory
+    return new File(multiModuleProjectDirectory, localRepositoryPath).getAbsoluteFile();
   }
 
   @Override

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProperties.java
@@ -336,12 +336,22 @@ public class MavenProperties {
     if(alternateGlobalSettingsFile == null) {
       global = configurationLocations.globalSettings();
     } else {
-      global = new File(baseDir, alternateGlobalSettingsFile);
+      File gs = new File(alternateGlobalSettingsFile);
+      if(gs.isAbsolute()) {
+        global = gs;
+      } else {
+        global = new File(baseDir, alternateGlobalSettingsFile);
+      }
     }
     if(alternateUserSettingsFile == null) {
       user = configurationLocations.userSettings();
     } else {
-      user = new File(baseDir, alternateUserSettingsFile);
+      File s = new File(alternateUserSettingsFile);
+      if(s.isAbsolute()) {
+        user = s;
+      } else {
+        user = new File(baseDir, alternateUserSettingsFile);
+      }
     }
     return new MavenSettingsLocations(global, user);
   }


### PR DESCRIPTION
Currently the basepath is always used to resolve the local repository or settings files but this is wrong if the path is already absoloute.

Fix https://github.com/eclipse-m2e/m2e-core/issues/1695