### PR TITLE
Add testcase for classifier with transitive dependencies

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -69,6 +70,36 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 				</location>
 				""");
 		assertStatusOk(getTargetStatus(target));
+	}
+
+	@Test
+	public void testWithClassifierFailsToCollect() throws Exception {
+		String targetXML = """
+				<location includeDependencyDepth="%depth%" includeDependencyScopes="compile,provided,runtime,system" includeSource="false" missingManifest="generate" type="Maven">
+					<dependencies>
+						<dependency>
+							<groupId>org.ehcache</groupId>
+							<artifactId>ehcache</artifactId>
+							<version>3.10.0</version>
+							<type>jar</type>
+							<classifier>jakarta</classifier>
+						</dependency>
+					</dependencies>
+				</location>
+				""";
+		for (String deepth : new String[] { "none", "direct", "infinite" }) {
+			ITargetLocation target = resolveMavenTarget(targetXML.replace("%depth%", deepth));
+			assertStatusOk(getTargetStatus(target));
+			TargetBundle[] bundles = target.getBundles();
+			// TODO check bundle and possible transtive dependencies!
+			for (TargetBundle targetBundle : bundles) {
+				URI location = targetBundle.getBundleInfo().getLocation();
+				assertTrue(
+						"bundle with classifier was not correctly fetched width deepth = " + deepth + " location = "
+								+ location,
+						location.toString().endsWith("org/ehcache/ehcache/3.10.0/ehcache-3.10.0-jakarta.jar"));
+			}
+		}
 	}
 
 	@Test

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -91,7 +91,6 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 			ITargetLocation target = resolveMavenTarget(targetXML.replace("%depth%", deepth));
 			assertStatusOk(getTargetStatus(target));
 			TargetBundle[] bundles = target.getBundles();
-			// TODO check bundle and possible transtive dependencies!
 			for (TargetBundle targetBundle : bundles) {
 				URI location = targetBundle.getBundleInfo().getLocation();
 				assertTrue(

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -241,6 +241,13 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		}
 		if (artifact != null) {
 			DependencyDepth depth = dependencyDepth;
+			if (isClassified(artifact)) {
+				// a classified artifact can not have any dependencies and will actually include
+				// the ones from the main artifact.
+				// if the user really wants this it is possible to include the pom typed
+				// artifact or the main artifact in the list
+				depth = DependencyDepth.NONE;
+			}
 			if (isPomType(artifact) && depth == DependencyDepth.NONE) {
 				// fetching only the pom but no dependencies does not makes much sense...
 				depth = DependencyDepth.DIRECT;
@@ -271,6 +278,11 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		}
 
 		return artifact;
+	}
+
+	private boolean isClassified(Artifact artifact) {
+		String classifier = artifact.getClassifier();
+		return classifier != null && !classifier.isEmpty();
 	}
 
 	private boolean isPomType(Artifact artifact) {


### PR DESCRIPTION
Currently if a dependency is specified  the transitive items seem to be not correctly collected, at laest there is one artifact (ehcache) that has a transitive dependency that is invalid (javax.xml) and one can select a different classifier (jakarta) to use the jakarta ones but this seem not to happen at the moment.

This adds a testcase to illustrate the problem.