### PR TITLE
Properly create IJavaProject in JpmsConfigurationTest

### DIFF
--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JpmsConfigurationTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JpmsConfigurationTest.java
@@ -75,7 +75,7 @@ public class JpmsConfigurationTest extends AbstractMavenProjectTestCase {
     waitForJobsToComplete();
     
     // At start, check all attributes are empty
-    IJavaProject javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+	IJavaProject javaProject = JavaCore.create(project);
     Map<String, String> jreAttributes = Utils.getJreContainerAttributes(javaProject);
     Map<String, String> m2eAttributes = Utils.getM2eContainerAttributes(javaProject);
     


### PR DESCRIPTION
The pattern used to cast java nature to java project is wrong and we have seen it used in many places but broke for some reason with 2024-03. This reduces the failing tests of
https://github.com/eclipse-m2e/m2e-core/pull/1720 .