### PR TITLE
[JDT] Remove support for removed 'JRE' execution environment

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -109,7 +109,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
   protected static final LinkedHashMap<String, String> ENVIRONMENTS = new LinkedHashMap<>();
 
   static {
-    Set<String> supportedExecutionEnvironmentTypes = Set.of("JRE", "J2SE", "JavaSE");
+    Set<String> supportedExecutionEnvironmentTypes = Set.of("J2SE", "JavaSE");
 
     List<String> sources = new ArrayList<>();
 
@@ -120,9 +120,9 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
 
     List<String> releases = new ArrayList<>(List.of("6", "7", "8"));
 
-    for(var ee : JavaRuntime.getExecutionEnvironmentsManager().getExecutionEnvironments()) {
-      var eeId = ee.getId();
-      if(supportedExecutionEnvironmentTypes.stream().filter(type -> eeId.startsWith(type)).findAny().isEmpty()) {
+    for(IExecutionEnvironment ee : JavaRuntime.getExecutionEnvironmentsManager().getExecutionEnvironments()) {
+      String eeId = ee.getId();
+      if(supportedExecutionEnvironmentTypes.stream().noneMatch(eeId::startsWith)) {
         continue;
       }
       Map<String, String> complianceOptions = ee.getComplianceOptions();


### PR DESCRIPTION
With https://github.com/eclipse-equinox/equinox/issues/571 and https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/425 support for 'JRE-1.1' execution environment is removed from JDT respectively Equinox. Therefore M2E has no need anymore to support this exotic (and probably hardly used) execution environment.
