### PR TITLE
Revert "Update plexus-build-api to codehaus one"

### DIFF
--- a/org.eclipse.m2e.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.feature/forceQualifierUpdate.txt
@@ -1,2 +1,2 @@
 # To force a version qualifier update add the bug here
-Update build-qualifier because maven-runtime version update to Maven 3.9.6
+Update build-qualifier because maven-runtime content changes

--- a/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/org.eclipse.m2e.maven.runtime/pom.xml
@@ -35,7 +35,7 @@
 		<maven-resolver.version>1.9.18</maven-resolver.version>
 		<apache-commons-codec.version>1.16.1</apache-commons-codec.version><!-- Keep in sync with what maven includes-->
 		<!-- below are m2e-specific addons -->
-		<plexus-build-api.version>1.2.0</plexus-build-api.version>
+		<plexus-build-api.version>0.0.7</plexus-build-api.version>
 		<jars.directory>target/jars</jars.directory>
 		<outputDirectory.sources>${project.build.directory}/classes-source</outputDirectory.sources>
 		<failIfMacSigningFailed>false</failIfMacSigningFailed>
@@ -73,7 +73,7 @@
 			<artifactId>org.eclipse.sisu.plexus</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
+			<groupId>org.sonatype.plexus</groupId>
 			<artifactId>plexus-build-api</artifactId>
 			<version>${plexus-build-api.version}</version>
 		</dependency>


### PR DESCRIPTION
The plexus-build-api [1] can be implemented by Maven Mojos in order to support IDE's (like Eclipse+M2E) to improve their integration with the implementing Mojo.

But just embedding the new API jar without adding support for it in M2E does not have any effect and just increases the size of the runtime. Therefore this should be reverted and re-added together with the necessary changes in M2E's code to support it.
That being said it would not be harmful to just update the dependency because org.codehaus.plexus:plexus-build-api:1.2.0 has a dependency to org.sonatype.plexus:plexus-build-api:0.0.7 and therefore also pulls it into the m2e.maven.runtime.

This reverts commit 847581dbb7879e65163c304bac03ba0b004a278f respectively parts of https://github.com/eclipse-m2e/m2e-core/pull/1737.

[1] - https://github.com/codehaus-plexus/plexus-build-api

CC @akurtakov