### PR TITLE
Force qualifier update of m2e.maven.runtime to resign embedded jansi

### DIFF
--- a/org.eclipse.m2e.maven.runtime/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.maven.runtime/forceQualifierUpdate.txt
@@ -1,3 +1,2 @@
 # To force a version qualifier update add the bug here
-Update build-qualifier because maven-runtime version update to Maven 3.9.7
 Update build-qualifier (probably) because of changed Mac-signing certificates.


### PR DESCRIPTION
Update build-qualifier (probably) because of changed Mac-signing certificates.