### PR TITLE
Ignore container encoding when checking if an encoding is already set

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/ProjectConfigurationManager.java
@@ -489,7 +489,7 @@ public class ProjectConfigurationManager
     MavenProject mavenProject = request.mavenProject();
     Properties mavenProperties = mavenProject.getProperties();
     String sourceEncoding = mavenProperties.getProperty("project.build.sourceEncoding");
-    if(!Objects.equals(project.getDefaultCharset(), sourceEncoding)) {
+    if(!Objects.equals(project.getDefaultCharset(false), sourceEncoding)) {
       log.debug("Setting encoding for project {}: {}", project.getName(), sourceEncoding); //$NON-NLS-1$
       project.setDefaultCharset(sourceEncoding, monitor);
     }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -478,7 +478,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
       }
 
       // Set folder encoding (null = platform/container default)
-      if(sourceFolder.exists() && !Objects.equals(sourceFolder.getDefaultCharset(), sourceEncoding)) {
+      if(sourceFolder.exists() && !Objects.equals(sourceFolder.getDefaultCharset(false), sourceEncoding)) {
         sourceFolder.setDefaultCharset(sourceEncoding, monitor);
       }
 
@@ -573,7 +573,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
           addResourceFolder(classpath, path, outputPath, addTestFlag);
         }
         // Set folder encoding (null = platform default)
-        if(r.exists() && !Objects.equals(r.getDefaultCharset(), resourceEncoding)) {
+        if(r.exists() && !Objects.equals(r.getDefaultCharset(false), resourceEncoding)) {
           r.setDefaultCharset(resourceEncoding, monitor);
         }
       } else {


### PR DESCRIPTION
If the container encoding is not ignored it can happen that for example a project's encoding is not set if the workspace preference matches the encoding defined in the pom.xml.

Follow-up on https://github.com/eclipse-m2e/m2e-core/pull/1758