### PR TITLE
Release 2.6.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,9 @@
 
 ## 2.6.1
 
-* 📅 Release Date: _expected_ beginning of June 2024
+* 📅 Release Date: 04th June 2024
+
+Various minor bug-fixes, enhancements and dependency updates.
 
 ### Embedded and use Maven 3.9.7
 

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.6.1.qualifier"
+      version="2.6.2.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
The value of `<M2E_RELEASE>` is `2.6.1`.
The value of `<M2E_PREVIOUS_RELEASE>` is `2.6.0` and the value of `<M2E_RELEASE_WO_DOTS>` is `261`
The value of `<CONTAINING_SIMREL>` is `2024-06`

## Release process steps:
- [x] Add/finalize and submit an entry in the `RELEASE_NOTES.md` dedicated to this release (done with this PR).
- [x] Run `m2e-promote-snapshots-to-release` M2E Jenkins job with parameter `releaseVersion` value `<M2E_RELEASE>`
- [x] Update M2E's contribution to the Eclipse Simultaneous Release:
https://git.eclipse.org/c/simrel/org.eclipse.simrel.build.git/tree/m2e.aggrcon, usually it is sufficient to update the repo URL and description.
- [ ] Create and push git tag `<M2E_RELEASE>` on the release commit (usually this PR's commit).
- [x] `Create a new Release` at the M2E project website: https://projects.eclipse.org/projects/technology.m2e
Name: <M2E_RELEASE>, Release date: default is today, which is usually fine.
In the `Review Documentation` section add the `New & Notworthy URL`:
https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS>
- [ ] Create a new GitHub release, based on the just pushed `<M2E_RELEASE>-tag`
```
We are pleased to announce the release of M2E <M2E_RELEASE>.

The releases' p2-repo is: https://download.eclipse.org/technology/m2e/releases/<M2E_RELEASE>
Noteworthy changes in this release are listed in: https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS>

**Full Changelog**: https://github.com/eclipse-m2e/m2e-core/compare/<M2E_PREVIOUS_RELEASE>...<M2E_RELEASE>

Special thanks to to everybody who contributed to this release!

## New Contributors
<GENERATED from GH automated release notes text>
```
- [ ] Send the following announcement to the [M2E-dev mailing-list](https://accounts.eclipse.org/mailing-list/m2e-dev) (m2e-dev@eclipse.org):
```
M2E <M2E_RELEASE> is released!


📥 P2 repository is available at https://download.eclipse.org/technology/m2e/releases/<M2E_RELEASE>
(and it also mirrored at https://download.eclipse.org/technology/m2e/releases/latest/ and referenced by Marketplace Entry https://marketplace.eclipse.org/content/eclipse-m2e-maven-support-eclipse-ide until a newer release is promoted)
🏷️ Git tag is <M2E_RELEASE>: https://github.com/eclipse-m2e/m2e-core/tree/<M2E_RELEASE>
📝 Release notes are available in https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#<M2E_RELEASE_WO_DOTS> ; full changelog is https://github.com/eclipse-m2e/m2e-core/compare/<M2E_PREVIOUS_RELEASE>...<M2E_RELEASE>
👔 PMI Release entry is at https://projects.eclipse.org/projects/technology.m2e/releases/<M2E_RELEASE>
🧑‍🤝‍🧑 M2E <M2E_RELEASE> will be part of Eclipse SimRel <CONTAINING_SIMREL>
🙏 Special thanks to to everybody who contributed to this release!


Greetings
```