### PR TITLE
[Runtime] Remove unused org.apache.commons.lang3 import instruction

### DIFF
--- a/org.eclipse.m2e.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.feature/forceQualifierUpdate.txt
@@ -1,2 +1,2 @@
 # To force a version qualifier update add the bug here
-Update build-qualifier because maven-runtime version update to Maven 3.9.8
+Update build-qualifier because maven-runtime version update to Maven 3.9.8 (updated)

--- a/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/org.eclipse.m2e.maven.runtime/pom.xml
@@ -206,8 +206,7 @@
 								javax.inject;version="[1.0.0,2.0.0)",\
 								javax.annotation;version="[1.2.0,2.0.0)", \
 								org.apache.commons.cli;version="[1.4.0,2.0.0)", \
-								org.apache.commons.codec*, \
-								org.apache.commons.lang3*
+								org.apache.commons.codec*
 							Require-Bundle: \
 								com.google.guava;bundle-version="32.2.1"
 


### PR DESCRIPTION
Since Maven 3.9.8 commons-lang3 is not used anymore in Maven core.