### PR TITLE
Add bnd-maven-plugin integration to m2e

### DIFF
--- a/org.eclipse.m2e.bnd.ui/.classpath
+++ b/org.eclipse.m2e.bnd.ui/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.m2e.bnd.ui/.project
+++ b/org.eclipse.m2e.bnd.ui/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.m2e.bnd.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.m2e.bnd.ui/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.m2e.bnd.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.m2e.bnd.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.m2e.bnd.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/org.eclipse.m2e.bnd.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.bnd.ui/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: bnd-maven-plugin integration
+Bundle-SymbolicName: org.eclipse.m2e.bnd.ui
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse
+Automatic-Module-Name: org.eclipse.m2e.bnd.ui
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.m2e.bnd.ui/build.properties
+++ b/org.eclipse.m2e.bnd.ui/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .


### PR DESCRIPTION
PDE now offers so called "shared components" (based on bndtools) we can leverage them to give a better user experience in m2e without needing the user to have bndtools (or pde) installed at all.

This PR is to track progress and make sure the current WIP can be integrated with the current code base.