### PR TITLE
Update lemminx integration to Java 21 BREE

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -21,6 +21,7 @@ jobs:
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: technology.m2e
+      javaVersion: 21
       setupScript: 'cd org.eclipse.m2e.maven.runtime && mvn generate-resources'
     secrets:
       gitlabAPIToken: ${{ secrets.M2E_GITLAB_API_TOKEN }}

--- a/org.eclipse.m2e.editor.lemminx.tests/.classpath
+++ b/org.eclipse.m2e.editor.lemminx.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.eclipse.m2e.editor.lemminx.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.m2e.editor.lemminx.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=21

--- a/org.eclipse.m2e.editor.lemminx.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, Lemminx and Mav
 Bundle-SymbolicName: org.eclipse.m2e.editor.lemminx.tests
 Bundle-Version: 2.0.2.qualifier
 Automatic-Module-Name: org.eclipse.m2e.editor.lemminx.tests
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse.org - m2e
 Fragment-Host: org.eclipse.m2e.editor.lemminx
 Require-Bundle: org.junit,

--- a/org.eclipse.m2e.editor.lemminx/.classpath
+++ b/org.eclipse.m2e.editor.lemminx/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.eclipse.m2e.editor.lemminx/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.m2e.editor.lemminx/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=21

--- a/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, LemMinX and Maven LS extension (requires Incubating components)
 Bundle-SymbolicName: org.eclipse.m2e.editor.lemminx;singleton:=true
-Bundle-Version: 2.0.600.qualifier
+Bundle-Version: 2.0.601.qualifier
 Automatic-Module-Name: org.eclipse.m2e.xmlls.extension
 Import-Package: javax.inject;version="[1.0.0,2.0.0)",
  org.apache.commons.cli;version="1.6.0",

--- a/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Require-Bundle: org.eclipse.wildwebdeveloper.xml;bundle-version="[1.3,1.4)",
  org.eclipse.m2e.core,
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
  org.eclipse.core.resources
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse.org - m2e

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -24,7 +24,7 @@
 	<artifactId>org.eclipse.m2e.editor.lemminx</artifactId>
 	<name>M2E Maven POM File Editor (Wild Web Developer, LemMinX, LS)</name>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.600-SNAPSHOT</version>
+	<version>2.0.601-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="2.0.600.qualifier"
+      version="2.0.601.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
As WWD requires Java 21 the only way to make tests work is if they are run with Java 21 too.