### PR TITLE
Keep only the artifacts of the last 2 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 	options {
 		timeout(time: 45, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'10'))
+		buildDiscarder(logRotator(numToKeepStr:'5', artifactNumToKeepStr: 'master'.equals(env.BRANCH_NAME) ? '5' : '1' ))
 		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}


### PR DESCRIPTION
In order to save disk space, the number of builds to keep with artifacts should be limited to 2.

This change should be applied to all branches.