### PR TITLE
[PDE] Reduce usage of PDE internals in production code

### DIFF
--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEProjectHelper.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEProjectHelper.java
@@ -46,11 +46,11 @@ import org.eclipse.pde.core.build.IBuildModel;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.core.project.IBundleProjectDescription;
-import org.eclipse.pde.internal.core.natures.FeatureProject;
 
 public class PDEProjectHelper {
 
 	private static final String PDE_PLUGIN_NATURE = IBundleProjectDescription.PLUGIN_NATURE;
+	private static final String PDE_FEATURE_NATURE = "org.eclipse.pde.FeatureNature";
 
 	private static AtomicBoolean isListeningForPluginModelChanges = new AtomicBoolean(false);
 
@@ -115,8 +115,8 @@ public class PDEProjectHelper {
 		if (project != null) {
 			// see
 			// org.eclipse.pde.internal.ui.wizards.feature.AbstractCreateFeatureOperation
-			if (!project.hasNature(FeatureProject.NATURE)) {
-				AbstractProjectConfigurator.addNature(project, FeatureProject.NATURE, monitor);
+			if (!project.hasNature(PDE_FEATURE_NATURE)) {
+				AbstractProjectConfigurator.addNature(project, PDE_FEATURE_NATURE, monitor);
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up on https://github.com/eclipse-m2e/m2e-core/pull/1835.

In general we could also consider to add API constants for such constant Strings in PDE.