### PR TITLE
Fix syntax error in shell script for deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
 			steps {
 				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
+						#!/bin/bash
 						deployM2ERepository()
 						{
 							echo Deploy m2e repo to ${1}


### PR DESCRIPTION
Ubuntu uses dash as default shell thus explicitly call bash.