### PR TITLE
Stop jarsigning

### DIFF
--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -199,15 +199,6 @@
 						</dependency>
 					</dependencies>
 				</plugin>
-				<plugin>
-					<groupId>org.eclipse.cbi.maven.plugins</groupId>
-					<artifactId>eclipse-jarsigner-plugin</artifactId>
-					<version>1.5.0</version>
-					<configuration>
-						<excludeInnerJars>true</excludeInnerJars>
-						<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -220,25 +211,6 @@
 	</pluginRepositories>
 
 	<profiles>
-		<profile>
-			<id>eclipse-sign</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.cbi.maven.plugins</groupId>
-						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>sign</id>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 		<profile>
 			<id>windows</id>
 			<activation>


### PR DESCRIPTION
PGP sign is enough, simrel no longer requires jarsigning and build becomes faster and more stable without the network roadtrips caused by eclipse-jarsigner.