### PR TITLE
TychoConnectorTest move to Java 21

### DIFF
--- a/org.eclipse.m2e.pde.connector.tests/projects/tycho/.mvn/extensions.xml
+++ b/org.eclipse.m2e.pde.connector.tests/projects/tycho/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>3.0.0</version>
+    <version>4.0.9</version>
   </extension>
 </extensions>

--- a/org.eclipse.m2e.pde.connector.tests/projects/tycho/pde.tycho.plugin/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector.tests/projects/tycho/pde.tycho.plugin/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pde.tycho.plugin
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: pde.tycho.plugin

--- a/org.eclipse.m2e.pde.connector.tests/projects/tycho/pde.tycho.pomless.plugin/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector.tests/projects/tycho/pde.tycho.pomless.plugin/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pde.tycho.pomless.plugin
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: pde.tycho.plugin

--- a/org.eclipse.m2e.pde.connector.tests/projects/tycho/pom.xml
+++ b/org.eclipse.m2e.pde.connector.tests/projects/tycho/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho-version>3.0.0</tycho-version>
+		<tycho-version>4.0.9</tycho-version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
GH builder for MacOS fails with "M2EClasspath Container not found! (org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17[CPE_CONTAINER][K_SOURCE][isExported:false], org.eclipse.pde.core.requiredPlugins[CPE_CONTAINER][K_SOURCE][isExported:false], /pde.tycho.plugin/src/[CPE_SOURCE][K_SOURCE][isExported:false]". Move up to get more stable tests.