### PR TITLE
Do not include o.e.m2e.tests.common in sdk feature

### DIFF
--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -51,12 +51,4 @@
          id="org.eclipse.m2e.pde.feature.source"
          version="0.0.0"/>
 
-   <plugin
-         id="org.eclipse.m2e.tests.common"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.m2e.tests.common.source"
-         version="0.0.0"/>
-
 </feature>

--- a/org.eclipse.m2e.sdk.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.sdk.feature/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+# To force a version qualifier update add the bug here
+https://github.com/eclipse-m2e/m2e-core/pull/1864


### PR DESCRIPTION
This bundle is only useful for the other test bundles which are not included in the p2 repo at all.