### PR TITLE
[Build] Remove workaround for previously different default shell

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 					string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')
 				]) {
 				xvnc(useXauthority: true) {
-					sh '''#!/bin/bash -x
+					sh '''
 						mavenArgs="clean verify --batch-mode -Dmaven.test.failure.ignore=true -Dtycho.p2.baselineMode=failCommon"
 						if [[ ${BRANCH_NAME} == master ]] || [[ ${BRANCH_NAME} =~ m2e-[0-9]+\\.[0-9]+\\.x ]]; then
 							mvn ${mavenArgs} -Peclipse-sign,its -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}" -Dgpg.passphrase="${KEYRING_PASSPHRASE}"
@@ -54,7 +54,7 @@ pipeline {
 			}
 			steps {
 				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-					sh '''#!/bin/bash -x
+					sh '''
 						deployM2ERepository()
 						{
 							echo Deploy m2e repo to ${1}


### PR DESCRIPTION
On the new Ubuntu images initially the 'dash' shell was used by default and now it was changed to use 'bash' again.

So we don't have to explicitly specify the shell anymore.

See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5061

This reverts the workarounds added via
- https://github.com/eclipse-m2e/m2e-core/pull/1854
- https://github.com/eclipse-m2e/m2e-core/pull/1855
- https://github.com/eclipse-m2e/m2e-core/pull/1857

On the other hand, we could also keep the explicit specification of the shell so that reads are aware what to expect?