### PR TITLE
Provide improved support for long property values

### DIFF
--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenPropertyDialog.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/dialogs/MavenPropertyDialog.java
@@ -13,9 +13,10 @@
 
 package org.eclipse.m2e.core.ui.internal.dialogs;
 
-// import org.eclipse.debug.ui.StringVariableSelectionDialog;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.DialogSettings;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.VerifyEvent;
 import org.eclipse.swt.events.VerifyListener;
@@ -28,10 +29,13 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
+import org.eclipse.m2e.core.ui.internal.M2EUIPluginActivator;
 import org.eclipse.m2e.core.ui.internal.Messages;
 
 
 public class MavenPropertyDialog extends Dialog {
+
+  private static final String DIALOG_SETTINGS = MavenPropertyDialog.class.getName();
 
   private final String title;
 
@@ -64,6 +68,8 @@ public class MavenPropertyDialog extends Dialog {
   @Override
   protected Control createDialogArea(Composite parent) {
     Composite comp = new Composite(parent, SWT.NONE);
+    comp.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
     GridLayout gridLayout = new GridLayout(2, false);
     gridLayout.marginTop = 7;
     gridLayout.marginWidth = 12;
@@ -186,4 +192,21 @@ public class MavenPropertyDialog extends Dialog {
     super.create();
     updateButtons();
   }
+
+  @Override
+  protected boolean isResizable() {
+    return true;
+  }
+
+  @Override
+  protected IDialogSettings getDialogBoundsSettings() {
+    IDialogSettings pluginSettings = M2EUIPluginActivator.getDefault().getDialogSettings();
+    IDialogSettings dialogSettings = pluginSettings.getSection(DIALOG_SETTINGS);
+    if(dialogSettings == null) {
+      dialogSettings = new DialogSettings(DIALOG_SETTINGS);
+      pluginSettings.addSection(dialogSettings);
+    }
+    return dialogSettings;
+  }
+
 }

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
@@ -32,6 +32,8 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
 import org.eclipse.debug.ui.StringVariableSelectionDialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.viewers.ColumnWeightData;
+import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
@@ -355,17 +357,23 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
     });
 
     this.propsTable = tableViewer.getTable();
+
+    TableLayout tableLayout = new TableLayout();
+    ColumnWeightData weightData = new ColumnWeightData(20, true);
+    tableLayout.addColumnData(weightData);
+    weightData = new ColumnWeightData(80, true);
+    tableLayout.addColumnData(weightData);
+    this.propsTable.setLayout(tableLayout);
+
     //this.tProps.setItemCount(10);
     this.propsTable.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 4, 3));
     this.propsTable.setLinesVisible(true);
     this.propsTable.setHeaderVisible(true);
 
     final TableColumn propColumn = new TableColumn(this.propsTable, SWT.NONE, 0);
-    propColumn.setWidth(120);
     propColumn.setText(Messages.launchPropName);
 
     final TableColumn valueColumn = new TableColumn(this.propsTable, SWT.NONE, 1);
-    valueColumn.setWidth(200);
     valueColumn.setText(Messages.launchPropValue);
 
     final Button addPropButton = new Button(mainComposite, SWT.NONE);


### PR DESCRIPTION
- Make the MavenPropertyDialog resizeable and provide dialog settings to remember the size.
- Use a table layout for the property table of the MavenLaunchMainTab.