### PR TITLE
Avoid grabbing focus when creating the launch configuration main tab

### DIFF
--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/ui/internal/launch/MavenLaunchMainTab.java
@@ -412,8 +412,6 @@ public class MavenLaunchMainTab extends AbstractLaunchConfigurationTab implement
     runtimeSelector = new MavenRuntimeSelector(mainComposite);
     runtimeSelector.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 4, 1));
     runtimeSelector.addSelectionChangedListener(event -> entriesChanged());
-
-    goalsText.setFocus();
   }
 
   protected Shell getShell() {


### PR DESCRIPTION
- Normally one can, in the Run Configurations dialog, use the keyboard in the left control to navigate each of the launch configurations but that does work for m2e because the configuration control grabs away the focus.