### PR TITLE
Fix build warning with latest tycho/maven-gpg-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,17 +22,17 @@ pipeline {
 			steps {
 				withCredentials([
 					file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING'),
-					string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')
+					string(credentialsId: 'gpg-passphrase', variable: 'MAVEN_GPG_PASSPHRASE')
 				]) {
 				xvnc(useXauthority: true) {
 					sh '''#!/bin/bash -x
 						mavenArgs="clean verify --batch-mode -Dmaven.test.failure.ignore=true -Dtycho.p2.baselineMode=failCommon"
 						if [[ ${BRANCH_NAME} == master ]] || [[ ${BRANCH_NAME} =~ m2e-[0-9]+\\.[0-9]+\\.x ]]; then
-							mvn ${mavenArgs} -Peclipse-sign,its -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}" -Dgpg.passphrase="${KEYRING_PASSPHRASE}"
+							mvn ${mavenArgs} -Peclipse-sign,its -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}"
 						else
 							# Clear signing environment variables for PRs
 							export KEYRING='EMPTY'
-							export KEYRING_PASSPHRASE='EMPTY'
+							export MAVEN_GPG_PASSPHRASE='EMPTY'
 							mvn ${mavenArgs} -Pits
 						fi
 					'''


### PR DESCRIPTION
Removes
```
[WARNING]  Parameter 'passphrase' (user property 'gpg.passphrase') is
deprecated: Do not use this configuration, it may leak sensitive
information. Rely on gpg-agent or env variables instead.
[WARNING]
[WARNING] W A R N I N G
[WARNING]
[WARNING] Do not store passphrase in any file (disk or SCM repository),
[WARNING] instead rely on GnuPG agent or provide passphrase in
[WARNING] MAVEN_GPG_PASSPHRASE environment variable for batch mode.
[WARNING]
[WARNING] Sensitive content loaded from Mojo configuration
```
from the build output.