### PR TITLE
Perform Maven target dependency update in non-UI thread

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.3.300.qualifier"
+      version="2.3.400.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.1.1.qualifier
+Bundle-Version: 2.1.2.qualifier
 Export-Package: org.eclipse.m2e.pde.ui.target.editor;x-friends:="org.eclipse.m2e.swtbot.tests"
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetDependencyEditor.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetDependencyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Christoph Läubrich and others
+ * Copyright (c) 2021, 2025 Christoph Läubrich and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,10 +30,14 @@ public class MavenTargetDependencyEditor {
 
 	public MavenTargetDependencyEditor(Composite parent, MavenTargetLocation targetLocation,
 			MavenTargetDependency selectedRoot) {
+		this(parent, new TargetDependencyModel(targetLocation, selectedRoot));
+	}
+
+	/* package */ MavenTargetDependencyEditor(Composite parent, TargetDependencyModel model) {
 		composite = new Composite(parent, SWT.NONE);
 		composite.setLayout(new BorderLayout());
 
-		model = new TargetDependencyModel(targetLocation, selectedRoot);
+		this.model = model;
 
 		new DependencyTable(composite, model);
 	}

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Christoph Läubrich and others
+ * Copyright (c) 2018, 2025 Christoph Läubrich and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,6 +41,7 @@ import org.eclipse.m2e.pde.target.MavenTargetRepository;
 import org.eclipse.m2e.pde.target.MissingMetadataMode;
 import org.eclipse.m2e.pde.target.TemplateFeatureModel;
 import org.eclipse.m2e.pde.target.shared.DependencyDepth;
+import org.eclipse.m2e.pde.ui.target.editor.internal.TargetDependencyModel;
 import org.eclipse.pde.core.target.ITargetDefinition;
 import org.eclipse.pde.core.target.ITargetLocation;
 import org.eclipse.pde.ui.target.ITargetLocationWizard;
@@ -86,6 +87,7 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 	public MavenTargetLocationWizard(MavenTargetLocation targetLocation) {
 		this.targetLocation = targetLocation;
 		setWindowTitle(Messages.MavenTargetLocationWizard_0);
+		setNeedsProgressMonitor(true);
 		if (targetLocation != null) {
 			for (MavenTargetRepository mavenTargetRepository : targetLocation.getExtraRepositories()) {
 				repositoryList.add(mavenTargetRepository.copy());
@@ -105,7 +107,9 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 				setControl(composite);
 				composite.setLayout(new GridLayout(2, false));
 				createRepositoryLink(composite);
-				dependencyEditor = new MavenTargetDependencyEditor(composite, targetLocation, selectedRoot);
+				TargetDependencyModel dependencyModel = new TargetDependencyModel(targetLocation, selectedRoot);
+				dependencyModel.setContext(getContainer());
+				dependencyEditor = new MavenTargetDependencyEditor(composite, dependencyModel);
 				dependencyEditor.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
 
 				new Label(composite, SWT.NONE).setText(Messages.MavenTargetLocationWizard_14);

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/Messages.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Christoph Läubrich and others
+ * Copyright (c) 2020, 2025 Christoph Läubrich and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -57,6 +57,7 @@ public class Messages extends NLS {
 	public static String MavenTargetLocationWizard_23;
 	public static String MavenTargetLocationLabelProvider_1;
 	public static String MavenTargetLocationLabelProvider_2;
+	public static String TargetDependencyModel_1;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/messages.properties
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/messages.properties
@@ -39,3 +39,4 @@ MavenTargetLocationLabelProvider_1={0}:{1} ({2})
 MavenTargetLocationLabelProvider_2={0} Maven Dependencies
 NewFeatureWizard_PlugPage_title = Additionally referenced Plug-ins and Fragments
 NewFeatureWizard_PlugPage_desc = Select the plug-ins and fragments that are additionally added to the generated feature.
+TargetDependencyModel_1=Updating {0}...

--- a/org.eclipse.m2e.swtbot.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.swtbot.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTBot Integration Tests
 Bundle-SymbolicName: org.eclipse.m2e.swtbot.tests
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.1.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.100",
  org.eclipse.m2e.pde.target,
  org.eclipse.m2e.pde.ui,

--- a/org.eclipse.m2e.swtbot.tests/pom.xml
+++ b/org.eclipse.m2e.swtbot.tests/pom.xml
@@ -8,6 +8,7 @@
 		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 
+	<version>2.1.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.m2e.swtbot.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<name>M2E - SWTBot Integration tests</name>

--- a/org.eclipse.m2e.swtbot.tests/src/org/eclipse/m2e/pde/ui/MavenTargetDependencyEditorTest.java
+++ b/org.eclipse.m2e.swtbot.tests/src/org/eclipse/m2e/pde/ui/MavenTargetDependencyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Patrick Ziegler and others.
+ * Copyright (c) 2024, 2025 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.ui;
 
+import static org.eclipse.swtbot.swt.finder.waits.Conditions.widgetIsEnabled;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -192,11 +193,6 @@ public class MavenTargetDependencyEditorTest {
 			workbench.getDisplay().syncExec(wizardDialog::close);
 		}
 	}
-	
-	private void readAndDispatch() {
-		Display display = workbench.getDisplay();
-		display.syncExec(display::readAndDispatch);
-	}
 
 	/**
 	 * Checks whether the initial "enablement" state of all buttons in the Maven
@@ -316,7 +312,7 @@ public class MavenTargetDependencyEditorTest {
 
 		table.select(12);
 		robot.button("Update").click();
-		readAndDispatch();
+		robot.waitUntil(widgetIsEnabled(table));
 
 		assertEquals(table.cell(12, 1), "kotlin-stdlib-common");
 		assertNotEquals(table.cell(12, 2), "1.7.22");
@@ -329,7 +325,7 @@ public class MavenTargetDependencyEditorTest {
 
 		table.select(13, 15);
 		robot.button("Update").click();
-		readAndDispatch();
+		robot.waitUntil(widgetIsEnabled(table));
 
 		assertEquals(table.cell(13, 1), "kotlin-stdlib-jdk7");
 		assertNotEquals(table.cell(13, 2), "1.7.22");


### PR DESCRIPTION
Depending on how many artifacts are updated, this might be a long-running operation and should therefore be run without blocking the application.