### PR TITLE
Handle the case of empty BSN in maven target location

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.3.200.qualifier"
+      version="2.3.300.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -56,6 +56,22 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 	}
 
 	@Test
+	public void testBadSymbolicName() throws Exception {
+		ITargetLocation target = resolveMavenTarget("""
+				<location includeDependencyScope="compile" missingManifest="generate" type="Maven">
+				    <dependencies>
+				        <dependency>
+				            <groupId>javax.xml.ws</groupId>
+				            <artifactId>jaxws-api</artifactId>
+				            <version>2.3.1</version>
+				        </dependency>
+				    </dependencies>
+				</location>
+				""");
+		assertStatusOk(getTargetStatus(target));
+	}
+
+	@Test
 	public void testBadDependencyDirect() throws Exception {
 		ITargetLocation target = resolveMavenTarget("""
 				<location missingManifest="generate" type="Maven">

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.1.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -164,9 +165,7 @@ public class MavenBundleWrapper {
 			return wrappedNode;
 		}
 		Jar jar = new Jar(originalFile);
-		Manifest originalManifest = jar.getManifest();
-		if (originalManifest != null
-				&& originalManifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME) != null) {
+		if (isValidOSGi(jar.getManifest())) {
 			// already a bundle!
 			visited.put(node,
 					wrappedNode = new WrappedBundle(node, List.of(), null, originalFile.toPath(), jar, List.of()));
@@ -244,6 +243,15 @@ public class MavenBundleWrapper {
 			}
 			return wrappedNode;
 		}
+	}
+
+	private static boolean isValidOSGi(Manifest originalManifest) {
+		if (originalManifest == null) {
+			return false;
+		}
+		Attributes attributes = originalManifest.getMainAttributes();
+		String symbolicName = attributes.getValue(Constants.BUNDLE_SYMBOLICNAME);
+		return symbolicName != null && !symbolicName.isBlank();
 	}
 
 	private static Jar getCachedJar(Path cacheFile, Path sourceFile) {


### PR DESCRIPTION
It seem for some reasons there are "bundles" in the wild that contain an OSGi manifest with an empty BSN what currently leads to a NPE if used inside a target.

This now enhances the check for a valid OSGi manifest in a way that it is not only required to have a BSN but also that it is not empty.

See https://github.com/eclipse-tycho/tycho/pull/4700