### PR TITLE
Remove signatures from wrapped source bundles

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/AbstractMavenTargetTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/AbstractMavenTargetTest.java
@@ -32,7 +32,9 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IStatus;
@@ -160,6 +162,17 @@ public abstract class AbstractMavenTargetTest {
 		File file = URIUtil.toFile(bundleInfo.getLocation());
 		try (var jar = new JarFile(file)) {
 			return jar.getManifest().getMainAttributes();
+		}
+	}
+
+	static void assertValidSignature(TargetBundle targetBundle) throws IOException {
+		try (JarInputStream stream = new JarInputStream(
+				targetBundle.getBundleInfo().getLocation().toURL().openStream())) {
+			for (JarEntry entry = stream.getNextJarEntry(); entry != null; entry = stream.getNextJarEntry()) {
+				for (byte[] drain = new byte[4096]; stream.read(drain, 0, drain.length) != -1;) {
+					// nothing we just want to trigger the signature verification
+				}
+			}
 		}
 	}
 

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -72,6 +72,39 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 	}
 
 	@Test
+	public void testSourceWithSignature() throws Exception {
+		ITargetLocation target = resolveMavenTarget(
+				"""
+						<location includeDependencyDepth="none" includeDependencyScopes="compile" label="LemMinX" includeSource="true" missingManifest="error" type="Maven">
+						    <dependencies>
+						        <dependency>
+						            <groupId>org.eclipse.lemminx</groupId>
+						            <artifactId>org.eclipse.lemminx</artifactId>
+						            <version>0.29.0</version>
+						            <type>jar</type>
+						        </dependency>
+						    </dependencies>
+						    <repositories>
+						        <repository>
+						            <id>lemminx-releases</id>
+						            <url>https://repo.eclipse.org/content/repositories/lemminx-releases/</url>
+						        </repository>
+						    </repositories>
+						</location>
+						""");
+		assertStatusOk(getTargetStatus(target));
+		TargetBundle[] allBundles = target.getBundles();
+		boolean sourcesFound = false;
+		for (TargetBundle targetBundle : allBundles) {
+			if (targetBundle.isSourceBundle()) {
+				sourcesFound = true;
+				assertValidSignature(targetBundle);
+			}
+		}
+		assertTrue("No source bundle generated!", sourcesFound);
+	}
+
+	@Test
 	public void testBadDependencyDirect() throws Exception {
 		ITargetLocation target = resolveMavenTarget("""
 				<location missingManifest="generate" type="Maven">

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
@@ -13,45 +13,35 @@
 package org.eclipse.m2e.pde.target;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.Objects;
-import java.util.jar.Attributes;
-import java.util.jar.Attributes.Name;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarInputStream;
-import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
-import java.util.zip.ZipEntry;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
+import org.eclipse.m2e.pde.target.shared.MavenBundleWrapper;
 import org.eclipse.pde.core.target.TargetBundle;
-import org.osgi.framework.Constants;
 
 public class MavenSourceBundle extends TargetBundle {
 
-	@SuppressWarnings("restriction")
-	public static final String ECLIPSE_SOURCE_BUNDLE_HEADER = org.eclipse.pde.internal.core.ICoreConstants.ECLIPSE_SOURCE_BUNDLE;
-
 	public MavenSourceBundle(BundleInfo sourceTarget, Artifact artifact, CacheManager cacheManager) throws Exception {
 		this.fSourceTarget = sourceTarget;
-		fInfo.setSymbolicName(sourceTarget.getSymbolicName() + ".source");
-		fInfo.setVersion(sourceTarget.getVersion());
+		String symbolicName = sourceTarget.getSymbolicName();
+		String version = sourceTarget.getVersion();
+		fInfo.setSymbolicName(MavenBundleWrapper.getSourceBundleName(symbolicName));
+		fInfo.setVersion(version);
 		Manifest manifest;
 		File sourceFile = artifact.getFile();
 		try (JarFile jar = new JarFile(sourceFile)) {
 			manifest = Objects.requireNonNullElseGet(jar.getManifest(), Manifest::new);
 		}
-		if (isValidSourceManifest(manifest)) {
+		if (MavenBundleWrapper.isValidSourceManifest(manifest)) {
 			fInfo.setLocation(sourceFile.toURI());
 		} else {
 			File generatedSourceBundle = cacheManager.accessArtifactFile(artifact, file -> {
 				if (CacheManager.isOutdated(file, sourceFile)) {
-					addSourceBundleMetadata(manifest, sourceTarget);
-					transferJarEntries(sourceFile, manifest, file);
+					MavenBundleWrapper.addSourceBundleMetadata(manifest, symbolicName, version);
+					MavenBundleWrapper.transferJarEntries(sourceFile, manifest, file);
 				}
 				return file;
 			});
@@ -59,34 +49,5 @@ public class MavenSourceBundle extends TargetBundle {
 		}
 	}
 
-	private void addSourceBundleMetadata(Manifest manifest, BundleInfo bundle) {
-		Attributes attr = manifest.getMainAttributes();
-		if (attr.isEmpty()) {
-			attr.put(Name.MANIFEST_VERSION, "1.0");
-		}
-		attr.putValue(ECLIPSE_SOURCE_BUNDLE_HEADER,
-				bundle.getSymbolicName() + ";version=\"" + bundle.getVersion() + "\";roots:=\".\"");
-		attr.putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
-		attr.putValue(Constants.BUNDLE_NAME,
-				"Source Bundle for " + bundle.getSymbolicName() + ":" + bundle.getVersion());
-		attr.putValue(Constants.BUNDLE_SYMBOLICNAME, fInfo.getSymbolicName());
-		attr.putValue(Constants.BUNDLE_VERSION, fInfo.getVersion());
-	}
-
-	private void transferJarEntries(File source, Manifest manifest, File target) throws IOException {
-		try (var output = new JarOutputStream(new FileOutputStream(target), manifest);
-				var input = new JarInputStream(new FileInputStream(source));) {
-			for (JarEntry entry; (entry = input.getNextJarEntry()) != null;) {
-				if (!JarFile.MANIFEST_NAME.equals(entry.getName())) {
-					output.putNextEntry(new ZipEntry(entry.getName()));
-					input.transferTo(output);
-				}
-			}
-		}
-	}
-
-	private static boolean isValidSourceManifest(Manifest manifest) {
-		return manifest != null && manifest.getMainAttributes().getValue(ECLIPSE_SOURCE_BUNDLE_HEADER) != null;
-	}
 
 }

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -13,6 +13,8 @@
 package org.eclipse.m2e.pde.target.shared;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,10 +29,16 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.jar.Attributes;
+import java.util.jar.Attributes.Name;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.model.Model;
@@ -71,6 +79,10 @@ import aQute.bnd.version.Version;
  * </ul>
  */
 public class MavenBundleWrapper {
+
+	@SuppressWarnings("restriction")
+	public static final String ECLIPSE_SOURCE_BUNDLE_HEADER = org.eclipse.pde.internal.core.ICoreConstants.ECLIPSE_SOURCE_BUNDLE;
+
 	private MavenBundleWrapper() {
 	}
 
@@ -307,5 +319,50 @@ public class MavenBundleWrapper {
 			return sourceTimeStamp.toMillis() > cacheTimeStamp.toMillis();
 		}
 		return true;
+	}
+
+	private static boolean isExcludedFromWrapping(String name) {
+		return name.equals(JarFile.MANIFEST_NAME) || name.startsWith("META-INF/SIG-") || name.startsWith("META-INF/")
+				&& (name.endsWith(".SF") || name.endsWith(".RSA") || name.endsWith(".DSA"));
+	}
+
+	public static void addSourceBundleMetadata(Manifest manifest, String symbolicName, String version) {
+
+		Attributes attr = manifest.getMainAttributes();
+		if (attr.isEmpty()) {
+			attr.put(Name.MANIFEST_VERSION, "1.0");
+		}
+		attr.putValue(ECLIPSE_SOURCE_BUNDLE_HEADER, symbolicName + ";version=\"" + version + "\";roots:=\".\"");
+		attr.putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
+		attr.putValue(Constants.BUNDLE_NAME, "Source Bundle for " + symbolicName + ":" + version);
+		attr.putValue(Constants.BUNDLE_SYMBOLICNAME, getSourceBundleName(symbolicName));
+		attr.putValue(Constants.BUNDLE_VERSION, version);
+	}
+
+	public static String getSourceBundleName(String symbolicName) {
+		return symbolicName + ".source";
+	}
+
+	public static void transferJarEntries(File source, Manifest manifest, File target) throws IOException {
+		Map<String, Attributes> manifestEntries = manifest.getEntries();
+		if (manifestEntries != null) {
+			// need to clear out signature infos
+			manifestEntries.clear();
+		}
+		try (var output = new JarOutputStream(new FileOutputStream(target), manifest);
+				var input = new JarInputStream(new FileInputStream(source));) {
+			for (JarEntry entry; (entry = input.getNextJarEntry()) != null;) {
+				if (MavenBundleWrapper.isExcludedFromWrapping(entry.getName())) {
+					// Exclude manifest and signatures
+					continue;
+				}
+				output.putNextEntry(new ZipEntry(entry.getName()));
+				input.transferTo(output);
+			}
+		}
+	}
+
+	public static boolean isValidSourceManifest(Manifest manifest) {
+		return manifest != null && manifest.getMainAttributes().getValue(ECLIPSE_SOURCE_BUNDLE_HEADER) != null;
 	}
 }

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -116,7 +116,7 @@
 				</dependency>
 			</dependencies>
 		</location>
-		<location includeDependencyDepth="none" includeDependencyScopes="compile" label="LemMinX" includeSource="true" missingManifest="error" type="Maven">
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" label="LemMinX" includeSource="false" missingManifest="error" type="Maven">
 			<dependencies>
 				<dependency>
 					<groupId>org.eclipse.lemminx</groupId>


### PR DESCRIPTION
Currently when the source bundle is signed, wrapping it into a source bundle will break the signature and make the jar invalid.

This now removes the signature from source bundles as they are transformed.

See https://github.com/eclipse-tycho/tycho/pull/4702