### PR TITLE
Update target platform deps

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -54,7 +54,7 @@
 				<dependency>
 					<groupId>ch.qos.logback</groupId>
 					<artifactId>logback-classic</artifactId>
-					<version>1.5.12</version>
+					<version>1.5.16</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -70,7 +70,7 @@
 				<dependency>
 					<groupId>com.google.code.gson</groupId>
 					<artifactId>gson</artifactId>
-					<version>2.11.0</version>
+					<version>2.12.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -82,7 +82,7 @@
 				<dependency>
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
-					<version>33.3.1-jre</version>
+					<version>33.4.0-jre</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -94,7 +94,7 @@
 				<dependency>
 					<groupId>commons-codec</groupId>
 					<artifactId>commons-codec</artifactId>
-					<version>1.17.1</version>
+					<version>1.18.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
Content taken from https://github.com/eclipse-m2e/m2e-core/pull/1923 as all updates are not appliable without code changes. Updated are:
* ch.qos.logback:logback-classic:jar:1.5.12 has been updated to version 1.5.16
    additionally requires java.package; java.lang.module 0.0.0 compared
to the previous version
* com.google.code.gson:gson:jar:2.11.0 has been updated to version 2.12.1
    additionally requires osgi.ee; (&(osgi.ee=JavaSE)(version=1.8))
compared to the previous version
* com.google.guava:guava:jar:33.3.1-jre has been updated to version 33.4.0-jre
* commons-codec:commons-codec:jar:1.17.1 has been updated to version 1.18.0