### PR TITLE
Set release instead of source/target for compiler plugin

### DIFF
--- a/org.eclipse.m2e.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.feature/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Update build-qualifier because maven-runtime version update to Maven 3.9.9
 Touch for https://github.com/eclipse-m2e/m2e-core/pull/1932
+Touch for https://github.com/eclipse-m2e/m2e-core/pull/1934

--- a/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/org.eclipse.m2e.maven.runtime/pom.xml
@@ -228,8 +228,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>
 					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
+						<release>8</release>
 						<proc>none</proc>
 					</configuration>
 				</plugin>

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Testing Helpers
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.1.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[3.9.900,4.0.0)",
  org.eclipse.m2e.jdt;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.core.runtime,
  org.eclipse.jdt.core,


### PR DESCRIPTION
Should fix :
```
17:06:19  [WARNING] bootstrap class path not set in conjunction with
-source 8
17:06:19  [WARNING] source value 8 is obsolete and will be removed in a
future release
17:06:19  [WARNING] target value 8 is obsolete and will be removed in a
future release
17:06:19  [WARNING] To suppress warnings about obsolete options, use
-Xlint:-options.
```
in the build.