### PR TITLE
Show the scope that introduces a transitive dependency

### DIFF
--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.1.qualifier
 Export-Package: org.eclipse.m2e.pde.ui.target.editor;x-friends:="org.eclipse.m2e.swtbot.tests"
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/provider/DependencyNodeLabelProvider.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/provider/DependencyNodeLabelProvider.java
@@ -13,6 +13,7 @@
 package org.eclipse.m2e.pde.ui.target.provider;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
@@ -48,6 +49,13 @@ public class DependencyNodeLabelProvider implements ILabelProvider {
 			MavenTargetLocation location = getTargetLocation(node);
 			String baseLabel = artifact.getGroupId() + ":" + artifact.getArtifactId() + " (" + artifact.getVersion()
 					+ ")";
+			Dependency dependency = node.getDependency();
+			if (dependency != null) {
+				String scope = dependency.getScope();
+				if (scope != null && !scope.isBlank()) {
+					baseLabel += " [" + scope + "]";
+				}
+			}
 			if (location != null) {
 				if (location.isExcluded(artifact)) {
 					return "(excluded) " + baseLabel;


### PR DESCRIPTION
Currently when we show the tree of transitive dependencies one can not see what scope contributes the dependency but this is an interesting information as we filter for these scopes