### PR TITLE
Redirect console output to file in test

### DIFF
--- a/org.eclipse.m2e.jdt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
  org.eclipse.ui.tests.harness,
- org.eclipse.ui
+ org.eclipse.ui,
+ org.eclipse.debug.ui;bundle-version="3.18.600"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse.org - m2e
 Automatic-Module-Name: org.eclipse.m2e.jdt.tests

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/RunTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/RunTest.java
@@ -12,6 +12,9 @@ package org.eclipse.m2e.jdt.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.FileLocator;
@@ -24,6 +27,7 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.junit.Test;
@@ -32,26 +36,35 @@ public class RunTest extends AbstractMavenProjectTestCase {
 
 	@Test
 	public void testRunTwice() throws Exception {
-		IProject project = importProject(FileLocator.toFileURL(getClass().getResource("/projects/basicProjectWithDep/pom.xml")).getPath());
+		IProject project = importProject(
+				FileLocator.toFileURL(getClass().getResource("/projects/basicProjectWithDep/pom.xml")).getPath());
 		waitForJobsToComplete(monitor);
 		project.build(IncrementalProjectBuilder.FULL_BUILD, null);
 		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-		ILaunchConfigurationWorkingCopy launchConfig = launchManager.getLaunchConfigurationType(IJavaLaunchConfigurationConstants.ID_JAVA_APPLICATION).newInstance(project, "launch");
+		ILaunchConfigurationWorkingCopy launchConfig = launchManager
+				.getLaunchConfigurationType(IJavaLaunchConfigurationConstants.ID_JAVA_APPLICATION)
+				.newInstance(project, "launch");
 		launchConfig.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName());
 		launchConfig.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "testMvn.TestClass");
 		launchConfig.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, project.getLocation().toString());
 		IJobFunction assertSuccessfulRun = monitor -> {
 			try {
-				ILaunch launch = launchConfig.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
-				while (!launch.isTerminated()) {
-					Thread.sleep(300);
+				Path file = Files.createTempFile("RunTest", ".log");
+				try {
+					launchConfig.setAttribute(IDebugUIConstants.ATTR_CAPTURE_IN_FILE, file.toAbsolutePath().toString());
+					ILaunch launch = launchConfig.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
+					while (!launch.isTerminated()) {
+						Thread.sleep(300);
+					}
+					IProcess process = launch.getProcesses()[0];
+					String errorOutput = process.getStreamsProxy().getErrorStreamMonitor().getContents();
+					assertEquals("", errorOutput);
+					assertEquals(0, process.getExitValue());
+					assertEquals("ok", Files.readString(file));
+					return Status.OK_STATUS;
+				} finally {
+					Files.delete(file);
 				}
-				IProcess process = launch.getProcesses()[0];
-				String errorOutput = process.getStreamsProxy().getErrorStreamMonitor().getContents();
-				assertEquals("", errorOutput);
-				assertEquals(0, process.getExitValue());
-				assertEquals("ok", process.getStreamsProxy().getOutputStreamMonitor().getContents());
-				return Status.OK_STATUS;
 			} catch (Exception e) {
 				return Status.error(e.getMessage(), e);
 			}


### PR DESCRIPTION
Reading the stream content seems to be not reliable enough and is prone to side effects.

THis now redirects the console output to a file and read it from there to make the test more robust.