### PR TITLE
Add support for using conditional packages directive.

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.function.Function;
 import java.util.jar.Attributes;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.pde.core.target.ITargetLocation;
 import org.eclipse.pde.core.target.TargetBundle;
@@ -36,6 +38,8 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
+
+import aQute.bnd.osgi.Jar;
 
 public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 
@@ -284,6 +288,44 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 		assertNull(sourceAttributes.getValue(Constants.EXPORT_PACKAGE));
 		assertNull(sourceAttributes.getValue(Constants.REQUIRE_BUNDLE));
 		assertNull(sourceAttributes.getValue(Constants.DYNAMICIMPORT_PACKAGE));
+	}
+
+	@Test
+	public void testConditionalPackage() throws Exception {
+		ITargetLocation target = resolveMavenTarget(
+				"""
+						<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="false" label="Maven-archetype" missingManifest="generate" type="Maven">
+						<dependencies>
+							<dependency>
+								<groupId>org.apache.maven.archetype</groupId>
+								<artifactId>archetype-common</artifactId>
+								<version>3.3.1</version>
+								<type>jar</type>
+							</dependency>
+							</dependencies>
+							<instructions><![CDATA[
+								Bundle-Name:           Bundle in Test from artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}:${mvnClassifier}
+								version:               ${version_cleanup;${mvnVersion}}
+								Bundle-SymbolicName:   m2e.custom.test.wrapped.${mvnArtifactId}
+								Bundle-Version:        ${version}
+								Import-Package:        *
+								Export-Package:        org.apache.maven.archetype;version="${version}";-noimport:=true
+								-conditionalpackage:   org.apache.commons.*
+							]]></instructions>
+						</location>
+						""");
+		assertStatusOk(getTargetStatus(target));
+		TargetBundle[] bundles = target.getBundles();
+		for (TargetBundle bundle : bundles) {
+			BundleInfo bundleInfo = bundle.getBundleInfo();
+			File file = new File(bundleInfo.getLocation());
+			try (Jar jar = new Jar(file)) {
+				Set<String> resources = jar.getResources().keySet();
+				assertTrue("Conditional package org.apache.commons.* not included.",
+						resources.stream().anyMatch(s -> s.startsWith("org/apache/commons/")));
+			}
+			;
+		}
 	}
 
 	@Test

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -60,8 +60,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.m2e.pde.target.shared.ProcessingMessage.Type;
 import org.osgi.framework.Constants;
 
-import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
 import aQute.bnd.version.Version;
 
 /**
@@ -204,7 +205,8 @@ public class MavenBundleWrapper {
 				List<ProcessingMessage> messages = new ArrayList<>();
 				wrapArtifactFile.getParentFile().mkdirs();
 				boolean hasErrors = false;
-				try (Analyzer analyzer = new Analyzer(analyzerJar);) {
+				try (Builder analyzer = new Builder(new Processor());) {
+					analyzer.setJar(analyzerJar);
 					analyzer.setProperty("mvnGroupId", artifact.getGroupId());
 					analyzer.setProperty("mvnArtifactId", artifact.getArtifactId());
 					analyzer.setProperty("mvnVersion", artifact.getBaseVersion());


### PR DESCRIPTION
bndtools has a feature named "conditional package"[1] that allows to slurp-in certain code into the final jar for example to prevent having a dependency on a full module when maybe only a single class is used,

Currently when using maven targets this can not be used because it is a feature only supported in the builder, this now adds support for using this as well as a test-case to demonstrate it.

[1] https://bnd.bndtools.org/instructions/conditionalpackage.html