### PR TITLE
Enclose system properties containing white space with quotation marks

### DIFF
--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 2.4.0.qualifier
+Bundle-Version: 2.4.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.7.3.qualifier
+Bundle-Version: 2.7.4.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.lemminx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven POM File Editor using Wild Web Developer, LemMinX and Maven LS extension (requires Incubating components)
 Bundle-SymbolicName: org.eclipse.m2e.editor.lemminx;singleton:=true
-Bundle-Version: 2.0.900.qualifier
+Bundle-Version: 2.0.901.qualifier
 Automatic-Module-Name: org.eclipse.m2e.xmlls.extension
 Import-Package: javax.inject;version="[1.0.0,2.0.0)",
  org.apache.commons.cli;version="1.6.0",

--- a/org.eclipse.m2e.editor.lemminx/pom.xml
+++ b/org.eclipse.m2e.editor.lemminx/pom.xml
@@ -24,7 +24,7 @@
 	<artifactId>org.eclipse.m2e.editor.lemminx</artifactId>
 	<name>M2E Maven POM File Editor (Wild Web Developer, LemMinX, LS)</name>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.900-SNAPSHOT</version>
+	<version>2.0.901-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/UnitTestLaunchConfigConfigurationTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/UnitTestLaunchConfigConfigurationTest.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.m2e.jdt.tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -37,6 +38,7 @@ import org.eclipse.m2e.core.internal.preferences.MavenConfigurationImpl;
 import org.eclipse.m2e.jdt.internal.UnitTestSupport;
 import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +55,11 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 	private static final String ROOT_PATH = "/projects/surefireFailsafeToTestLaunchSettings";
 	private static ILaunchManager LAUNCH_MANAGER = DebugPlugin.getDefault().getLaunchManager();
 
+	/*
+	 * XML allows encoding set of control characters: space (U+0020), carriage
+	 * return (U+000d), line feed (U+000a) and horizontal tab (U+0009).
+	 * https://www.w3.org/TR/xml-entity-names/000.html
+	 */
 	private static final String SUREFIRE_ARGS_SET = """
 			<configuration>
 				<argLine>
@@ -60,6 +67,10 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 				</argLine>
 				<systemPropertyVariables>
 					<surefireProp1>surefireProp1Value</surefireProp1>
+					<surefirePropWithSpaces>surefire Prop&#x20;With Spaces</surefirePropWithSpaces>
+					<surefirePropWithTab>surefirePropWith&#x09;Tab</surefirePropWithTab>
+					<surefirePropWithCR>has&#x0d;CR</surefirePropWithCR>
+					<surefirePropWithLF>has&#x0a;LF</surefirePropWithLF>
 					<surefireEmptyProp>${undefinedProperty}</surefireEmptyProp>
 				</systemPropertyVariables>
 				<environmentVariables>
@@ -76,6 +87,10 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 				<systemPropertyVariables>
 					<failsafeProp1>failsafeProp1Value</failsafeProp1>
 					<failsafeEmptyProp>${undefiniedProperty}</failsafeEmptyProp>
+					<failsafePropWithSpaces>failsafe Prop&#x20;With Spaces</failsafePropWithSpaces>
+					<failsafePropWithTab>failsafePropWith&#x09;Tab</failsafePropWithTab>
+					<failsafePropWithCR>has&#x0d;CR</failsafePropWithCR>
+					<failsafePropWithLF>has&#x0a;LF</failsafePropWithLF>
 				</systemPropertyVariables>
 				<environmentVariables>
 					<failsafeEnvironmentVariables1>failsafeEnvironmentVariables1Value</failsafeEnvironmentVariables1>
@@ -149,6 +164,12 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 		// check systemPropertyVariables
 		assertTrue(argLine.contains("-DsurefireProp1=surefireProp1Value"));
 
+		// check systemPropertyVariables with white space in values have values quoted
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithSpaces=\"surefire Prop With Spaces\""));
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithTab=\"surefirePropWith\tTab\""));
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithCR=\"has\rCR\""));
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithLF=\"has\nLF\""));
+
 		// check systemPropertyVariables with null value aren't set
 		assertTrue(!argLine.contains("-DsurefireEmptyProp="));
 
@@ -204,6 +225,13 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 
 		// check systemPropertyVariables with null value aren't set
 		assertTrue(!argLine.contains("-DfailsafeEmptyProp="));
+
+		// check systemPropertyVariables with white space in values have values quoted
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithSpaces=\"failsafe Prop With Spaces\""));
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithTab=\"failsafePropWith\tTab\""));
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithCR=\"has\rCR\""));
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithLF=\"has\nLF\""));
+
 	}
 
 	@Test
@@ -246,6 +274,13 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 
 		// check systemPropertyVariables
 		assertTrue(argLine.contains("-DsurefireProp1=surefireProp1Value"));
+
+		// check systemPropertyVariables with white space in values have values quoted
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithSpaces=\"surefire Prop With Spaces\""));
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithTab=\"surefirePropWith\tTab\""));
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithCR=\"has\rCR\""));
+		assertThat(argLine, Matchers.containsString("-DsurefirePropWithLF=\"has\nLF\""));
+
 	}
 
 	@Test
@@ -288,6 +323,13 @@ public class UnitTestLaunchConfigConfigurationTest extends AbstractMavenProjectT
 
 		// check systemPropertyVariables
 		assertTrue(argLine.contains("-DfailsafeProp1=failsafeProp1Value"));
+
+		// check systemPropertyVariables with white space in values have values quoted
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithSpaces=\"failsafe Prop With Spaces\""));
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithTab=\"failsafePropWith\tTab\""));
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithCR=\"has\rCR\""));
+		assertThat(argLine, Matchers.containsString("-DfailsafePropWithLF=\"has\nLF\""));
+
 	}
 
 	@Test

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.4.100.qualifier
+Bundle-Version: 2.4.101.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/UnitTestSupport.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/UnitTestSupport.java
@@ -281,7 +281,7 @@ public class UnitTestSupport {
       if(args.systemPropertyVariables() != null) {
         args.systemPropertyVariables().entrySet().stream() //
             .filter(e -> e.getKey() != null && e.getValue() != null)
-            .forEach(e -> launchArguments.add("-D" + e.getKey() + "=" + e.getValue()));
+            .forEach(e -> launchArguments.add("-D" + e.getKey() + "=" + escapeValue(e.getValue())));
       }
       copy.setAttribute(LAUNCH_CONFIG_VM_ARGUMENTS, launchArguments.toString());
 
@@ -304,6 +304,13 @@ public class UnitTestSupport {
       }
 
       copy.doSave();
+    }
+
+    private static String escapeValue(String raw) {
+      if(raw.contains(" ") || raw.contains("\t") || raw.contains("\r") || raw.contains("\n")) {
+        return "\"" + raw + "\"";
+      }
+      return raw;
     }
 
     private TestLaunchArguments getTestLaunchArguments(ILaunchConfiguration configuration, IMavenProjectFacade facade,

--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 2.1.100.qualifier
+Bundle-Version: 2.1.101.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.variables,

--- a/org.eclipse.m2e.lemminx.feature/feature.xml
+++ b/org.eclipse.m2e.lemminx.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.lemminx.feature"
       label="%featureName"
-      version="2.6.100.qualifier"
+      version="2.6.101.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Connector
 Bundle-SymbolicName: org.eclipse.m2e.pde.connector;singleton:=true
-Bundle-Version: 2.2.100.qualifier
+Bundle-Version: 2.2.101.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.connector
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse.org - m2e

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.1.1.qualifier
+Bundle-Version: 2.1.2.qualifier
 Export-Package: org.eclipse.m2e.pde.ui.target.editor;x-friends:="org.eclipse.m2e.swtbot.tests"
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.profiles.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Maven Profiles Management
 Bundle-SymbolicName: org.eclipse.m2e.profiles.core;singleton:=true
-Bundle-Version: 2.2.100.qualifier
+Bundle-Version: 2.2.101.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",


### PR DESCRIPTION
# Summary

Fixes #1904

For Surefire and Filesafe plugins with `<systemPropertyVariables />` containing properties with white space characters:
* tab (`U+0009`)
* line feed (`U+000a`)
* carriage return (`U+000d`)
* space (`U+0020`)

wrap values with double quotation marks (`"`).

# Details

I chose these four characters as an intersection of a set of characters, supported by XML, and std::isspace() functions.

Command line reference for `java` command states in [Standard options for java](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#standard-options-for-java)

> -Dproperty=value
> Sets a system property value. The property variable is a string with no spaces that represents the name of the property. The value variable is a string that represents the value of the property. **If value is a string with spaces**, then enclose it in quotation marks (for example -Dfoo="foo bar").

_(emphasis mine)_

that values with spaces must be enclosed, however in section [Using the JDK_JAVA_OPTIONS Launcher Environment Variable](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#using-the-jdk_java_options-launcher-environment-variable) it states:
> The content of the JDK_JAVA_OPTIONS environment variable is a list of arguments separated by white-space characters (as determined by isspace())

and [std::isspace()](https://en.cppreference.com/w/cpp/string/byte/isspace) provides this list:
> * space (0x20, ' ')
> * form feed (0x0c, '\f')
> * line feed (0x0a, '\n')
> * carriage return (0x0d, '\r')
> * horizontal tab (0x09, '\t')
> * vertical tab (0x0b, '\v')

While [000 \[C0 Controls and Basic Latin, C1 Controls and Latin-1 Supplement\]](https://www.w3.org/TR/xml-entity-names/000.html) section of [XML Entity Definitions for Characters (3rd Edition)](https://www.w3.org/TR/xml-entity-names/) specifies, which Unicode characters with code points between `U+00000` and `U+000FF` are valid XML entities.

Manual testing if `java` preserves said whitespace when passed to it through command line with following test program:
```java
package test;

import static java.util.stream.Collectors.joining;

public class SpaceTest {

	public static void main(String[] args) {
		System.getProperties().forEach((name, val) -> {
			if (((String) name).startsWith("prop.")) {
				System.out.append((String) name).println(':');
				System.out.println(((String) val).chars().mapToObj("%02X"::formatted).collect(joining(" ", "\t[", "]")));
			}
		});
	}

}

```
have shown following behavior on Fedora 41 and `OpenJDK Runtime Environment (Red_Hat-21.0.6.0.7-1) (build 21.0.6+7)`:
```bash
java -p ${ws}/test/bin -Dprop.whitespaces="$(printf "{\t\n\v\f\r }")" -m test/test.SpaceTest
```
and output:
```
prop.whitespaces:
        [7B 09 0A 0B 0C 0D 20 7D]
```