### PR TITLE
Set maven main class property for latest maven 4

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.7.1.qualifier
+Bundle-Version: 2.7.2.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/launch/MavenExternalRuntime.java
@@ -146,11 +146,7 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
       }
     };
 
-    Properties properties = new Properties();
-    copyProperties(properties, System.getProperties());
-    properties.put(PROPERTY_MAVEN_HOME, getLocation());
-
-    ConfigurationParser parser = new ConfigurationParser(handler, properties);
+    ConfigurationParser parser = new ConfigurationParser(handler, getConfigParserProperties());
 
     try (FileInputStream is = new FileInputStream(getLauncherConfigurationFile())) {
       parser.parse(is);
@@ -261,12 +257,8 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
 
     VersionHandler handler = new VersionHandler();
 
-    Properties properties = new Properties();
-    copyProperties(properties, System.getProperties());
-    properties.put(PROPERTY_MAVEN_HOME, getLocation());
-
     try (FileInputStream is = new FileInputStream(getLauncherConfigurationFile())) {
-      new ConfigurationParser(handler, properties).parse(is);
+      new ConfigurationParser(handler, getConfigParserProperties()).parse(is);
     }
     if(handler.mavenCore != null) {
       return handler.mavenCore;
@@ -275,4 +267,13 @@ public class MavenExternalRuntime extends AbstractMavenRuntime {
     }
     return null;
   }
+
+  private Properties getConfigParserProperties() {
+    Properties properties = new Properties();
+    copyProperties(properties, System.getProperties());
+    properties.put(PROPERTY_MAVEN_HOME, getLocation());
+    properties.put("maven.mainClass", "org.apache.maven.cling.MavenCling"); //required for maven 4
+    return properties;
+  }
+
 }

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.8.0.qualifier"
+      version="2.9.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.8.1.qualifier"
+      version="2.9.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Latest Maven 4 uses a placeholder for the main class in the maven config file and currently m2e fails to add such installations.

This now sets the property with a default value so m2e can parse the config again.