### PR TITLE
Handle version range in dependencies for target locations

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -45,6 +45,24 @@ import aQute.bnd.osgi.Jar;
 public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 
 	@Test
+	public void testVersionRanges() throws Exception {
+		ITargetLocation target = resolveMavenTarget(
+				"""
+						<location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="true" label="cucumber" missingManifest="generate" type="Maven">
+						    <dependencies>
+						        <dependency>
+						            <groupId>io.cucumber</groupId>
+						            <artifactId>cucumber-java</artifactId>
+						            <version>7.21.1</version>
+						            <type>jar</type>
+						        </dependency>
+						    </dependencies>
+						</location>
+						        """);
+		assertStatusOk(getTargetStatus(target));
+	}
+
+	@Test
 	public void testBadDependencyInChain() throws Exception {
 		ITargetLocation target = resolveMavenTarget("""
 				<location includeDependencyScope="compile" missingManifest="generate" type="Maven">

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.1.1.qualifier
+Bundle-Version: 2.1.2.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenDependencyCollector.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenDependencyCollector.java
@@ -14,6 +14,7 @@ package org.eclipse.m2e.pde.target.shared;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -35,6 +36,10 @@ import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.version.Version;
 
 /**
  * Collector to collect (and filter) all transitive dependencies of a maven
@@ -108,16 +113,45 @@ public class MavenDependencyCollector {
 		while (!queue.isEmpty()) {
 			ArtifactDescriptor current = queue.poll();
 			for (Dependency dependency : current.dependencies()) {
-				if (isValidDependency(dependency) && collected.add(getId(dependency))) {
-					ArtifactDescriptor dependencyDescriptor = readArtifactDescriptor(dependency, current.node(),
-							artifacts, nodes);
-					if (dependencyDescriptor != null) {
-						queue.add(dependencyDescriptor);
+				if (isValidDependency(dependency)) {
+					if (isVersionRanged(dependency)) {
+						ArtifactDescriptor dependencyDescriptor = resolveHighestVersion(dependency, current.node(),
+								artifacts, nodes);
+						if (dependencyDescriptor != null
+								&& collected.add(getId(dependencyDescriptor.node().getDependency()))) {
+							queue.add(dependencyDescriptor);
+						}
+					}
+					if (collected.add(getId(dependency))) {
+						ArtifactDescriptor dependencyDescriptor = readArtifactDescriptor(dependency, current.node(),
+								artifacts, nodes);
+						if (dependencyDescriptor != null) {
+							queue.add(dependencyDescriptor);
+						}
 					}
 				}
 			}
 		}
 		return new DependencyResult(depth, artifacts, rootDescriptor.node(), nodes);
+	}
+
+	private ArtifactDescriptor resolveHighestVersion(Dependency dependency, DependencyNode parent,
+			Collection<RepositoryArtifact> artifacts, List<DependencyNode> nodes)
+			throws VersionRangeResolutionException {
+		Artifact artifact = dependency.getArtifact();
+		VersionRangeRequest request = new VersionRangeRequest(artifact, repositories, "");
+		VersionRangeResult result = repoSystem.resolveVersionRange(repositorySession, request);
+		List<Version> list = result.getVersions().stream().sorted(Comparator.reverseOrder()).toList();
+		for (Version version : list) {
+			Artifact setVersion = artifact.setVersion(version.toString());
+			dependency = dependency.setArtifact(setVersion);
+			try {
+				return readArtifactDescriptor(dependency, parent, artifacts, nodes);
+			} catch (RepositoryException e) {
+				// we need to try the next version then!
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -197,6 +231,11 @@ public class MavenDependencyCollector {
 	private static boolean isClassified(MavenRootDependency root) {
 		String classifier = root.classifier();
 		return classifier != null && !classifier.isBlank();
+	}
+
+	private static boolean isVersionRanged(Dependency dependency) {
+		String version = dependency.getArtifact().getVersion();
+		return version != null && version.startsWith("(") || version.startsWith("[");
 	}
 
 }


### PR DESCRIPTION
Currently if a dependency uses a version range this fails to resolve the target as maven-resolver tries to use the version "as-is"

This now adds a testcase and a fix to resolve to the highest possible version in such case.

See
- https://github.com/eclipse-tycho/tycho/pull/4895