### PR TITLE
Gracefully handle projects that can't be built during project update

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.7.2.qualifier
+Bundle-Version: 2.7.3.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -468,6 +468,11 @@ public class ProjectRegistryManager implements ISaveParticipant {
             if(!allProcessedPoms.contains(newFacade.getPom())) {
               // facade from workspace state that has not been refreshed yet
               newFacade = readMavenProjectFacades(Collections.singletonList(pom), newState, context, monitor).get(pom);
+              if ( newFacade == null ) {
+                // https://github.com/eclipse-m2e/m2e-core/issues/1605
+                // projects that fail even minimal validation, e.g. unresolvable parent pom, cannot be read
+                continue;
+              }
             } else {
               // recreate facade instance to trigger project changed event
               // this is only necessary for facades that are refreshed because their dependencies changed

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.9.0.qualifier"
+      version="2.9.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"


### PR DESCRIPTION
If a project fails even a build at VALIDATION_LEVEL_MINIMAL its configuration cannot be updated. One such root cause is an unresolvable parent pom.

Ignore such projects when updating configuration to allow the job to succeed for other projects.

Fixes #1605