### PR TITLE
Add test for TP issue with maven test scope in 2025-03

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -244,6 +244,29 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 	}
 
 	@Test
+	public void testNonOSGiArtifact_scopeTestIssue() throws Exception {
+		ITargetLocation target = resolveMavenTarget("""
+				<location includeDependencyDepth="infinite" includeDependencyScopes="compile,test,runtime" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
+					<dependencies>
+					<dependency>
+						<groupId>org.apache.poi</groupId>
+						<artifactId>poi</artifactId>
+						<version>4.1.2</version>
+						<type>jar</type>
+					</dependency>
+					<dependency>
+						<groupId>org.apache.poi</groupId>
+						<artifactId>poi-ooxml</artifactId>
+						<version>4.1.2</version>
+						<type>jar</type>
+					</dependency>
+					</dependencies>
+				</location>
+				""");
+		assertStatusOk(getTargetStatus(target));
+	}
+
+	@Test
 	public void testNonOSGiArtifact_missingArtifactGenerate_defaultInstructions() throws Exception {
 		ITargetLocation target = resolveMavenTarget("""
 				<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">


### PR DESCRIPTION
Related in #1976, this PR adds a test that fails when using the `test` scope when loading a Maven dependency from a target platform.