### PR TITLE
Fix case where a non jar dependency is in the chain for wrapping

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -45,6 +45,24 @@ import aQute.bnd.osgi.Jar;
 public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 
 	@Test
+	public void testNonJarArtifactInDependencies() throws Exception {
+		ITargetLocation target = resolveMavenTarget(
+				"""
+						    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="true" label="Azure OpenAI" missingManifest="generate" type="Maven">
+						        <dependencies>
+						            <dependency>
+						                <groupId>com.azure</groupId>
+						                <artifactId>azure-ai-openai</artifactId>
+						                <version>1.0.0-beta.13</version>
+						                <type>jar</type>
+						            </dependency>
+						        </dependencies>
+						    </location>
+						""");
+		assertStatusOk(getTargetStatus(target));
+	}
+
+	@Test
 	public void testVersionRanges() throws Exception {
 		ITargetLocation target = resolveMavenTarget(
 				"""

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -164,6 +164,11 @@ public class MavenBundleWrapper {
 			return wrappedNode;
 		}
 		Artifact artifact = node.getArtifact();
+		if (!"jar".equals(artifact.getExtension())) {
+			visited.put(node, wrappedNode = new WrappedBundle(node, List.of(), null, null, null, List.of(
+					new ProcessingMessage(artifact, Type.INFO, "Skip " + node.getArtifact() + " it is not a jar"))));
+			return wrappedNode;
+		}
 		File originalFile = artifact.getFile();
 		if (originalFile == null) {
 			if (node.getDependency().isOptional()) {
@@ -177,7 +182,16 @@ public class MavenBundleWrapper {
 			}
 			return wrappedNode;
 		}
-		Jar jar = new Jar(originalFile);
+		Jar jar;
+		try {
+			jar = new Jar(originalFile);
+		} catch (IOException e) {
+			visited.put(node,
+					wrappedNode = new WrappedBundle(node, List.of(), null, null, null,
+							List.of(new ProcessingMessage(artifact, Type.ERROR,
+									"Artifact " + node.getArtifact() + " can not be read as a jar file"))));
+			return wrappedNode;
+		}
 		if (isValidOSGi(jar.getManifest())) {
 			// already a bundle!
 			visited.put(node,

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/ProcessingMessage.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/ProcessingMessage.java
@@ -20,7 +20,7 @@ import org.eclipse.aether.artifact.Artifact;
 public record ProcessingMessage(Artifact artifact, Type type, String message) {
 
 	public enum Type {
-		ERROR, WARN 
+		ERROR, WARN, INFO;
 	}
 
 }


### PR DESCRIPTION
Currently when there is a non jar in the dependency chain it fails to resolve the target because it can not read as a jar

See
- https://github.com/eclipse-tycho/tycho/pull/4951