### PR TITLE
Restore ignoreIfBetter

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClasspathContainerSaveHelper.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/MavenClasspathContainerSaveHelper.java
@@ -183,12 +183,18 @@ public class MavenClasspathContainerSaveHelper {
 
     private final int kind;
 
+    private final boolean ignoreIfBetter;
+
     AccessRuleReplace(IAccessRule accessRule) {
       pattern = accessRule.getPattern();
       kind = accessRule.getKind();
+      ignoreIfBetter = accessRule.ignoreIfBetter();
     }
 
     IAccessRule getAccessRule() {
+      if(ignoreIfBetter) {
+        return JavaCore.newAccessRule(pattern, kind | IAccessRule.IGNORE_IF_BETTER);
+      }
       return JavaCore.newAccessRule(pattern, kind);
     }
   }


### PR DESCRIPTION
Currently MavenClasspathContainerSaveHelper does not correctly restore the flag ignoreIfBetter, this fixes it.