### PR TITLE
Add tracing to maven protocol handler and force update for snapshots

### DIFF
--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -42,7 +42,8 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.core.filebuffers,
  org.eclipse.ui,
  org.eclipse.ui.navigator,
- org.eclipse.debug.ui
+ org.eclipse.debug.ui,
+ org.eclipse.ui.trace
 Import-Package: org.apache.maven.archetype.catalog;provider=m2e;version="[3.2.1,4.0.0)",
  org.apache.maven.archetype.catalog.io.xpp3;provider=m2e;version="[3.2.1,4.0.0)",
  org.apache.maven.archetype.common;provider=m2e;version="[3.2.1,4.0.0)",

--- a/org.eclipse.m2e.core.ui/plugin.xml
+++ b/org.eclipse.m2e.core.ui/plugin.xml
@@ -746,4 +746,15 @@
 			</enablement>
 	    </commonWizard>
 	 </extension>
+  <extension
+        point="org.eclipse.ui.trace.traceComponents">
+     <component
+           id="org.eclipse.m2e.core.ui.component1"
+           label="M2E Maven Integration for Eclipse">
+        <bundle
+              consumed="true"
+              name="org.eclipse.m2e.*">
+        </bundle>
+     </component>
+  </extension>
 </plugin>

--- a/org.eclipse.m2e.core/.options
+++ b/org.eclipse.m2e.core/.options
@@ -1,0 +1,1 @@
+org.eclipse.m2e.core/mvnProtocolHandler=false

--- a/org.eclipse.m2e.core/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/org.eclipse.m2e.core/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,5 +1,5 @@
 classpath=true
-dsVersion=V1_3
+dsVersion=V1_5
 eclipse.preferences.version=1
 enabled=true
 generateBundleActivationPolicyLazy=true

--- a/org.eclipse.m2e.core/build.properties
+++ b/org.eclipse.m2e.core/build.properties
@@ -20,7 +20,8 @@ bin.includes = plugin.xml,\
                m2eclipse.gif,\
                about_files/,\
                OSGI-INF/,\
-               lifecycle-mapping-metadata.xml
+               lifecycle-mapping-metadata.xml,\
+               .options
 output.. = bin/
 source.. = src/,\
            src-gen/


### PR DESCRIPTION
Currently if something goes wrong with the maven protocol handler it is very hard to get a sense of what's going on.

This now enables tracing for m2e and using that in the protocol handler to allow further analysis in case where things go wrong.