### PR TITLE
Only consider the default-compile execution when update JDT settings

### DIFF
--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -638,6 +638,11 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     boolean enablePreviewFeatures = false;
 
     for(MojoExecution execution : getCompilerMojoExecutions(request, monitor)) {
+      String id = execution.getExecutionId();
+      if(!"default-compile".equals(id)) {
+        //Maven can have many but JDT only supports one config!
+        continue;
+      }
       release = getCompilerLevel(request.mavenProject(), execution, "release", release, RELEASES, monitor);
       //XXX ignoring testRelease option, since JDT doesn't support main/test classpath separation - yet
       source = getCompilerLevel(request.mavenProject(), execution, "source", source, SOURCES, monitor); //$NON-NLS-1$


### PR DESCRIPTION
While in maven we can have many executions with many different settings, JDT only supports one set of settings. If there are multiple with conflicting settings currently "last win". This is especially bad when using multi-release configuration where it leads to the last execution overwrite the projects actual compile level.

This now checks through the ececutions and only use the default-compile one to actually set up the project settings for JDT.