### PR TITLE
Restore maven build shortcut without adding a toolbar button

### DIFF
--- a/org.eclipse.m2e.launching/plugin.xml
+++ b/org.eclipse.m2e.launching/plugin.xml
@@ -34,6 +34,11 @@
              description="%m2.shortcut.description.generate-sources"
              categoryId="org.eclipse.debug.ui.category.run"/>
   </extension>
+  
+  <extension point="org.eclipse.ui.handlers">
+    <handler commandId="org.eclipse.m2e.core.pomFileAction.run"
+             class="org.eclipse.m2e.actions.ExecutePomAction"/>
+  </extension>
 
   <extension point="org.eclipse.ui.bindings">
     <key sequence="M3+M2+X M"

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/actions/ExecutePomAction.java
@@ -19,6 +19,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -56,6 +58,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.handlers.HandlerUtil;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMavenExecutableLocation;
@@ -74,7 +77,8 @@ import org.eclipse.m2e.ui.internal.launch.MavenLaunchMainTab;
  * @author Dmitri Maximovich
  * @author Eugene Kuleshov
  */
-public class ExecutePomAction implements ILaunchShortcut, IExecutableExtension, ILaunchShortcut2 {
+public class ExecutePomAction extends AbstractHandler
+    implements ILaunchShortcut, IExecutableExtension, ILaunchShortcut2 {
   private static final Logger log = LoggerFactory.getLogger(ExecutePomAction.class);
 
   private boolean showDialog = false;
@@ -87,6 +91,12 @@ public class ExecutePomAction implements ILaunchShortcut, IExecutableExtension, 
     } else {
       this.goalName = (String) data;
     }
+  }
+
+  public Object execute(ExecutionEvent event) {
+    ISelection selection = HandlerUtil.getCurrentSelection(event);
+    launch(findPomXmlBasedir(selection), ILaunchManager.RUN_MODE);
+    return null;
   }
 
   public void launch(IEditorPart editor, String mode) {


### PR DESCRIPTION
Reconnected the shortcut to an action that calls the previous code.
This is working without bringing the Button back, as Requested in #2048 
Also closes #1618 

Restores the previous behavior of the shortcut: (be reconnecting the old code)
If no maven launch configuration exists: Open the Create Dialog.
If exactly one configuration exists: Launch that configuration.
If more than one exists: Open a filterable/maneuverable Dialog to select which one you want.

@laeubi How's this?