### PR TITLE
The m2e-core-tests Git repository is now imported from master

### DIFF
--- a/setup/m2e.setup
+++ b/setup/m2e.setup
@@ -98,8 +98,7 @@
   <setupTask
       xsi:type="git:GitCloneTask"
       id="git.clone.m2e.core"
-      remoteURI="eclipse-m2e/m2e-core"
-      recursive="true">
+      remoteURI="eclipse-m2e/m2e-core">
     <annotation
         source="http://www.eclipse.org/oomph/setup/InducedChoices">
       <detail
@@ -109,6 +108,29 @@
       <detail
           key="label">
         <value>${scope.project.label} Git repository</value>
+      </detail>
+      <detail
+          key="target">
+        <value>remoteURI</value>
+      </detail>
+    </annotation>
+    <description>${scope.project.label}</description>
+  </setupTask>
+  <setupTask
+      xsi:type="git:GitCloneTask"
+      id="git.clone.m2e.core.tests"
+      remoteURI="eclipse-m2e/m2e-core-tests"
+      checkoutBranch="master"
+      locationQualifier="m2e-core/">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/InducedChoices">
+      <detail
+          key="inherit">
+        <value>github.remoteURIs</value>
+      </detail>
+      <detail
+          key="label">
+        <value>${scope.project.label} tests Git repository</value>
       </detail>
       <detail
           key="target">


### PR DESCRIPTION
Related to #2076, I have changed the _m2e.setup_ file so that the automatic installation of the development environment works again. Now, the _m2e-core-tests_ Git repository is imported separately from _master_. 

Obviously, this change should be undone once _m2e-core-tests_ is moved from _master_ to _main_.