### PR TITLE
m2e-core depends on LifecycleExecutionPlanCalculatorFacade

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 2.7.600.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[3.8.6,4.0.0)",
+Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[3.9.1101,4.0.0)",
  org.eclipse.m2e.workspace.cli;bundle-version="0.1.0",
  org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="3.9.0",


### PR DESCRIPTION
This was introduced in Maven Runtime bundle in version 3.9.1101