### PR TITLE
Add support for immutable collections in MavenProjectMutableState

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProjectMutableState.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenProjectMutableState.java
@@ -70,17 +70,25 @@ public class MavenProjectMutableState {
     setElements(project.getTestResources(), testResources);
 
     if(properties != null) {
-      project.getProperties().clear();
-      project.getProperties().putAll(properties);
+      try {
+        project.getProperties().clear();
+        project.getProperties().putAll(properties);
+      } catch(UnsupportedOperationException e) {
+        //if the collection itself is immutable then we do not need to restore a snapshot because it can not be altered anyways!
+      }
     }
 
     project.setContextValue(CTX_SNAPSHOT, null);
   }
 
   private <T> void setElements(List<T> collection, List<T> elements) {
-    if(elements != null) {
-      collection.clear();
-      collection.addAll(elements);
+    try {
+      if(elements != null) {
+        collection.clear();
+        collection.addAll(elements);
+      }
+    } catch(UnsupportedOperationException e) {
+      //if the collection itself is immutable then we do not need to restore a snapshot because it can not be altered anyways!
     }
   }
 


### PR DESCRIPTION
If the underlying collection is already immutable (e.g. Maven 4) we can not restore it but then we also do not need to bother about modifications.

This now catch the UnsupportedOperationException and let the code just go on.