### PR TITLE
Add Option to Rewrite Existing Manifest for Maven Artifacts

### DIFF
--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.3.600.qualifier"
+      version="2.3.700.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/shared/tests/MavenBundleWrapperTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/shared/tests/MavenBundleWrapperTest.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2026 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.shared.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+
+import org.eclipse.m2e.pde.target.shared.MavenBundleWrapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link MavenBundleWrapper} functionality.
+ */
+public class MavenBundleWrapperTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testGetEclipseSourceBundle_createsNewBundle() throws Exception {
+    // Create a source JAR file
+    File sourceFile = temporaryFolder.newFile("test-source.jar");
+    createSourceJar(sourceFile);
+
+    Manifest manifest = new Manifest();
+    File result = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest, "com.example.bundle", "1.0.0");
+
+    assertNotNull(result);
+    assertTrue("Eclipse source bundle should exist", result.exists());
+    assertEquals("com.example.bundle.source_1.0.0.jar", result.getName());
+    assertEquals(sourceFile.getParentFile(), result.getParentFile());
+
+    // Verify manifest headers
+    try (JarFile jar = new JarFile(result)) {
+      Manifest resultManifest = jar.getManifest();
+      assertNotNull(resultManifest);
+      Attributes attrs = resultManifest.getMainAttributes();
+      assertEquals("com.example.bundle.source", attrs.getValue("Bundle-SymbolicName"));
+      assertEquals("1.0.0", attrs.getValue("Bundle-Version"));
+      assertTrue(attrs.getValue("Eclipse-SourceBundle").contains("com.example.bundle"));
+    }
+  }
+
+  @Test
+  public void testGetEclipseSourceBundle_returnsCache() throws Exception {
+    // Create a source JAR file
+    File sourceFile = temporaryFolder.newFile("cached-source.jar");
+    createSourceJar(sourceFile);
+
+    Manifest manifest1 = new Manifest();
+    File result1 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest1, "com.example.bundle", "1.0.0");
+
+    // Remember modification time
+    long firstModTime = result1.lastModified();
+
+    // Wait a bit to ensure timestamp would be different if regenerated
+    Thread.sleep(100);
+
+    // Call again - should return cached version
+    Manifest manifest2 = new Manifest();
+    File result2 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest2, "com.example.bundle", "1.0.0");
+
+    assertEquals(result1.getAbsolutePath(), result2.getAbsolutePath());
+    assertEquals("Cache should be reused, modification time should be unchanged", firstModTime, result2.lastModified());
+  }
+
+  @Test
+  public void testGetEclipseSourceBundle_regeneratesWhenSourceChanged() throws Exception {
+    // Create a source JAR file
+    File sourceFile = temporaryFolder.newFile("changing-source.jar");
+    createSourceJar(sourceFile);
+
+    Manifest manifest1 = new Manifest();
+    File result1 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest1, "com.example.bundle", "1.0.0");
+    long firstSize = result1.length();
+
+    // Modify the source file
+    Thread.sleep(100); // Ensure different timestamp
+    createSourceJar(sourceFile, "additional content");
+
+    // Update source file timestamp to be newer
+    sourceFile.setLastModified(System.currentTimeMillis());
+
+    Manifest manifest2 = new Manifest();
+    File result2 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest2, "com.example.bundle", "1.0.0");
+
+    assertEquals(result1.getAbsolutePath(), result2.getAbsolutePath());
+    // The file should be regenerated (different size due to different content)
+    assertTrue("Regenerated bundle should have different size", result2.length() != firstSize);
+  }
+
+  @Test
+  public void testGetEclipseSourceBundle_differentBSNCreatesSeparateCache() throws Exception {
+    // Create a source JAR file
+    File sourceFile = temporaryFolder.newFile("artifact-source.jar");
+    createSourceJar(sourceFile);
+
+    // Wrap the same source with different BSN/version
+    Manifest manifest1 = new Manifest();
+    File result1 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest1, "com.example.bundle", "1.0.0");
+
+    Manifest manifest2 = new Manifest();
+    File result2 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest2, "com.other.bundle", "2.0.0");
+
+    // Should be different files
+    assertFalse("Different BSN/version should produce different cache files", result1.getAbsolutePath().equals(result2.getAbsolutePath()));
+    assertEquals("com.example.bundle.source_1.0.0.jar", result1.getName());
+    assertEquals("com.other.bundle.source_2.0.0.jar", result2.getName());
+
+    // Verify each has correct manifest
+    try (JarFile jar1 = new JarFile(result1)) {
+      Attributes attrs1 = jar1.getManifest().getMainAttributes();
+      assertEquals("com.example.bundle.source", attrs1.getValue("Bundle-SymbolicName"));
+      assertEquals("1.0.0", attrs1.getValue("Bundle-Version"));
+    }
+    try (JarFile jar2 = new JarFile(result2)) {
+      Attributes attrs2 = jar2.getManifest().getMainAttributes();
+      assertEquals("com.other.bundle.source", attrs2.getValue("Bundle-SymbolicName"));
+      assertEquals("2.0.0", attrs2.getValue("Bundle-Version"));
+    }
+  }
+
+  @Test
+  public void testIsOutdated_returnsTrueForMissingCache() throws Exception {
+    File sourceFile = temporaryFolder.newFile("source.jar");
+    File cacheFile = new File(temporaryFolder.getRoot(), "cache.jar");
+
+    assertTrue("Missing cache file should be outdated", MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()));
+  }
+
+  @Test
+  public void testIsOutdated_returnsFalseForUpToDateCache() throws Exception {
+    File sourceFile = temporaryFolder.newFile("source.jar");
+    File cacheFile = temporaryFolder.newFile("cache.jar");
+
+    // Set cache to be same timestamp as source
+    cacheFile.setLastModified(sourceFile.lastModified());
+
+    assertFalse("Cache with same timestamp should not be outdated", MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()));
+  }
+
+  @Test
+  public void testIsOutdated_returnsTrueWhenSourceNewer() throws Exception {
+    File sourceFile = temporaryFolder.newFile("source.jar");
+    File cacheFile = temporaryFolder.newFile("cache.jar");
+
+    // Set source to be newer than cache
+    Thread.sleep(100);
+    sourceFile.setLastModified(System.currentTimeMillis());
+    cacheFile.setLastModified(sourceFile.lastModified() - 1000);
+
+    assertTrue("Cache should be outdated when source is newer", MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()));
+  }
+
+  private void createSourceJar(File file) throws IOException {
+    createSourceJar(file, null);
+  }
+
+  private void createSourceJar(File file, String additionalContent) throws IOException {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(file), manifest)) {
+      // Add a dummy source file
+      jos.putNextEntry(new ZipEntry("com/example/Test.java"));
+      String content = "package com.example;\npublic class Test {}";
+      if (additionalContent != null) {
+        content += "\n// " + additionalContent;
+      }
+      jos.write(content.getBytes());
+      jos.closeEntry();
+    }
+  }
+}

--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/IgnoreExistingMetadataTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/IgnoreExistingMetadataTest.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2026 Vector Informatik GmbH
+ * All rights reserved.
+ * www.vector.com
+ *******************************************************************************/
+package org.eclipse.m2e.pde.target.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.jar.Attributes;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.m2e.pde.target.MissingMetadataMode;
+import org.eclipse.m2e.pde.target.shared.DependencyDepth;
+import org.eclipse.pde.core.target.ITargetLocation;
+import org.eclipse.pde.core.target.TargetBundle;
+import org.junit.Test;
+import org.osgi.framework.Constants;
+
+public class IgnoreExistingMetadataTest extends AbstractMavenTargetTest {
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataFalse_WithInstructions_MissingMetadataModeGenerate_ExpectOriginalManifest()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, false, MissingMetadataMode.GENERATE));
+		assertOriginalManifest(target);
+	}
+
+	private String getTargetXMLForDependencyWithExistingManifest(DependencyDepth dependencyDepth, boolean includeSource,
+			boolean ignoreExistingMetadata, MissingMetadataMode missingMetadataMode, String instructions) {
+		return String.format(
+				"""
+						<location includeDependencyDepth="%s" includeDependencyScopes="compile" includeSource="%s" ignoreExistingMetadata="%s" missingManifest="%s" type="Maven">
+						    <dependencies>
+						        <dependency>
+						            <groupId>org.slf4j</groupId>
+						            <artifactId>slf4j-api</artifactId>
+						            <version>2.0.7</version>
+						            <type>jar</type>
+						        </dependency>
+						    </dependencies>
+						    <instructions><![CDATA[
+						        %s
+						    ]]></instructions>
+						</location>
+						""",
+				dependencyDepth, includeSource, ignoreExistingMetadata, missingMetadataMode, instructions);
+	}
+
+	private void assertOriginalManifest(ITargetLocation target) throws IOException {
+		assertStatusOk(getTargetStatus(target));
+		TargetBundle[] bundles = target.getBundles();
+		assertEquals(1, bundles.length);
+
+		Attributes attributes = getManifestMainAttributes(bundles[0]);
+
+		assertEquals("slf4j.api", attributes.getValue(Constants.BUNDLE_SYMBOLICNAME));
+		assertEquals("2.0.7", attributes.getValue(Constants.BUNDLE_VERSION));
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataFalse_WithInstructions_MissingMetadataModeError_ExpectOriginalManifest()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, false, MissingMetadataMode.ERROR));
+		assertOriginalManifest(target);
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataFalse_WithInstructions_MissingMetadataModeIgnore_ExpectOriginalManifest()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, false, MissingMetadataMode.IGNORE));
+		assertOriginalManifest(target);
+	}
+
+	private String getTargetXMLForDependencyWithExistingManifest(DependencyDepth dependencyDepth, boolean includeSource,
+			boolean ignoreExistingMetadata, MissingMetadataMode missingMetadataMode) {
+		return getTargetXMLForDependencyWithExistingManifest(dependencyDepth, includeSource, ignoreExistingMetadata,
+				missingMetadataMode, getInstructionsForCustomBSN("custom.slf4j.api"));
+	}
+
+	private String getInstructionsForCustomBSN(String customBSN) {
+		return String.format("""
+				Bundle-SymbolicName: %s
+				""", customBSN);
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_WithInstructions_MissingMetadataModeGenerate_ExpectOverriddenManifest()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, true, MissingMetadataMode.GENERATE));
+		assertOverriddenManifest(target);
+	}
+
+	private void assertOverriddenManifest(ITargetLocation target) throws IOException {
+		assertStatusOk(getTargetStatus(target));
+		TargetBundle[] bundles = target.getBundles();
+		assertEquals(1, bundles.length);
+
+		Attributes attributes = getManifestMainAttributes(bundles[0]);
+
+		assertEquals("custom.slf4j.api", attributes.getValue(Constants.BUNDLE_SYMBOLICNAME));
+		assertEquals("2.0.7", attributes.getValue(Constants.BUNDLE_VERSION));
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_WithInstructions_MissingMetadataModeError_ExpectOverriddenManifest()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, true, MissingMetadataMode.GENERATE));
+		assertOverriddenManifest(target);
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_WithInstructions_MissingMetadataModeIgnore_ExpectOverriddenManifest()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, true, MissingMetadataMode.GENERATE));
+		assertOverriddenManifest(target);
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_DependencyDepthDirect_ExpectError()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(
+				DependencyDepth.DIRECT, false, true, MissingMetadataMode.GENERATE));
+		IStatus status = getTargetStatus(target);
+		assertErrorStatusAndMessage(status, "The dependency depth must be none!");
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_DependencyDepthInfinite_ExpectError()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(
+				DependencyDepth.INFINITE, false, true, MissingMetadataMode.GENERATE));
+		IStatus status = getTargetStatus(target);
+		assertErrorStatusAndMessage(status, "The dependency depth must be none!");
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_noBSNInInstructions_ExpectError()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, true, MissingMetadataMode.GENERATE, "Bundle-Version: 2.0.0"));
+		IStatus status = getTargetStatus(target);
+		assertErrorStatusAndMessage(status,
+				"The symbolic name in the bnd instructions must be defined and differ from the original one.");
+	}
+
+	@Test
+	public void testExistingBundle_MissingManifestGenerate_IgnoreExistingMetadataTrue_WithSameBSN_ExpectError()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				false, true, MissingMetadataMode.GENERATE, getInstructionsForCustomBSN("slf4j.api")));
+		IStatus status = getTargetStatus(target);
+		assertErrorStatusAndMessage(status,
+				"The symbolic name in the bnd instructions must be defined and differ from the original one.");
+	}
+
+	private void assertErrorStatusAndMessage(IStatus status, String errorReason) {
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		IStatus[] statusChildren = status.getChildren();
+		assertEquals(1, statusChildren.length);
+		String errorMessage = statusChildren[0].getMessage();
+		assertTrue("Unexpected error message: " + errorMessage,
+				errorMessage.equals("org.slf4j:slf4j-api:jar:2.0.7 cannot be overridden: " + errorReason));
+	}
+
+	@Test
+	public void testNonBundle_IgnoreExistingMetadataTrue_ExpectError() throws Exception {
+		ITargetLocation target = resolveMavenTarget(//
+				"""
+						<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="false" ignoreExistingMetadata="true" missingManifest="error" type="Maven">
+						    <dependencies>
+						        <dependency>
+						            <groupId>com.google.errorprone</groupId>
+						            <artifactId>error_prone_annotations</artifactId>
+						            <version>2.18.0</version>
+						            <type>jar</type>
+						        </dependency>
+						    </dependencies>
+						    <instructions><![CDATA[
+						        Bundle-SymbolicName: custom.errorprone
+						        Bundle-Version: 1.0.0
+						    ]]></instructions>
+						</location>
+						""");
+		IStatus status = getTargetStatus(target);
+		assertEquals(IStatus.ERROR, status.getSeverity());
+
+		IStatus[] statusChildren = status.getChildren();
+		assertEquals(1, statusChildren.length);
+
+		Throwable exception = statusChildren[0].getException();
+		assertTrue(exception instanceof CoreException);
+		assertTrue(exception.getMessage().contains("Error reading manifest"));
+	}
+
+	@Test
+	public void testExistingBundle_IgnoreExistingMetadataTrue_IncludeSourceTrue_ExpectOverriddenSourceBundle()
+			throws Exception {
+		ITargetLocation target = resolveMavenTarget(getTargetXMLForDependencyWithExistingManifest(DependencyDepth.NONE,
+				true, true, MissingMetadataMode.GENERATE));
+		assertStatusOk(getTargetStatus(target));
+		TargetBundle[] bundles = target.getBundles();
+		assertEquals(2, bundles.length);
+
+		Optional<TargetBundle> mainBundle = Arrays.stream(bundles).filter(b -> !b.isSourceBundle()).findFirst();
+		assertTrue(mainBundle.isPresent());
+
+		Attributes mainBundleAttributes = getManifestMainAttributes(mainBundle.get());
+
+		assertEquals("custom.slf4j.api", mainBundleAttributes.getValue(Constants.BUNDLE_SYMBOLICNAME));
+		assertEquals("2.0.7", mainBundleAttributes.getValue(Constants.BUNDLE_VERSION));
+
+		Optional<TargetBundle> sourceBundle = Arrays.stream(bundles).filter(b -> b.isSourceBundle()).findFirst();
+		assertTrue(sourceBundle.isPresent());
+
+		Attributes sourceAttributes = getManifestMainAttributes(sourceBundle.get());
+		assertEquals("custom.slf4j.api.source", sourceAttributes.getValue(Constants.BUNDLE_SYMBOLICNAME));
+		String sourceBundleHeader = sourceAttributes.getValue("Eclipse-SourceBundle");
+		assertTrue("Header Eclipse-SourceBundle has wrong value: " + sourceBundleHeader,
+				sourceBundleHeader.startsWith("custom.slf4j.api;version="));
+	}
+
+}

--- a/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.target/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration
 Bundle-SymbolicName: org.eclipse.m2e.pde.target;singleton:=true
-Bundle-Version: 2.1.100.qualifier
+Bundle-Version: 2.1.200.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.target
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenSourceBundle.java
@@ -35,13 +35,14 @@ public class MavenSourceBundle extends TargetBundle {
 		try (JarFile jar = new JarFile(sourceFile)) {
 			manifest = Objects.requireNonNullElseGet(jar.getManifest(), Manifest::new);
 		}
+		File sourceBundleFile = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest, symbolicName, version);
 		if (MavenBundleWrapper.isValidSourceManifest(manifest)) {
-			fInfo.setLocation(sourceFile.toURI());
+			fInfo.setLocation(sourceBundleFile.toURI());
 		} else {
 			File generatedSourceBundle = cacheManager.accessArtifactFile(artifact, file -> {
-				if (CacheManager.isOutdated(file, sourceFile)) {
+				if (CacheManager.isOutdated(file, sourceBundleFile)) {
 					MavenBundleWrapper.addSourceBundleMetadata(manifest, symbolicName, version);
-					MavenBundleWrapper.transferJarEntries(sourceFile, manifest, file);
+					MavenBundleWrapper.transferJarEntries(sourceBundleFile, manifest, file);
 				}
 				return file;
 			});

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetBundle.java
@@ -92,6 +92,18 @@ public class MavenTargetBundle extends TargetBundle {
 				file != null ? file.toURI() : null, -1, false);
 		try {
 			bundle = new TargetBundle(file);
+			if (location.isIgnoreExistingMetadata()) {
+				String overrideError = OverridePreconditionChecker.checkOverridePreconditions(
+						bundle.getBundleInfo().getSymbolicName(), location.getRoots(), location.getInstructions(),
+						location.getDependencyDepth());
+				if (overrideError != null) {
+					bundle = null;
+					status = Status.error(artifact + " cannot be overridden: " + overrideError);
+					LOGGER.log(status);
+					return;
+				}
+				generateOrOverrideManifest(artifact, location, monitor, true);
+			}
 		} catch (Exception ex) {
 			MissingMetadataMode metadataMode = location.getMetadataMode();
 			if (metadataMode == MissingMetadataMode.ERROR) {
@@ -99,8 +111,7 @@ public class MavenTargetBundle extends TargetBundle {
 				LOGGER.log(status);
 			} else if (metadataMode == MissingMetadataMode.GENERATE) {
 				try {
-					bundle = getWrappedArtifact(artifact, location, monitor);
-					isWrapped = true;
+					generateOrOverrideManifest(artifact, location, monitor, false);
 				} catch (Exception e) {
 					// not possible then
 					String message = artifact + " is not a bundle and cannot be automatically bundled as such ";
@@ -117,12 +128,18 @@ public class MavenTargetBundle extends TargetBundle {
 		}
 	}
 
+	private void generateOrOverrideManifest(Artifact artifact, MavenTargetLocation location, IProgressMonitor monitor,
+			boolean ignoreExistingMetadata) throws Exception {
+		bundle = getWrappedArtifact(artifact, location, monitor, ignoreExistingMetadata);
+		isWrapped = true;
+	}
+
 	public Artifact getArtifact() {
 		return artifact;
 	}
 
 	private static TargetBundle getWrappedArtifact(Artifact artifact, MavenTargetLocation location,
-			IProgressMonitor monitor) throws Exception {
+			IProgressMonitor monitor, boolean ignoreExistingMetadata) throws Exception {
 		IMaven maven = MavenPlugin.getMaven();
 		List<RemoteRepository> repositories = RepositoryUtils.toRepos(location.getAvailableArtifactRepositories(maven));
 		Function<DependencyNode, Properties> instructionsLookup = node -> {
@@ -139,7 +156,8 @@ public class MavenTargetBundle extends TargetBundle {
 			RepositorySystemSession repositorySession = context.getRepositorySession();
 			try {
 				WrappedBundle wrap = MavenBundleWrapper.getWrappedArtifact(artifact, instructionsLookup, repositories,
-						repoSystem, repositorySession, context.getComponentLookup().lookup(SyncContextFactory.class));
+						repoSystem, repositorySession, context.getComponentLookup().lookup(SyncContextFactory.class),
+						ignoreExistingMetadata);
 				List<ProcessingMessage> directErrors = wrap.messages(false)
 						.filter(msg -> msg.type() == ProcessingMessage.Type.ERROR).toList();
 				if (directErrors.isEmpty()) {

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -113,6 +113,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	public static final String ATTRIBUTE_DEPENDENCY_SCOPES = "includeDependencyScopes";
 	public static final String ATTRIBUTE_INCLUDE_SOURCE = "includeSource";
 	public static final String ATTRIBUTE_MISSING_META_DATA = "missingManifest";
+	public static final String ATTRIBUTE_IGNORE_EXISTING_METADATA = "ignoreExistingMetadata";
 	public static final List<String> DEFAULT_DEPENDENCY_SCOPES = List
 			.of(org.apache.maven.artifact.Artifact.SCOPE_COMPILE);
 	public static final MissingMetadataMode DEFAULT_METADATA_MODE = MissingMetadataMode.GENERATE;
@@ -130,6 +131,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	private final Set<Artifact> failedArtifacts = new HashSet<>();
 	private final Map<String, BNDInstructions> instructionsMap = new LinkedHashMap<>();
 	private final boolean includeSource;
+	private final boolean ignoreExistingMetadata;
 	private final List<MavenTargetDependency> roots;
 	private final List<MavenTargetRepository> extraRepositories;
 	private final IFeature featureTemplate;
@@ -139,7 +141,8 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	public MavenTargetLocation(String label, Collection<MavenTargetDependency> rootDependecies,
 			Collection<MavenTargetRepository> extraRepositories, MissingMetadataMode metadataMode,
 			DependencyDepth dependencyDepth, Collection<String> dependencyScopes, boolean includeSource,
-			Collection<BNDInstructions> instructions, Collection<String> excludes, IFeature featureTemplate) {
+			boolean ignoreExistingMetadata, Collection<BNDInstructions> instructions, Collection<String> excludes,
+			IFeature featureTemplate) {
 		this.label = label;
 		this.dependencyDepth = dependencyDepth;
 		this.featureTemplate = featureTemplate;
@@ -148,6 +151,8 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		this.metadataMode = metadataMode;
 		this.dependencyScopes = dependencyScopes;
 		this.includeSource = includeSource;
+		this.ignoreExistingMetadata = ignoreExistingMetadata;
+
 		for (BNDInstructions instr : instructions) {
 			instructionsMap.put(instr.key(), instr);
 		}
@@ -442,7 +447,8 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		}
 
 		return new MavenTargetLocation(label, latest, extraRepositories, metadataMode, dependencyDepth,
-				dependencyScopes, includeSource, instructionsMap.values(), excludedArtifacts, featureTemplate);
+				dependencyScopes, includeSource, ignoreExistingMetadata, instructionsMap.values(), excludedArtifacts,
+				featureTemplate);
 	}
 
 	public MavenTargetDependency update(MavenTargetDependency source, IProgressMonitor monitor) throws CoreException {
@@ -564,6 +570,10 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		return includeSource;
 	}
 
+	public boolean isIgnoreExistingMetadata() {
+		return ignoreExistingMetadata;
+	}
+
 	@Override
 	public String serialize() {
 		StringBuilder xml = new StringBuilder();
@@ -573,6 +583,7 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		attribute(xml, ATTRIBUTE_DEPENDENCY_SCOPES, dependencyScopes.stream().collect(Collectors.joining(",")));
 		attribute(xml, ATTRIBUTE_DEPENDENCY_DEPTH, dependencyDepth.name().toLowerCase());
 		attribute(xml, ATTRIBUTE_INCLUDE_SOURCE, includeSource ? "true" : "");
+		attribute(xml, ATTRIBUTE_IGNORE_EXISTING_METADATA, ignoreExistingMetadata ? "true" : "");
 		attribute(xml, "type", getType());
 		xml.append(">");
 		if (featureTemplate != null) {
@@ -710,15 +721,15 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 
 	public MavenTargetLocation withInstructions(Collection<BNDInstructions> instructions) {
 		return new MavenTargetLocation(label, roots.stream().map(MavenTargetDependency::copy).toList(),
-				extraRepositories, metadataMode, dependencyDepth, dependencyScopes, includeSource, instructions,
-				excludedArtifacts, featureTemplate);
+				extraRepositories, metadataMode, dependencyDepth, dependencyScopes, includeSource,
+				ignoreExistingMetadata, instructions, excludedArtifacts, featureTemplate);
 	}
 
 	public MavenTargetLocation withoutRoot(MavenTargetDependency toRemove) {
 		return new MavenTargetLocation(label,
 				roots.stream().filter(root -> root != toRemove).map(root -> root.copy()).collect(Collectors.toList()),
 				extraRepositories, metadataMode, dependencyDepth, dependencyScopes, includeSource,
-				instructionsMap.values(), excludedArtifacts, featureTemplate);
+				ignoreExistingMetadata, instructionsMap.values(), excludedArtifacts, featureTemplate);
 	}
 
 }

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocationFactory.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocationFactory.java
@@ -81,8 +81,10 @@ public class MavenTargetLocationFactory implements ITargetLocationFactory {
 			String label = location.getAttribute(MavenTargetLocation.ATTRIBUTE_LABEL);
 			boolean includeSource = Boolean
 					.parseBoolean(location.getAttribute(MavenTargetLocation.ATTRIBUTE_INCLUDE_SOURCE));
+			boolean ignoreExistingMetadata = Boolean
+					.parseBoolean(location.getAttribute(MavenTargetLocation.ATTRIBUTE_IGNORE_EXISTING_METADATA));
 			return new MavenTargetLocation(label, dependencies, repositories, mode, dependencyDepth, locationScopes,
-					includeSource, instructions, excludes, templateFeature);
+					includeSource, ignoreExistingMetadata, instructions, excludes, templateFeature);
 		} catch (Exception e) {
 			throw new CoreException(Status.error(e.getMessage(), e));
 		}

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/OverridePreconditionChecker.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/OverridePreconditionChecker.java
@@ -1,0 +1,59 @@
+package org.eclipse.m2e.pde.target;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.m2e.pde.target.shared.DependencyDepth;
+import org.osgi.framework.Constants;
+
+public class OverridePreconditionChecker {
+
+	/**
+	 * Validates preconditions for using override instructions on a bundle.
+	 *
+	 * @param originalSymbolicName the bundle symbolic name from the original
+	 *                             manifest; may be {@code null} if the artifact is
+	 *                             not a bundle
+	 * @param rootDependecies      the root dependencies of the artifact; must
+	 *                             contain exactly one entry
+	 * @param instructions         collection of {@link BNDInstructions}; must
+	 *                             contain exactly one entry with a symbolic name
+	 *                             different from {@code originalSymbolicName}
+	 * @param dependencyDepth      the dependency depth; must be
+	 *                             {@link DependencyDepth#NONE}
+	 * @return an error message if any precondition fails, otherwise {@code null}
+	 */
+	public static String checkOverridePreconditions(String originalSymbolicName,
+			List<MavenTargetDependency> rootDependecies, Collection<BNDInstructions> instructions,
+			DependencyDepth dependencyDepth) {
+		if (dependencyDepth != DependencyDepth.NONE) {
+			return "The dependency depth must be none!";
+		}
+		if (originalSymbolicName == null) {
+			return "The artifact is no bundle.";
+		}
+
+		if (rootDependecies.size() != 1) {
+			return "The location must contain exactly one root dependency.";
+		}
+
+		if (instructions.size() != 1) {
+			return "The location must contain exactly one bnd instruction which must contain a symbolic name that differs from the original one.";
+		}
+		BNDInstructions instruction = instructions.iterator().next();
+		if (!isSymbolicNameDefinedAndDiffers(instruction.asProperties(), originalSymbolicName)) {
+			return "The symbolic name in the bnd instructions must be defined and differ from the original one.";
+		}
+		return null;
+	}
+
+	private static boolean isSymbolicNameDefinedAndDiffers(Properties properties, String originalSymbolicName) {
+		if (properties == null) {
+			return false;
+		}
+		Object definedSymbolicName = properties.get(Constants.BUNDLE_SYMBOLICNAME);
+		return definedSymbolicName != null && !definedSymbolicName.equals(originalSymbolicName);
+	}
+
+}

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -92,22 +92,26 @@ public class MavenBundleWrapper {
 	/**
 	 * Wraps an artifact (and possible its dependents if required) to produce a
 	 * manifest with OSGi metadata.
-	 * 
-	 * @param artifact           the artifact to wrap
-	 * @param instructionsLookup a lookup for bnd instructions
-	 * @param repositories       the repositories that should be used to resolve
-	 *                           dependencies
-	 * @param repoSystem         the repository system for lookup dependent items
-	 * @param repositorySession  the session to use
-	 * @param syncContextFactory the sync context factory to acquire exclusive
-	 *                           access to the wrapped artifact and its dependencies
+	 *
+	 * @param artifact               the artifact to wrap
+	 * @param instructionsLookup     a lookup for bnd instructions
+	 * @param repositories           the repositories that should be used to resolve
+	 *                               dependencies
+	 * @param repoSystem             the repository system for lookup dependent
+	 *                               items
+	 * @param repositorySession      the session to use
+	 * @param syncContextFactory     the sync context factory to acquire exclusive
+	 *                               access to the wrapped artifact and its
+	 *                               dependencies
+	 * @param ignoreExistingMetadata if true, the manifest file is forced to be
+	 *                               overridden
 	 * @return the wrapped artifact
 	 * @throws Exception if wrapping the artifact fails for any reason
 	 */
 	public static WrappedBundle getWrappedArtifact(Artifact artifact,
 			Function<DependencyNode, Properties> instructionsLookup, List<RemoteRepository> repositories,
 			RepositorySystem repoSystem, RepositorySystemSession repositorySession,
-			SyncContextFactory syncContextFactory) throws Exception {
+			SyncContextFactory syncContextFactory, boolean ignoreExistingMetadata) throws Exception {
 		CollectRequest collectRequest = new CollectRequest();
 		collectRequest.setRoot(new Dependency(artifact, null));
 		collectRequest.setRepositories(repositories);
@@ -150,7 +154,7 @@ public class MavenBundleWrapper {
 			});
 			syncContext.acquire(lockList, null);
 			Map<DependencyNode, WrappedBundle> visited = new HashMap<>();
-			WrappedBundle wrappedNode = getWrappedNode(node, instructionsLookup, visited);
+			WrappedBundle wrappedNode = getWrappedNode(node, instructionsLookup, visited, ignoreExistingMetadata);
 			for (WrappedBundle wrap : visited.values()) {
 				wrap.getJar().ifPresent(jar -> jar.close());
 			}
@@ -159,8 +163,8 @@ public class MavenBundleWrapper {
 	}
 
 	private static WrappedBundle getWrappedNode(DependencyNode node,
-			Function<DependencyNode, Properties> instructionsLookup, Map<DependencyNode, WrappedBundle> visited)
-			throws Exception {
+			Function<DependencyNode, Properties> instructionsLookup, Map<DependencyNode, WrappedBundle> visited,
+			boolean ignoreExistingMetadata) throws Exception {
 		WrappedBundle wrappedNode = visited.get(node);
 		if (wrappedNode != null) {
 			return wrappedNode;
@@ -198,7 +202,7 @@ public class MavenBundleWrapper {
 									"Artifact " + node.getArtifact() + " can not be read as a jar file"))));
 			return wrappedNode;
 		}
-		if (isValidOSGi(jar.getManifest())) {
+		if (!ignoreExistingMetadata && isValidOSGi(jar.getManifest())) {
 			// already a bundle!
 			visited.put(node,
 					wrappedNode = new WrappedBundle(node, List.of(), null, originalFile.toPath(), jar, List.of()));
@@ -207,7 +211,7 @@ public class MavenBundleWrapper {
 		List<DependencyNode> children = node.getChildren();
 		List<WrappedBundle> depends = new ArrayList<>();
 		for (DependencyNode child : children) {
-			depends.add(getWrappedNode(child, instructionsLookup, visited));
+			depends.add(getWrappedNode(child, instructionsLookup, visited, false));
 		}
 		WrappedBundle wrappedNodeAfterVisit = visited.get(node);
 		if (wrappedNodeAfterVisit != null) {
@@ -392,4 +396,40 @@ public class MavenBundleWrapper {
 	public static boolean isValidSourceManifest(Manifest manifest) {
 		return manifest != null && manifest.getMainAttributes().getValue(ECLIPSE_SOURCE_BUNDLE_HEADER) != null;
 	}
+
+  /**
+   * Creates or returns a cached Eclipse source bundle from a source JAR file. The resulting bundle will have proper Eclipse-SourceBundle manifest
+   * headers. The cached file is stored alongside the original source file, named using the source bundle symbolic name and version (e.g.,
+   * {@code com.example.bundle.source_1.0.0.jar}) to support caching different wrappings of the same source file with different BSN/version
+   * combinations.
+   *
+   * @param sourceFile    the original source JAR file (e.g., xyz-source.jar)
+   * @param manifest      the manifest to use (will be modified with source bundle metadata)
+   * @param symbolicName  the bundle symbolic name of the host bundle
+   * @param bundleVersion the version of the host bundle
+   * @return the cached eclipse source bundle file
+   * @throws IOException if reading/writing files fails
+   */
+  public static File getEclipseSourceBundle(File sourceFile, Manifest manifest, String symbolicName, String bundleVersion) throws IOException {
+    // Create the cached file name based on the actual BSN and version to handle
+    // cases where the same source jar is wrapped with different BSN/version
+    String eclipseSourceName = getSourceBundleName(symbolicName) + "_" + bundleVersion + ".jar";
+    File eclipseSourceFile = new File(sourceFile.getParentFile(), eclipseSourceName);
+    Path eclipseSourcePath = eclipseSourceFile.toPath();
+    Path sourceFilePath = sourceFile.toPath();
+
+    // Check if cached file exists and is up-to-date
+    if (!isOutdated(eclipseSourcePath, sourceFilePath)) {
+      return eclipseSourceFile;
+    }
+
+    // Generate new eclipse source bundle
+    addSourceBundleMetadata(manifest, symbolicName, bundleVersion);
+    transferJarEntries(sourceFile, manifest, eclipseSourceFile);
+
+    // Set the last modified time to match source file for cache validation
+    Files.setLastModifiedTime(eclipseSourcePath, Files.getLastModifiedTime(sourceFilePath));
+
+    return eclipseSourceFile;
+  }
 }

--- a/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Integration UI
 Bundle-SymbolicName: org.eclipse.m2e.pde.ui;singleton:=true
-Bundle-Version: 2.1.100.qualifier
+Bundle-Version: 2.1.200.qualifier
 Export-Package: org.eclipse.m2e.pde.ui.target.editor;x-friends:="org.eclipse.m2e.swtbot.tests"
 Automatic-Module-Name: org.eclipse.m2e.pde.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationWizard.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/MavenTargetLocationWizard.java
@@ -69,6 +69,7 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 	private ITargetDefinition targetDefinition;
 	private BNDInstructions bndInstructions;
 	private Button includeSource;
+	private Button ignoreExistingMetadata;
 	private MavenTargetDependencyEditor dependencyEditor;
 	private List<MavenTargetRepository> repositoryList = new ArrayList<>();
 	private Button createFeature;
@@ -128,6 +129,8 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 				scopeLabel.setText(Messages.MavenTargetLocationWizard_10);
 				createScopes(composite);
 				includeSource = createCheckBox(composite, Messages.MavenTargetLocationWizard_8);
+				ignoreExistingMetadata = createCheckBox(composite, Messages.MavenTargetLocationWizard_24);
+				ignoreExistingMetadata.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> updateUI()));
 				createFeature = createCheckBox(composite, Messages.MavenTargetLocationWizard_13);
 				createFeature.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> updateUI()));
 				if (targetLocation != null) {
@@ -141,6 +144,7 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 					include.setSelection(new StructuredSelection(targetLocation.getDependencyDepth()));
 					bndInstructions = targetLocation.getInstructions(null);
 					includeSource.setSelection(targetLocation.isIncludeSource());
+					ignoreExistingMetadata.setSelection(targetLocation.isIgnoreExistingMetadata());
 					var template = targetLocation.getFeatureTemplate();
 					createFeature.setSelection(template != null);
 					locationLabel.setText(Objects.requireNonNullElse(targetLocation.getLabel(), ""));
@@ -230,8 +234,9 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 			}
 
 			private void updateUI() {
-				editInstructionsButton.setVisible(
-						metadata.getStructuredSelection().getFirstElement() == MissingMetadataMode.GENERATE);
+				editInstructionsButton
+						.setVisible(metadata.getStructuredSelection().getFirstElement() == MissingMetadataMode.GENERATE
+								|| ignoreExistingMetadata.getSelection());
 				if (include.getStructuredSelection().getFirstElement() == DependencyDepth.NONE) {
 					for (Button button : scopes) {
 						button.setEnabled(false);
@@ -348,7 +353,7 @@ public class MavenTargetLocationWizard extends Wizard implements ITargetLocation
 		DependencyDepth depth = (DependencyDepth) include.getStructuredSelection().getFirstElement();
 		MavenTargetLocation location = new MavenTargetLocation(locationLabel.getText(), dependencyEditor.getRoots(),
 				repositoryList, (MissingMetadataMode) metadata.getStructuredSelection().getFirstElement(), depth,
-				selectedScopes, includeSource.getSelection(), list, excludes, f);
+				selectedScopes, includeSource.getSelection(), ignoreExistingMetadata.getSelection(), list, excludes, f);
 		if (iscreate) {
 			targetLocation = location;
 		} else {

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/Messages.java
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/Messages.java
@@ -55,6 +55,7 @@ public class Messages extends NLS {
 	public static String MavenTargetLocationWizard_20;
 	public static String MavenTargetLocationWizard_21;
 	public static String MavenTargetLocationWizard_23;
+	public static String MavenTargetLocationWizard_24;
 	public static String MavenTargetLocationLabelProvider_1;
 	public static String MavenTargetLocationLabelProvider_2;
 	static {

--- a/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/messages.properties
+++ b/org.eclipse.m2e.pde.ui/src/org/eclipse/m2e/pde/ui/target/editor/messages.properties
@@ -33,6 +33,7 @@ MavenTargetLocationWizard_17=Dependencies depth
 MavenTargetLocationWizard_20=<a>Edit instructions</a>
 MavenTargetLocationWizard_21=Edit the default instructions used in case of necessary manifest generation
 MavenTargetLocationWizard_23=Enter the desired maven artifact to add to the target platform
+MavenTargetLocationWizard_24=Override existing OSGi-Manifest
 MavenTargetRepositoryEditor_1=New Repository...
 ClipboardParser_1=Clipboard content was ignored: {0}
 MavenTargetLocationLabelProvider_1={0}:{1} ({2})


### PR DESCRIPTION
**Problem**

Currently, the .target platform supports generating an OSGi manifest when a Maven artifact is missing one, using the option generate. However, there is no way to modify or regenerate an existing manifest for Maven-based libraries.

When migrating third-party libraries to Maven locations in .target files, many artifacts already include a manifest that does not meet our requirements (e.g., incomplete OSGi metadata). We need a mechanism to rewrite these manifests without manually editing the JARs.

**Proposed Solution**

Introduce a new option to rewrite a manifest file in the _Maven Artifact Target Entry Dialog_:

<img width="930" height="707" alt="image" src="https://github.com/user-attachments/assets/5572682b-d3d7-4274-877e-1496add234ce" />

The new option _generate_rewrite_ behaves like the current generate mode for missing manifests, but applies even when a manifest already exists. So, if _generate_rewrite_ is enabled, the manifest will be regenerated based on the same logic used for missing manifests. This allows consistent handling of Maven artifacts during migration without manual intervention.

**Benefits**

- Simplifies migration of third-party libraries to Maven-based .target definitions.
- Ensures uniform OSGi metadata across all artifacts.
- Reduces manual work and risk of errors when modifying manifests.

This Pull Request is related to [https://github.com/eclipse-pde/eclipse.pde/pull/2164](https://github.com/eclipse-pde/eclipse.pde/pull/2164)