### PR TITLE
[RelEng] Stop producing source features

### DIFF
--- a/m2e-parent/pom.xml
+++ b/m2e-parent/pom.xml
@@ -81,17 +81,6 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<excludes>
-								<plugin id="org.eclipse.m2e.workspace.cli" />
-							</excludes>
-						</configuration>
-					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/org.eclipse.m2e.sdk.feature/build.properties
+++ b/org.eclipse.m2e.sdk.feature/build.properties
@@ -12,3 +12,6 @@
 
 bin.includes = feature.xml,\
                feature.properties
+
+# Temporarily disable the baseline check to remove sources with only a minor bump
+pom.model.property.tycho.baseline.skip = true

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.10.101.qualifier"
+      version="2.11.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -24,15 +24,7 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.m2e.feature.source"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.m2e.lemminx.feature"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.m2e.lemminx.feature.source"
          version="0.0.0"/>
 
    <includes
@@ -40,23 +32,11 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.m2e.logback.feature.source"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.m2e.pde.feature"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.m2e.pde.feature.source"
          version="0.0.0"/>
 
    <plugin
          id="org.eclipse.m2e.tests.common"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.m2e.tests.common.source"
          version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
The automatic generation of source features is deprecated. And including all sources explicitly into the SDK prevents excluding specific problematic sources.

This is a reincarnation of
- https://github.com/eclipse-m2e/m2e-core/pull/2037