### PR TITLE
[RelEng] Exclude jansi's Mac jnilib files from maven.runtime source

### DIFF
--- a/org.eclipse.m2e.feature/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.feature/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Touch for https://github.com/eclipse-m2e/m2e-core/pull/1932
 Touch for https://github.com/eclipse-m2e/m2e-core/pull/1934
 Update build-qualifier because maven-runtime version update to Maven 3.9.12
+Update build-qualifier for removal of jansi's mac natives from maven.runtime sources

--- a/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/org.eclipse.m2e.maven.runtime/pom.xml
@@ -331,7 +331,7 @@
 						<configuration>
 							<outputDirectory>${outputDirectory.sources}</outputDirectory>
 							<classifier>sources</classifier>
-							<excludes>**/*.java</excludes>
+							<excludes>**/*.java,**/org/fusesource/jansi/internal/native/**/*.jnilib</excludes>
 							<useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
 						</configuration>
 					</execution>


### PR DESCRIPTION
The native jnilib files embedded into the jansi sources are not Mac-signed, which prevents Eclipse products containing the maven.runtime source from being signed for Mac.

As the native's are not really relevant for sources, they are simply excluded.

See 
- https://github.com/eclipse-packaging/packages/issues/406#issuecomment-3723835366