### PR TITLE
Fix README.md for m2e-apt activation mode

### DIFF
--- a/org.eclipse.m2e.apt.ui/README.md
+++ b/org.eclipse.m2e.apt.ui/README.md
@@ -12,7 +12,7 @@ You can change the workspace or project preferences to delegate annotation proce
 
 See this [blog post](https://community.jboss.org/en/tools/blog/2012/05/20/annotation-processing-support-in-m2e-or-m2e-apt-100-is-out) for more informations.
 
-Default m2e-apt activation mode (from workspace preferences) can be overridden by an `<m2e.apt.activation>` Maven property in a project's pom.xml `settings` section. Valid values are :
+Default m2e-apt activation mode (from workspace preferences) can be overridden by an `<m2e.apt.activation>` Maven property in a project's pom.xml `properties` section. Valid values are :
 
 * `disabled` : m2e-apt activation is disabled for this project
 * `jdt_apt` : enable m2e-apt on this project and delegate Annotation Processing to JDT APT


### PR DESCRIPTION
There's no `settings` section in the POM.
I guess you mean `properties` section.