### PR TITLE
Fix NPE when Model.getLocation() returns null

### DIFF
--- a/org.eclipse.m2e.core.tests/resources/projects/gitVersioningExtension/.mvn/extensions.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/gitVersioningExtension/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>me.qoomon</groupId>
+		<artifactId>maven-git-versioning-extension</artifactId>
+		<version>9.11.0</version>
+	</extension>
+</extensions>

--- a/org.eclipse.m2e.core.tests/resources/projects/gitVersioningExtension/.mvn/maven-git-versioning-extension.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/gitVersioningExtension/.mvn/maven-git-versioning-extension.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns="https://github.com/qoomon/maven-git-versioning-extension"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration.xsd">
+	<refs>
+		<ref type="branch">
+			<pattern>.*</pattern>
+			<version>${version}</version>
+		</ref>
+	</refs>
+</configuration>

--- a/org.eclipse.m2e.core.tests/resources/projects/gitVersioningExtension/pom.xml
+++ b/org.eclipse.m2e.core.tests/resources/projects/gitVersioningExtension/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>git-versioning-test</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+</project>

--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/ExtensionsTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -20,8 +21,10 @@ import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.embedder.IComponentLookup;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
@@ -102,6 +105,25 @@ public class ExtensionsTest extends AbstractMavenProjectTestCase {
 		IFile file = project.getFile("target/classes/file.txt");
 		assertTrue(file.exists());
 		assertEquals("foo-bar-content", new String(file.getContents().readAllBytes()));
+	}
+
+	@Test
+	public void testGitVersioningExtension() throws Exception {
+		// Pre-initialize git repo in workspace (required by the extension to activate)
+		File projectDir = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile(),
+				"gitVersioningExtension");
+		copyDir(new File("resources/projects/gitVersioningExtension"), projectDir);
+		assertEquals(0, new ProcessBuilder("git", "init").directory(projectDir).start().waitFor());
+		assertEquals(0, new ProcessBuilder("git", "add", ".").directory(projectDir).start().waitFor());
+		assertEquals(0,
+				new ProcessBuilder("git", "-c", "user.email=test@test.com", "-c", "user.name=Test", "commit", "-m",
+						"init").directory(projectDir).start().waitFor());
+		// Import project - the extension modifies the model, stripping InputLocation metadata
+		IProject project = importProject("resources/projects/gitVersioningExtension/pom.xml");
+		waitForJobsToComplete(new NullProgressMonitor());
+		// Without the fix, Model.getLocation("") returns null causing NPE in
+		// AnnotationMappingMetadataSource and SourceLocationHelper
+		assertNoErrors(project);
 	}
 
 	private IProject importPomlessProject(String rootProject, String... poms) throws IOException, CoreException {

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.7.700.qualifier
+Bundle-Version: 2.7.800.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/AnnotationMappingMetadataSource.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/lifecyclemapping/AnnotationMappingMetadataSource.java
@@ -79,7 +79,12 @@ public class AnnotationMappingMetadataSource implements MappingMetadataSource {
   private AnnotationMappingMetadataSource(MavenProject project, List<PI> pis) {
     this.project = project;
     this.pis = pis;
-    projectId = project.getModel().getLocation(SELF).getSource().getModelId();
+    InputLocation selfLocation = project.getModel().getLocation(SELF);
+    if(selfLocation != null && selfLocation.getSource() != null) {
+      projectId = selfLocation.getSource().getModelId();
+    } else {
+      projectId = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+    }
   }
 
   @Override
@@ -171,7 +176,14 @@ public class AnnotationMappingMetadataSource implements MappingMetadataSource {
   }
 
   private static List<PI> parsePIs(MavenProject project) {
-    InputSource source = project.getModel().getLocation(SELF).getSource();
+    InputLocation selfLocation = project.getModel().getLocation(SELF);
+    if(selfLocation == null) {
+      return List.of();
+    }
+    InputSource source = selfLocation.getSource();
+    if(source == null) {
+      return List.of();
+    }
     File pom = project.getFile();
     if((pom == null || !pom.isFile()) && source.getLocation() != null) {
       pom = new File(source.getLocation());

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/markers/SourceLocationHelper.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.IPath;
 
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.InputLocation;
+import org.apache.maven.model.InputLocationTracker;
 import org.apache.maven.model.InputSource;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
@@ -116,20 +117,14 @@ public class SourceLocationHelper {
       elementName = PLUGIN;
     }
 
-    File pomFile = mavenProject.getFile();
-    if(pomFile.getAbsolutePath().equals(inputLocation.getSource().getLocation())) {
+    if(isInCurrentPom(inputLocation, mavenProject.getFile())) {
       // Plugin/execution is specified in current pom
       return getSourceLocation(inputLocation, elementName);
     }
 
     // Plugin/execution is specified in some parent pom
     SourceLocation causeLocation = getSourceLocation(inputLocation, elementName);
-    inputLocation = mavenProject.getModel().getParent().getLocation(SELF);
-    if(inputLocation == null) {
-      // parent location cannot be determined for participant-added parents
-      return new SourceLocation(1, 1, 1, causeLocation);
-    }
-    return getSourceLocation(inputLocation, PARENT, causeLocation);
+    return resolveParentPomLocation(mavenProject, causeLocation);
   }
 
   private static InputLocation findExecutionLocation(Plugin plugin, String executionId) {
@@ -156,10 +151,10 @@ public class SourceLocationHelper {
         if(found != null) {
 
           // missing transitive managed dependency
-          String projectId = mavenProject.getModel().getLocation(SELF).getSource().getModelId();
-          String depId = found.getLocation(SELF).getSource().getModelId();
+          String projectId = getModelId(mavenProject.getModel());
+          String depId = getModelId(found);
 
-          if(!projectId.equals(depId)) {
+          if(depId != null && !Objects.equals(projectId, depId)) {
             // let's see if it comes from a directly imported pom
             DependencyManagement origMgmt = mavenProject.getOriginalModel().getDependencyManagement();
             org.apache.maven.model.Dependency importDep = findDependencyImport(origMgmt, depId);
@@ -224,34 +219,66 @@ public class SourceLocationHelper {
     if(inputLocation == null) {
       // Should never happen
       inputLocation = mavenProject.getModel().getLocation(SELF);
+      if(inputLocation == null) {
+        return new SourceLocation(1, 1, 1);
+      }
       return new SourceLocation(inputLocation.getLineNumber(), 1, inputLocation.getColumnNumber() - COLUMN_END_OFFSET);
     }
 
-    File pomFile = mavenProject.getFile();
-    if(pomFile.getAbsolutePath().equals(inputLocation.getSource().getLocation())) {
+    if(isInCurrentPom(inputLocation, mavenProject.getFile())) {
       // Dependency is specified in current pom
       return getSourceLocation(inputLocation, DEPENDENCY);
     }
 
-    // Plugin/execution is specified in some parent pom
+    // Dependency is specified in some parent pom
     SourceLocation causeLocation = getSourceLocation(inputLocation, DEPENDENCY);
-    inputLocation = mavenProject.getModel().getParent().getLocation(SELF);
-    return getSourceLocation(inputLocation, PARENT, causeLocation);
+    return resolveParentPomLocation(mavenProject, causeLocation);
   }
 
   private static SourceLocation getSourceLocation(InputLocation inputLocation, String elementName) {
+    if(inputLocation == null) {
+      return new SourceLocation(1, 1, 1);
+    }
     InputSource source = inputLocation.getSource();
     return new SourceLocation( //
         source != null ? source.getLocation() : null, source != null ? source.getModelId() : null,
-        inputLocation.getLineNumber(), //  
+        inputLocation.getLineNumber(), //
         inputLocation.getColumnNumber() - elementName.length() - COLUMN_START_OFFSET,
         inputLocation.getColumnNumber() - COLUMN_END_OFFSET);
   }
 
   private static SourceLocation getSourceLocation(InputLocation inputLocation, String elementName,
       SourceLocation causeLocation) {
+    if(inputLocation == null) {
+      return new SourceLocation(1, 1, 1, causeLocation);
+    }
     return new SourceLocation(inputLocation.getLineNumber(),
         inputLocation.getColumnNumber() - elementName.length() - COLUMN_START_OFFSET,
         inputLocation.getColumnNumber() - COLUMN_END_OFFSET, causeLocation);
+  }
+
+  private static boolean isInCurrentPom(InputLocation inputLocation, File pomFile) {
+    InputSource source = inputLocation.getSource();
+    return source != null && pomFile.getAbsolutePath().equals(source.getLocation());
+  }
+
+  private static SourceLocation resolveParentPomLocation(MavenProject mavenProject, SourceLocation causeLocation) {
+    if(mavenProject.getModel().getParent() == null) {
+      return new SourceLocation(1, 1, 1, causeLocation);
+    }
+    // parent location cannot be determined for participant-added parents
+    InputLocation parentLocation = mavenProject.getModel().getParent().getLocation(SELF);
+    return getSourceLocation(parentLocation, PARENT, causeLocation);
+  }
+
+  private static String getModelId(InputLocationTracker tracker) {
+    if(tracker == null) {
+      return null;
+    }
+    InputLocation location = tracker.getLocation(SELF);
+    if(location == null || location.getSource() == null) {
+      return null;
+    }
+    return location.getSource().getModelId();
   }
 }


### PR DESCRIPTION
## Summary

Maven core extensions such as `maven-git-versioning-extension` modify the Maven model at runtime without preserving `InputLocation` metadata. This causes `Model.getLocation("")` to return `null`, leading to `NullPointerException` during project import and update.

**Stack trace:**
```
java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.InputLocation.getSource()"
  because the return value of "org.apache.maven.model.Model.getLocation(Object)" is null
    at o.e.m2e.core.internal.lifecyclemapping.AnnotationMappingMetadataSource.parsePIs(AnnotationMappingMetadataSource.java:174)
```
```
java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.InputLocation.getSource()"
  because "inputLocation" is null
    at o.e.m2e.core.internal.markers.SourceLocationHelper.getSourceLocation(SourceLocationHelper.java:243)
```

## Changes

- `AnnotationMappingMetadataSource`: add null checks in constructor and `parsePIs()` for `Model.getLocation()` and `InputLocation.getSource()`
- `SourceLocationHelper`: add null checks in `getSourceLocation()`, `findLocation()` and `getMavenDependency()` for all `getLocation(SELF)` dereferences

## Reproducer

Use any Maven core extension declared in `.mvn/extensions.xml` (e.g. `maven-git-versioning-extension`) and try to import or update a Maven project in Eclipse.

Fixes #1310