### PR TITLE
Remove workaround to access lemminx.uber-jar in m2e.editor.lemminx.bnd

### DIFF
--- a/org.eclipse.m2e.editor.lemminx.bnd/.classpath
+++ b/org.eclipse.m2e.editor.lemminx.bnd/.classpath
@@ -3,7 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<!--  workaround for https://github.com/eclipse-pde/eclipse.pde/pull/1603 -->
-	<classpathentry kind="var" path="M2_REPO/org/eclipse/lemminx/org.eclipse.lemminx/0.29.0/org.eclipse.lemminx-0.29.0-uber.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
The required fix is now available and the directly referenced jar is not in the target-platform anymore, and can lead to classpath errors.

Follow-up on:
- https://github.com/eclipse-m2e/m2e-core/pull/1888