### PR TITLE
Skip unsafe ancestor Maven resource folders

### DIFF
--- a/org.eclipse.m2e.jdt.tests/projects/ancestor-resource-with-sibling/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/ancestor-resource-with-sibling/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>foo.bar</groupId>
+  <artifactId>ancestor-resource-with-sibling</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <build>
+    <resources>
+      <resource>
+        <directory>..</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
+</project>

--- a/org.eclipse.m2e.jdt.tests/projects/ancestor-resource-with-sibling/src/main/resources/app.properties
+++ b/org.eclipse.m2e.jdt.tests/projects/ancestor-resource-with-sibling/src/main/resources/app.properties
@@ -1,0 +1,1 @@
+name=ancestor-resource-with-sibling

--- a/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationTest.java
+++ b/org.eclipse.m2e.jdt.tests/src/org/eclipse/m2e/jdt/tests/JavaConfigurationTest.java
@@ -163,6 +163,15 @@ public class JavaConfigurationTest extends AbstractMavenProjectTestCase {
 	}
 
 	@Test
+	public void testAncestorResourceDoesNotSkipLaterResources() throws CoreException, IOException, InterruptedException {
+		IJavaProject project = importResourceProject("/projects/ancestor-resource-with-sibling/pom.xml");
+		List<String> srcEntryPaths = Arrays.stream(project.getRawClasspath())
+				.filter(cp -> IClasspathEntry.CPE_SOURCE == cp.getEntryKind()).filter(cp -> !cp.isTest())
+				.map(IClasspathEntry::getPath).map(IPath::toString).toList();
+		assertTrue(srcEntryPaths.contains("/ancestor-resource-with-sibling/src/main/resources"));
+	}
+
+	@Test
 	public void testAddSourceResource() throws CoreException, IOException, InterruptedException {
 		File baseDir = new File(FileLocator
 				.toFileURL(JavaConfigurationTest.class.getResource("/projects/add-source-resource/submoduleA/pom.xml"))

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.5.100.qualifier
+Bundle-Version: 2.5.200.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.5.200.qualifier
+Bundle-Version: 2.5.100.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -1003,7 +1003,14 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     }
     if(!project.exists(relativePath) && Files.exists(folderPath)
         && !ResourcesPlugin.getWorkspace().getRoot().getLocation().toPath().equals(folderPath)) {
-      String linkName = projectLocation.relativize(folderPath).toString().replace("/", "_");
+      Path relativized = projectLocation.relativize(folderPath);
+      if(relativized.startsWith("..")) {
+        // Resource directory is outside (ancestor or sibling of) the project.
+        // Cannot create a valid linked folder for paths that escape the project tree.
+        // Return the project itself so the caller skips this resource directory.
+        return project;
+      }
+      String linkName = relativized.toString().replace("/", "_");
       IFolder folder = project.getFolder(linkName);
       createLinkWithRetry(folder, folderPath.toUri());
       folder.setPersistentProperty(LINKED_MAVEN_RESOURCE, "true");

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -636,6 +636,12 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
       } catch(IOException ex) {
         resourceDirectory = new File(directory).getAbsoluteFile();
       }
+      Path projectLocation = project.getLocation().toPath().toAbsolutePath().normalize();
+      Path resourcePath = resourceDirectory.toPath().toAbsolutePath().normalize();
+      if(projectLocation.startsWith(resourcePath) && !projectLocation.equals(resourcePath)) {
+        log.error("Skipping resource folder " + resourceDirectory);
+        continue;
+      }
       IContainer r = getFolder(project, resourceDirectory.getPath());
       if(r == project) {
         /*
@@ -990,7 +996,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
   }
 
   protected IContainer getFolder(IProject project, String path) throws CoreException {
-    Path projectLocation = project.getLocation().toPath().toAbsolutePath();
+    Path projectLocation = project.getLocation().toPath().toAbsolutePath().normalize();
     Path folderPath = Path.of(path).normalize();
     if(projectLocation.equals(folderPath)) {
       return project;
@@ -999,13 +1005,14 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     if(folderPath.isAbsolute()) {
       relativePath = getProjectRelativePath(project, folderPath);
     } else {
-      folderPath = projectLocation.resolve(path);
+      folderPath = projectLocation.resolve(path).normalize();
       relativePath = IPath.fromOSString(path);
     }
     IFolder folder = project.getFolder(relativePath);
     if((!project.exists(relativePath) || !folder.getProject().equals(project)) && Files.exists(folderPath)
         && !ResourcesPlugin.getWorkspace().getRoot().getLocation().toPath().equals(folderPath)) {
-      String linkName = projectLocation.relativize(folderPath).toString().replace("/", "_");
+      Path relativized = projectLocation.relativize(folderPath);
+      String linkName = relativized.toString().replace("\\", "_").replace("/", "_");
       folder = project.getFolder(linkName);
       createLinkWithRetry(folder, folderPath.toUri());
       folder.setPersistentProperty(LINKED_MAVEN_RESOURCE, "true");


### PR DESCRIPTION
## Summary

This changes the fix for ancestor Maven resource directories to be resource-specific instead of changing the shared folder resolution path.

When a Maven resource directory resolves to a strict ancestor of the imported Eclipse project, m2e now skips that resource entry because it cannot be represented safely as a project folder or linked resource. The configurator then continues processing the remaining resources so a later valid resource folder is still added to the classpath.

## Details

- Skip only resource directories where the project location is inside the resource directory, but not equal to it.
- Keep `getFolder(...)` behavior unchanged for normal source, output, generated source, and external sibling folder cases.
- Continue after skipping the unsafe ancestor resource instead of returning from all resource processing.
- Add a regression project with `<directory>..</directory>` followed by `src/main/resources` to verify import succeeds and the valid resource remains configured.