### PR TITLE
If no default execution is found, use the first other instead

### DIFF
--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.7.700.qualifier
+Bundle-Version: 2.7.800.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/MavenImpl.java
@@ -83,7 +83,6 @@ import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.scope.internal.MojoExecutionScope;
 import org.apache.maven.lifecycle.LifecycleExecutor;
-import org.apache.maven.session.scope.internal.SessionScope;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.lifecycle.internal.LifecycleExecutionPlanCalculator;
 import org.apache.maven.model.ConfigurationContainer;
@@ -120,6 +119,7 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.project.ProjectSorter;
 import org.apache.maven.repository.RepositorySystem;
+import org.apache.maven.session.scope.internal.SessionScope;
 import org.apache.maven.settings.Mirror;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
@@ -705,6 +705,9 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
 
   private <T> T getMojoParameterValue(MavenSession session, MojoExecution mojoExecution, List<String> parameterPath,
       Class<T> asType) throws CoreException {
+    if(mojoExecution == null) {
+      return null;
+    }
     Xpp3Dom dom = mojoExecution.getConfiguration();
     if(dom == null) {
       return null;
@@ -742,6 +745,9 @@ public class MavenImpl implements IMaven, IMavenConfigurationChangeListener {
   @Override
   public <T> T getMojoParameterValue(MavenProject project, MojoExecution mojoExecution, String parameter,
       Class<T> asType, IProgressMonitor monitor) throws CoreException {
+    if(mojoExecution == null) {
+      return null;
+    }
     return getExecutionContext().execute(project,
         (context, pm) -> getMojoParameterValue(context.getSession(), mojoExecution, List.of(parameter), asType),
         monitor);

--- a/org.eclipse.m2e.jdt.tests/projects/nonedefaultcompile/app/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/nonedefaultcompile/app/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>parentproject</artifactId>
+    <groupId>com.example</groupId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>app</artifactId>
+  <name>app</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/org.eclipse.m2e.jdt.tests/projects/nonedefaultcompile/core/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/nonedefaultcompile/core/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>parentproject</artifactId>
+    <groupId>com.example</groupId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>core</artifactId>
+
+  <name>core</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <sources>
+                                <source>
+                                    ${project.basedir}/../app/src/main/java
+                                </source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <annotationProcessorPaths></annotationProcessorPaths>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/org.eclipse.m2e.jdt.tests/projects/nonedefaultcompile/pom.xml
+++ b/org.eclipse.m2e.jdt.tests/projects/nonedefaultcompile/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parentproject</artifactId>
+  <version>1.0</version>
+  <name>parentproject</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+  <packaging>pom</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <modules>
+    <module>core</module>
+    <module>app</module>
+  </modules>
+
+</project>

--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.5.100.qualifier
+Bundle-Version: 2.5.200.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -724,34 +724,18 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
 
   protected void addJavaProjectOptions(Map<String, String> options, ProjectConfigurationRequest request,
       IProgressMonitor monitor) throws CoreException {
-    String source = null, target = null;
+    MojoExecution execution = getDefaultCompileExecution(getCompilerMojoExecutions(request, monitor));
+    String release = getCompilerLevel(request.mavenProject(), execution, "release", null, RELEASES, monitor);
+    //XXX ignoring testRelease option, since JDT doesn't support main/test classpath separation - yet
+    String source = getCompilerLevel(request.mavenProject(), execution, "source", null, SOURCES, monitor); //$NON-NLS-1$
+    String target = getCompilerLevel(request.mavenProject(), execution, "target", null, TARGETS, monitor); //$NON-NLS-1$
+    boolean generateParameters = isGenerateParameters(request.mavenProject(), execution, monitor);
+    boolean enablePreviewFeatures = isEnablePreviewFeatures(request.mavenProject(), execution, monitor);
 
-    //New release flag in JDK 9. See http://mail.openjdk.java.net/pipermail/jdk9-dev/2015-July/002414.html
-    String release = null;
-
-    boolean generateParameters = false;
-
-    boolean enablePreviewFeatures = false;
-
-    boolean hasDefaultCompile = getCompilerMojoExecutions(request, monitor).stream()
-        .filter(e -> "default-compile".equals(e.getExecutionId())).findAny().isPresent();
-    for(MojoExecution execution : getCompilerMojoExecutions(request, monitor)) {
-      String id = execution.getExecutionId();
-      if(hasDefaultCompile && !"default-compile".equals(id)) {
-        //Maven can have many but JDT only supports one config!
-        continue;
-      }
-      release = getCompilerLevel(request.mavenProject(), execution, "release", release, RELEASES, monitor);
-      //XXX ignoring testRelease option, since JDT doesn't support main/test classpath separation - yet
-      source = getCompilerLevel(request.mavenProject(), execution, "source", source, SOURCES, monitor); //$NON-NLS-1$
-      target = getCompilerLevel(request.mavenProject(), execution, "target", target, TARGETS, monitor); //$NON-NLS-1$
-      generateParameters = generateParameters || isGenerateParameters(request.mavenProject(), execution, monitor);
-      enablePreviewFeatures = enablePreviewFeatures
-          || isEnablePreviewFeatures(request.mavenProject(), execution, monitor);
-
-      // process -err:+deprecation , -warn:-serial ...
-      for(Object o : maven.getMojoParameterValue(request.mavenProject(), execution, "compilerArgs", List.class,
-          monitor)) {
+    // process -err:+deprecation , -warn:-serial ...
+    List<?> value = maven.getMojoParameterValue(request.mavenProject(), execution, "compilerArgs", List.class, monitor);
+    if(value != null) {
+      for(Object o : value) {
         if(o instanceof String compilerArg) {
           boolean err = false/*, warn = false*/;
           String[] settings = new String[0];
@@ -817,6 +801,21 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
       options.put(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
     }
 
+  }
+
+  private MojoExecution getDefaultCompileExecution(List<MojoExecution> executions) {
+    if(executions.isEmpty()) {
+      return null;
+    }
+    for(MojoExecution execution : executions) {
+      String id = execution.getExecutionId();
+      if("default-compile".equals(id)) {
+        //Maven can have many but JDT only supports one config so we prefer the default one
+        return execution;
+      }
+    }
+    //If no default is found
+    return executions.get(0);
   }
 
   /**


### PR DESCRIPTION
Currently if the default maven execution is disabled the JDT
configurator currently fall back to the defaults instead of configuring
the project correctly.

This now makes sure that if there is an execution it is used.

Fix https://github.com/eclipse-m2e/m2e-core/issues/2113
Fix https://github.com/eclipse-m2e/m2e-core/issues/2162
Closes https://github.com/eclipse-m2e/m2e-core/pull/2114