### PR TITLE
Drop unused IWorkspace @Reference from PlexusContainerManager

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.AbstractModule;
 
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
@@ -88,9 +87,6 @@ public class PlexusContainerManager {
 
   @Reference
   private IMavenConfiguration mavenConfiguration;
-
-  @Reference
-  private IWorkspace workspace;
 
   @Deactivate
   void dispose() {


### PR DESCRIPTION
The IWorkspace field on PlexusContainerManager was added in aecf30541 (Jun 2022) when the multi-module-root lookup was implemented inline in this class. That logic was later moved to
MavenProperties.computeMultiModuleProjectDirectory(File), which calls ResourcesPlugin.getWorkspace() statically and lazily. Since then the field has had no readers — its only effect is to make SCR delay the activation of PlexusContainerManager (and transitively MavenImpl / IMaven) until the IWorkspace service from org.eclipse.core.resources is registered.

On a cold OSGi cache (e.g. first launch after an upgrade) the resources bundle / IWorkspace DS publication races with early callers of MavenPlugin.getMaven(), causing the IMaven ServiceTracker to return null and producing NPEs in embedders that touch m2e during their own initialization, e.g.

  Cannot invoke "org.eclipse.m2e.core.embedder.IMaven.getSettings()"
  because the return value of "org.eclipse.m2e.core.MavenPlugin.getMaven()"
  is null

Reported downstream as redhat-developer/vscode-java#3469 and matching the pattern described in #966. Removing the unused @Reference takes org.eclipse.core.resources off the IMaven activation critical path; the remaining static use of ResourcesPlugin.getWorkspace() in MavenProperties.computeMultiModuleProjectDirectory(File) is invoked lazily on actual project lookups, by which point the workspace is always available.

relateive issue 
- https://github.com/redhat-developer/vscode-java/issues/3469
- https://github.com/microsoft/vscode-java-pack/issues/1613