### PR TITLE
Support Maven <exclusions> syntax within target <dependency> elements

### DIFF
--- a/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/DependencyExclusionTest.java
+++ b/org.eclipse.m2e.pde.target.tests/src/org/eclipse/m2e/pde/target/tests/DependencyExclusionTest.java
@@ -153,6 +153,74 @@ public class DependencyExclusionTest extends AbstractMavenTargetTest {
 		assertTargetBundles(target, includeSource ? withSourceBundles(expectedBundles) : expectedBundles);
 	}
 
+	@Test
+	public void testMavenExclusionSyntaxOnDependency() throws Exception {
+		ITargetLocation target = resolveMavenTarget(String.format(
+				"""
+						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
+							<dependencies>
+								<dependency>
+									<groupId>org.junit.platform</groupId>
+									<artifactId>junit-platform-commons</artifactId>
+									<version>1.9.3</version>
+									<type>jar</type>
+									<exclusions>
+										<exclusion>
+											<groupId>org.apiguardian</groupId>
+											<artifactId>apiguardian-api</artifactId>
+										</exclusion>
+									</exclusions>
+								</dependency>
+							</dependencies>
+						</location>
+						""",
+				includeSource));
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
+		List<ExpectedBundle> expectedBundles = List.of(junitPlatformCommons("1.9.3"));
+		assertTargetBundles(target, includeSource ? withSourceBundles(expectedBundles) : expectedBundles);
+	}
+
+	@Test
+	public void testMavenExclusionOnOneDependencyExcludesGlobally() throws Exception {
+		// Per-dependency <exclusion> feeds into the same excludedArtifacts set as the
+		// location-level <exclude>, so once an artifact is excluded it is excluded from
+		// the whole target location even if another root dependency would bring it in.
+		ITargetLocation target = resolveMavenTarget(String.format(
+				"""
+						<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="%s" missingManifest="error" type="Maven">
+							<dependencies>
+								<dependency>
+									<groupId>org.junit.jupiter</groupId>
+									<artifactId>junit-jupiter-api</artifactId>
+									<version>5.9.3</version>
+									<type>jar</type>
+									<exclusions>
+										<exclusion>
+											<groupId>org.apiguardian</groupId>
+											<artifactId>apiguardian-api</artifactId>
+										</exclusion>
+									</exclusions>
+								</dependency>
+								<dependency>
+									<groupId>org.junit.platform</groupId>
+									<artifactId>junit-platform-commons</artifactId>
+									<version>1.9.3</version>
+									<type>jar</type>
+								</dependency>
+							</dependencies>
+						</location>
+						""",
+				includeSource));
+		assertStatusOk(target.getStatus());
+		assertArrayEquals(EMPTY, target.getFeatures());
+		List<ExpectedBundle> expectedBundles = List.of(//
+				junitJupiterAPI(), //
+				junitPlatformCommons("1.9.3"), //
+				opentest4j());
+		assertTargetBundles(target, includeSource ? withSourceBundles(expectedBundles) : expectedBundles);
+	}
+
 	private static ExpectedBundle junitPlatformCommons(String version) {
 		return originalOSGiBundle("junit-platform-commons", version, "org.junit.platform:junit-platform-commons");
 	}

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetDependency.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetDependency.java
@@ -12,10 +12,12 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.target;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
 import org.eclipse.aether.graph.DependencyNode;
 
 public final class MavenTargetDependency extends Dependency {
@@ -66,7 +68,13 @@ public final class MavenTargetDependency extends Dependency {
 	}
 
 	public MavenTargetDependency copy() {
-		return new MavenTargetDependency(getGroupId(), getArtifactId(), getVersion(), getType(), getClassifier());
+		MavenTargetDependency copy = new MavenTargetDependency(getGroupId(), getArtifactId(), getVersion(), getType(),
+				getClassifier());
+		List<Exclusion> exclusions = getExclusions();
+		if (!exclusions.isEmpty()) {
+			copy.setExclusions(new ArrayList<>(exclusions));
+		}
+		return copy;
 	}
 
 	public boolean matches(Dependency other) {

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocation.java
@@ -97,6 +97,8 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 	public static final String ELEMENT_GROUP_ID = "groupId";
 	public static final String ELEMENT_INSTRUCTIONS = "instructions";
 	public static final String ELEMENT_EXCLUDED = "exclude";
+	public static final String ELEMENT_EXCLUSIONS = "exclusions";
+	public static final String ELEMENT_EXCLUSION = "exclusion";
 	public static final String ELEMENT_DEPENDENCY = "dependency";
 	public static final String ELEMENT_DEPENDENCIES = "dependencies";
 	public static final String ELEMENT_REPOSITORY = "repository";
@@ -272,10 +274,14 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 				}
 				List<RepositoryArtifact> artifacts = dependecies.artifacts();
 				split.setWorkRemaining(artifacts.size());
+				List<org.apache.maven.model.Exclusion> depExclusions = root.getExclusions();
 				for (RepositoryArtifact a : artifacts) {
 					if (a.artifact().getFile() == null) {
 						// this is a filtered dependency
 						continue;
+					}
+					if (matchesExclusion(a.artifact(), depExclusions)) {
+						setExcluded(a.artifact(), true);
 					}
 					addBundleForArtifact(a.artifact(), cacheManager, maven, targetBundles, split.split(1));
 				}
@@ -525,6 +531,26 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 		return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getBaseVersion();
 	}
 
+	private static boolean matchesExclusion(Artifact artifact,
+			List<org.apache.maven.model.Exclusion> exclusions) {
+		if (exclusions.isEmpty()) {
+			return false;
+		}
+		String groupId = artifact.getGroupId();
+		String artifactId = artifact.getArtifactId();
+		for (org.apache.maven.model.Exclusion exclusion : exclusions) {
+			if (matchesPattern(exclusion.getGroupId(), groupId)
+					&& matchesPattern(exclusion.getArtifactId(), artifactId)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean matchesPattern(String pattern, String value) {
+		return "*".equals(pattern) || pattern.equals(value);
+	}
+
 	List<DependencyNode> getDependencyNodes(MavenTargetDependency dependency) {
 		TargetBundles bundles = targetBundles;
 		if (bundles == null) {
@@ -600,6 +626,17 @@ public class MavenTargetLocation extends AbstractBundleContainer {
 				element(xml, ELEMENT_VERSION, dependency.getVersion());
 				element(xml, ELEMENT_TYPE, dependency.getType());
 				element(xml, ELEMENT_CLASSIFIER, dependency.getClassifier());
+				List<org.apache.maven.model.Exclusion> depExclusions = dependency.getExclusions();
+				if (!depExclusions.isEmpty()) {
+					xml.append("<" + ELEMENT_EXCLUSIONS + ">");
+					depExclusions.forEach(ex -> {
+						xml.append("<" + ELEMENT_EXCLUSION + ">");
+						element(xml, ELEMENT_GROUP_ID, ex.getGroupId());
+						element(xml, ELEMENT_ARTIFACT_ID, ex.getArtifactId());
+						xml.append("</" + ELEMENT_EXCLUSION + ">");
+					});
+					xml.append("</" + ELEMENT_EXCLUSIONS + ">");
+				}
 				xml.append("</" + ELEMENT_DEPENDENCY + ">");
 			});
 			xml.append("</" + ELEMENT_DEPENDENCIES + ">");

--- a/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocationFactory.java
+++ b/org.eclipse.m2e.pde.target/src/org/eclipse/m2e/pde/target/MavenTargetLocationFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.m2e.pde.target;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -130,7 +131,19 @@ public class MavenTargetLocationFactory implements ITargetLocationFactory {
 		String version = getText(MavenTargetLocation.ELEMENT_VERSION, element);
 		String artifactType = getText(MavenTargetLocation.ELEMENT_TYPE, element);
 		String classifier = getText(MavenTargetLocation.ELEMENT_CLASSIFIER, element);
-		return new MavenTargetDependency(groupId, artifactId, version, artifactType, classifier);
+		MavenTargetDependency dependency = new MavenTargetDependency(groupId, artifactId, version, artifactType,
+				classifier);
+		List<org.apache.maven.model.Exclusion> exclusions = descendants(element,
+				MavenTargetLocation.ELEMENT_EXCLUSION).map(exclusionElement -> {
+					org.apache.maven.model.Exclusion exclusion = new org.apache.maven.model.Exclusion();
+					exclusion.setGroupId(getText(MavenTargetLocation.ELEMENT_GROUP_ID, exclusionElement));
+					exclusion.setArtifactId(getText(MavenTargetLocation.ELEMENT_ARTIFACT_ID, exclusionElement));
+					return exclusion;
+				}).toList();
+		if (!exclusions.isEmpty()) {
+			dependency.setExclusions(new ArrayList<>(exclusions));
+		}
+		return dependency;
 	}
 
 	private static String getText(String tagName, Element location) {


### PR DESCRIPTION
Closes #286

The m2-pde target location now accepts the standard Maven `<exclusions>/<exclusion>` syntax inside each `<dependency>` element, in addition to the existing location-level `<exclude>` elements.

```xml
<dependency>
    <groupId>org.junit.jupiter</groupId>
    <artifactId>junit-jupiter-api</artifactId>
    <version>5.9.3</version>
    <exclusions>
        <exclusion>
            <groupId>org.apiguardian</groupId>
            <artifactId>apiguardian-api</artifactId>
        </exclusion>
    </exclusions>
</dependency>
```

Exclusions are per-dependency (not global) and are applied during transitive dependency collection via `MavenDependencyCollector`, consistent with standard Maven semantics. The `*` wildcard is supported for groupId and artifactId. The format round-trips correctly through `serialize()`/parse.