### PR TITLE
Set compiler.problem.forbiddenReference to error by default

### DIFF
--- a/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.jdt;singleton:=true
-Bundle-Version: 2.5.200.qualifier
+Bundle-Version: 2.5.300.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.m2e.jdt,
  org.eclipse.m2e.jdt.internal;x-friends:="org.eclipse.m2e.jdt.ui",

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -798,7 +798,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     // 360962 keep forbidden_reference severity set by the user
     IJavaProject jp = JavaCore.create(request.mavenProjectFacade().getProject());
     if(jp != null && jp.getOption(JavaCore.COMPILER_PB_FORBIDDEN_REFERENCE, false) == null) {
-      options.put(JavaCore.COMPILER_PB_FORBIDDEN_REFERENCE, JavaCore.WARNING);
+      options.put(JavaCore.COMPILER_PB_FORBIDDEN_REFERENCE, JavaCore.ERROR);
     }
     options.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES,
         enablePreviewFeatures ? JavaCore.ENABLED : JavaCore.DISABLED);


### PR DESCRIPTION
When configuring the JDT preferences for a Maven project, set the preference `compiler.problem.forbiddenReference` to `ERROR` by default (users can still overwrite it explicitly).

PDE now strongly discourages (and warns about) other values than `ERROR` and it's generally better to strictly consider JDT access rules by default. The former currently leads to test failures since
- https://github.com/eclipse-m2e/m2e-core/pull/2197

Alternatively the entire if-block could be removed and the default of `compiler.problem.forbiddenReference`, which is `ERROR` could be used.