### PR TITLE
Update jcl-over-slf4j embedded in Maven runtime to 2.0

### DIFF
--- a/org.eclipse.m2e.maven.runtime/pom.xml
+++ b/org.eclipse.m2e.maven.runtime/pom.xml
@@ -140,8 +140,13 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.16</version>
+			<version>2.0.18</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<version>2.0.18</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.annotation</groupId>


### PR DESCRIPTION
The embedded jcl-over-slf4j must be compatible with the used slf4j-api.

When updating to SLF4J-2 this update was forgotten:
- https://github.com/eclipse-m2e/m2e-core/pull/1378

Fixes https://github.com/eclipse-m2e/m2e-core/issues/2203

@haubi do you have any chance to test/verify this on your side?