### PR TITLE
Prevent deadlock during Plexus container creation

### DIFF
--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManagerTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManagerTest.java
@@ -1,0 +1,309 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Tyce Herrman and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal.embedder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.io.FileUtils;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.classworlds.ClassWorld;
+
+import org.eclipse.m2e.core.embedder.IComponentLookup;
+import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+
+import org.junit.Test;
+
+
+@SuppressWarnings("restriction")
+public class PlexusContainerManagerTest extends AbstractMavenProjectTestCase {
+
+  private static final long TIMEOUT_SECONDS = 10;
+
+  @Test
+  public void rootedCreationDoesNotBlockNonRootedCreation() throws Exception {
+    File rootA = createMavenRoot("root-a");
+    File rootB = createMavenRoot("root-b");
+    File canonicalRootA = rootA.getCanonicalFile();
+    File canonicalRootB = rootB.getCanonicalFile();
+    TestContainer containerA = new TestContainer(canonicalRootA);
+    TestContainer containerB = new TestContainer(canonicalRootB);
+    TestContainer nonRootedContainer = new TestContainer(null);
+    CountDownLatch creationStarted = new CountDownLatch(1);
+    CountDownLatch releaseCreation = new CountDownLatch(1);
+    PlexusContainerManager manager = new PlexusContainerManager((directory, logger, configuration) -> {
+      if(canonicalRootA.equals(directory)) {
+        creationStarted.countDown();
+        await(releaseCreation);
+        return containerA;
+      }
+      if(canonicalRootB.equals(directory)) {
+        return containerB;
+      }
+      if(directory == null) {
+        return nonRootedContainer;
+      }
+      throw new AssertionError("Unexpected root " + directory);
+    });
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    try {
+      Future<IMavenPlexusContainer> rootACreation = executor.submit(() -> manager.aquire(rootA));
+      await(creationStarted);
+
+      Future<IMavenPlexusContainer> nonRootedCreation = executor.submit(() -> manager.aquire());
+      Future<IMavenPlexusContainer> rootBCreation = executor.submit(() -> manager.aquire(rootB));
+
+      assertSame(nonRootedContainer, nonRootedCreation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      assertSame(containerB, rootBCreation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      assertFalse(rootACreation.isDone());
+
+      releaseCreation.countDown();
+      assertSame(containerA, rootACreation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    } finally {
+      releaseCreation.countDown();
+      shutdown(executor);
+      manager.dispose();
+      FileUtils.deleteDirectory(rootA);
+      FileUtils.deleteDirectory(rootB);
+    }
+  }
+
+  @Test
+  public void concurrentAcquisitionForSameRootCreatesOneContainer() throws Exception {
+    File root = createMavenRoot("same-root");
+    File canonicalRoot = root.getCanonicalFile();
+    TestContainer container = new TestContainer(canonicalRoot);
+    AtomicInteger factoryInvocations = new AtomicInteger();
+    CountDownLatch creationStarted = new CountDownLatch(1);
+    CountDownLatch releaseCreation = new CountDownLatch(1);
+    CountDownLatch callersReady = new CountDownLatch(2);
+    CountDownLatch startCallers = new CountDownLatch(1);
+    PlexusContainerManager manager = new PlexusContainerManager((directory, logger, configuration) -> {
+      assertEquals(canonicalRoot, directory);
+      factoryInvocations.incrementAndGet();
+      creationStarted.countDown();
+      await(releaseCreation);
+      return container;
+    });
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<IMavenPlexusContainer> first = executor.submit(() -> {
+        callersReady.countDown();
+        await(startCallers);
+        return manager.aquire(root);
+      });
+      Future<IMavenPlexusContainer> second = executor.submit(() -> {
+        callersReady.countDown();
+        await(startCallers);
+        return manager.aquire(root);
+      });
+      await(callersReady);
+      startCallers.countDown();
+      await(creationStarted);
+
+      releaseCreation.countDown();
+      assertSame(container, first.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      assertSame(container, second.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      assertEquals(1, factoryInvocations.get());
+    } finally {
+      startCallers.countDown();
+      releaseCreation.countDown();
+      shutdown(executor);
+      manager.dispose();
+      FileUtils.deleteDirectory(root);
+    }
+  }
+
+  @Test
+  public void failedCreationCanBeRetried() throws Exception {
+    File root = createMavenRoot("retry");
+    Exception failure = new Exception("Expected creation failure");
+    TestContainer container = new TestContainer(root.getCanonicalFile());
+    AtomicInteger factoryInvocations = new AtomicInteger();
+    PlexusContainerManager manager = new PlexusContainerManager((directory, logger, configuration) -> {
+      if(factoryInvocations.getAndIncrement() == 0) {
+        throw failure;
+      }
+      return container;
+    });
+    try {
+      try {
+        manager.aquire(root);
+        fail("Expected container creation to fail");
+      } catch(Exception e) {
+        assertSame(failure, e);
+      }
+
+      assertSame(container, manager.aquire(root));
+      assertEquals(2, factoryInvocations.get());
+    } finally {
+      manager.dispose();
+      FileUtils.deleteDirectory(root);
+    }
+  }
+
+  @Test
+  public void cleanupDisposesStaleContainerOnce() throws Exception {
+    File root = createMavenRoot("cleanup");
+    TestContainer first = new TestContainer(root.getCanonicalFile());
+    TestContainer second = new TestContainer(root.getCanonicalFile());
+    AtomicInteger factoryInvocations = new AtomicInteger();
+    PlexusContainerManager manager = new PlexusContainerManager((directory, logger, configuration) ->
+        factoryInvocations.getAndIncrement() == 0 ? first : second);
+    try {
+      assertSame(first, manager.aquire(root));
+      Files.delete(new File(root, IMavenPlexusContainer.MVN_FOLDER).toPath());
+
+      manager.cleanup();
+      manager.cleanup();
+      first.verifyDisposedOnce();
+
+      Files.createDirectory(new File(root, IMavenPlexusContainer.MVN_FOLDER).toPath());
+      assertSame(second, manager.aquire(root));
+      assertNotSame(first, second);
+
+      manager.dispose();
+      first.verifyDisposedOnce();
+      second.verifyDisposedOnce();
+    } finally {
+      manager.dispose();
+      FileUtils.deleteDirectory(root);
+    }
+  }
+
+  @Test
+  public void deactivationHandlesInFlightCreation() throws Exception {
+    File root = createMavenRoot("deactivate");
+    TestContainer container = new TestContainer(root.getCanonicalFile());
+    CountDownLatch creationStarted = new CountDownLatch(1);
+    CountDownLatch releaseCreation = new CountDownLatch(1);
+    PlexusContainerManager manager = new PlexusContainerManager((directory, logger, configuration) -> {
+      creationStarted.countDown();
+      await(releaseCreation);
+      return container;
+    });
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<IMavenPlexusContainer> creation = executor.submit(() -> manager.aquire(root));
+      await(creationStarted);
+
+      manager.dispose();
+      releaseCreation.countDown();
+      assertFutureFailure(creation, IllegalStateException.class);
+      container.verifyDisposedOnce();
+
+      try {
+        manager.aquire(root);
+        fail("Expected acquisition after deactivation to fail");
+      } catch(IllegalStateException expected) {
+        // expected
+      }
+    } finally {
+      releaseCreation.countDown();
+      shutdown(executor);
+      manager.dispose();
+      FileUtils.deleteDirectory(root);
+    }
+    container.verifyDisposedOnce();
+  }
+
+  private static File createMavenRoot(String name) throws Exception {
+    File root = Files.createTempDirectory(PlexusContainerManagerTest.class.getSimpleName() + '-' + name).toFile();
+    Files.createDirectory(new File(root, IMavenPlexusContainer.MVN_FOLDER).toPath());
+    return root;
+  }
+
+  private static void await(CountDownLatch latch) throws InterruptedException {
+    assertTrue("Timed out waiting for test coordination", latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+  }
+
+  private static void shutdown(ExecutorService executor) throws InterruptedException {
+    executor.shutdownNow();
+    assertTrue("Executor did not terminate", executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+  }
+
+  private static void assertFutureFailure(Future<?> future, Class<? extends Throwable> expected) throws Exception {
+    try {
+      future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      fail("Expected future to fail with " + expected.getSimpleName());
+    } catch(ExecutionException e) {
+      assertTrue("Expected " + expected.getName() + " but got " + e.getCause(), expected.isInstance(e.getCause()));
+    }
+  }
+
+  private static final class TestContainer implements IMavenPlexusContainer {
+
+    private final Optional<File> mavenDirectory;
+
+    private final ClassWorld classWorld;
+
+    private final PlexusContainer container;
+
+    private final AtomicInteger disposeInvocations = new AtomicInteger();
+
+    TestContainer(File mavenDirectory) throws Exception {
+      this.mavenDirectory = Optional.ofNullable(mavenDirectory);
+      classWorld = new ClassWorld("plexus.core", PlexusContainerManagerTest.class.getClassLoader());
+      var containerRealm = classWorld.getRealm("plexus.core");
+      container = (PlexusContainer) Proxy.newProxyInstance(PlexusContainer.class.getClassLoader(),
+          new Class<?>[] {PlexusContainer.class}, (proxy, method, arguments) -> switch(method.getName()) {
+            case "getContainerRealm" -> containerRealm;
+            case "dispose" -> {
+              disposeInvocations.incrementAndGet();
+              classWorld.close();
+              yield null;
+            }
+            case "toString" -> "TestPlexusContainer";
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> arguments != null && proxy == arguments[0];
+            default -> throw new AssertionError("Unexpected PlexusContainer method " + method);
+          });
+    }
+
+    @Override
+    public Optional<File> getMavenDirectory() {
+      return mavenDirectory;
+    }
+
+    @Override
+    public PlexusContainer getContainer() {
+      return container;
+    }
+
+    @Override
+    public IComponentLookup getComponentLookup() {
+      throw new UnsupportedOperationException();
+    }
+
+    void verifyDisposedOnce() {
+      assertEquals(1, disposeInvocations.get());
+    }
+
+  }
+
+}

--- a/org.eclipse.m2e.core/forceQualifierUpdate.txt
+++ b/org.eclipse.m2e.core/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Update build-qualifier because the compiled byte-code has changed, probably due to newer JDK minor version used in the CI
 Update build-qualifier to pick-up changes in source bundle generation in new Tycho 5.0.3
+Prevent deadlock during Plexus container creation (#1749, #2008)

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerFactory.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Tyce Herrman and others
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.m2e.core.internal.embedder;
+
+import java.io.File;
+
+import org.codehaus.plexus.logging.LoggerManager;
+
+import org.eclipse.m2e.core.embedder.IMavenConfiguration;
+
+
+@FunctionalInterface
+interface PlexusContainerFactory {
+
+  IMavenPlexusContainer create(File multiModuleProjectDirectory, LoggerManager loggerManager,
+      IMavenConfiguration mavenConfiguration) throws Exception;
+
+}

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/embedder/PlexusContainerManager.java
@@ -16,14 +16,18 @@ package org.eclipse.m2e.core.internal.embedder;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Component;
@@ -79,9 +83,19 @@ public class PlexusContainerManager {
 
   private static final String PLEXUS_CORE_REALM = "plexus.core";
 
+  private final Object containerLock = new Object();
+
+  private final PlexusContainerFactory containerFactory;
+
+  private boolean active = true;
+
   private IMavenPlexusContainer nonRootedContainer;
 
+  private CompletableFuture<IMavenPlexusContainer> nonRootedContainerCreation;
+
   private final Map<File, IMavenPlexusContainer> containerMap = new HashMap<>();
+
+  private final Map<File, CompletableFuture<IMavenPlexusContainer>> containerCreations = new HashMap<>();
 
   @Reference
   private LoggerManager loggerManager;
@@ -92,31 +106,54 @@ public class PlexusContainerManager {
   @Reference
   private IWorkspace workspace;
 
+  public PlexusContainerManager() {
+    this(PlexusContainerManager::newPlexusContainer);
+  }
+
+  PlexusContainerManager(PlexusContainerFactory containerFactory) {
+    this.containerFactory = Objects.requireNonNull(containerFactory);
+  }
+
   @Deactivate
   void dispose() {
-    synchronized(containerMap) {
-      containerMap.values().forEach(PlexusContainerManager::disposeContainer);
+    List<IMavenPlexusContainer> containers;
+    IllegalStateException deactivated = new IllegalStateException("Plexus container manager is deactivated");
+    synchronized(containerLock) {
+      if(!active) {
+        return;
+      }
+      active = false;
+      containers = new ArrayList<>(containerMap.values());
       containerMap.clear();
       if(nonRootedContainer != null) {
-        disposeContainer(nonRootedContainer);
+        containers.add(nonRootedContainer);
         nonRootedContainer = null;
       }
+      containerCreations.values().forEach(creation -> creation.completeExceptionally(deactivated));
+      containerCreations.clear();
+      if(nonRootedContainerCreation != null) {
+        nonRootedContainerCreation.completeExceptionally(deactivated);
+        nonRootedContainerCreation = null;
+      }
     }
+    containers.forEach(PlexusContainerManager::disposeContainer);
   }
 
   /**
    * Performs a cleanup cycle by disposing (and removing) container that are no longer referencing a valid maven root
    */
   void cleanup() {
-    synchronized(containerMap) {
+    List<IMavenPlexusContainer> staleContainers = new ArrayList<>();
+    synchronized(containerLock) {
       containerMap.entrySet().removeIf(entry -> {
         if(!new File(entry.getKey(), IMavenPlexusContainer.MVN_FOLDER).isDirectory()) {
-          disposeContainer(entry.getValue());
+          staleContainers.add(entry.getValue());
           return true;
         }
         return false;
       });
     }
+    staleContainers.forEach(PlexusContainerManager::disposeContainer);
   }
 
   private static void disposeContainer(IMavenPlexusContainer mavenPlexusContainer) {
@@ -133,13 +170,23 @@ public class PlexusContainerManager {
   }
 
   public IMavenPlexusContainer aquire() throws Exception {
-    synchronized(containerMap) {
-      cleanup();
+    cleanup();
+    CompletableFuture<IMavenPlexusContainer> creation;
+    boolean creator = false;
+    synchronized(containerLock) {
+      checkActive();
       if(nonRootedContainer == null) {
-        nonRootedContainer = newPlexusContainer(null, loggerManager, mavenConfiguration);
+        creation = nonRootedContainerCreation;
+        if(creation == null) {
+          creation = new CompletableFuture<>();
+          nonRootedContainerCreation = creation;
+          creator = true;
+        }
+      } else {
+        return nonRootedContainer;
       }
-      return nonRootedContainer;
     }
+    return creator ? createContainer(null, creation) : awaitContainer(creation);
   }
 
   public IMavenPlexusContainer aquire(IResource basedir) throws Exception {
@@ -162,19 +209,99 @@ public class PlexusContainerManager {
       return aquire();
     }
     File canonicalDirectory = directory.getCanonicalFile();
-    synchronized(containerMap) {
-      cleanup();
+    cleanup();
+    CompletableFuture<IMavenPlexusContainer> creation;
+    boolean creator = false;
+    synchronized(containerLock) {
+      checkActive();
       IMavenPlexusContainer plexusContainer = containerMap.get(canonicalDirectory);
-      if(plexusContainer == null) {
-        try {
-          plexusContainer = newPlexusContainer(canonicalDirectory, loggerManager, mavenConfiguration);
-          containerMap.put(canonicalDirectory, plexusContainer);
-        } catch(ExtensionResolutionException e) {
-          //TODO how can we create an error marker on the extension file?
-          ExtensionResolutionExceptionFacade.throwForFile(e, new File(directory, IMavenPlexusContainer.EXTENSIONS_FILENAME));
-        }
+      if(plexusContainer != null) {
+        return plexusContainer;
       }
-      return plexusContainer;
+      creation = containerCreations.get(canonicalDirectory);
+      if(creation == null) {
+        creation = new CompletableFuture<>();
+        containerCreations.put(canonicalDirectory, creation);
+        creator = true;
+      }
+    }
+    try {
+      return creator ? createContainer(canonicalDirectory, creation) : awaitContainer(creation);
+    } catch(ExtensionResolutionException e) {
+      //TODO how can we create an error marker on the extension file?
+      ExtensionResolutionExceptionFacade.throwForFile(e,
+          new File(directory, IMavenPlexusContainer.EXTENSIONS_FILENAME));
+      return null;
+    }
+  }
+
+  private IMavenPlexusContainer createContainer(File directory,
+      CompletableFuture<IMavenPlexusContainer> creation) throws Exception {
+    IMavenPlexusContainer plexusContainer;
+    try {
+      plexusContainer = Objects.requireNonNull(containerFactory.create(directory, loggerManager, mavenConfiguration));
+    } catch(Throwable failure) {
+      synchronized(containerLock) {
+        clearCreation(directory, creation);
+        creation.completeExceptionally(failure);
+      }
+      return awaitContainer(creation);
+    }
+
+    boolean published;
+    synchronized(containerLock) {
+      published = active && isCurrentCreation(directory, creation);
+      clearCreation(directory, creation);
+      if(published) {
+        if(directory == null) {
+          nonRootedContainer = plexusContainer;
+        } else {
+          containerMap.put(directory, plexusContainer);
+        }
+        creation.complete(plexusContainer);
+      } else {
+        creation.completeExceptionally(new IllegalStateException("Plexus container manager is deactivated"));
+      }
+    }
+    if(!published) {
+      disposeContainer(plexusContainer);
+    }
+    return awaitContainer(creation);
+  }
+
+  private boolean isCurrentCreation(File directory, CompletableFuture<IMavenPlexusContainer> creation) {
+    return directory == null ? nonRootedContainerCreation == creation : containerCreations.get(directory) == creation;
+  }
+
+  private void clearCreation(File directory, CompletableFuture<IMavenPlexusContainer> creation) {
+    if(directory == null) {
+      if(nonRootedContainerCreation == creation) {
+        nonRootedContainerCreation = null;
+      }
+    } else {
+      containerCreations.remove(directory, creation);
+    }
+  }
+
+  private void checkActive() {
+    if(!active) {
+      throw new IllegalStateException("Plexus container manager is deactivated");
+    }
+  }
+
+  private static IMavenPlexusContainer awaitContainer(CompletableFuture<IMavenPlexusContainer> creation)
+      throws Exception {
+    try {
+      return creation.get();
+    } catch(ExecutionException e) {
+      Throwable cause = e.getCause();
+      if(cause instanceof Exception exception) {
+        throw exception;
+      }
+      if(cause instanceof Error error) {
+        throw error;
+      }
+      throw new IllegalStateException(cause);
     }
   }
 


### PR DESCRIPTION
## What changed

- coordinate rooted and non-rooted Plexus container creation with per-key single-flight futures
- create and dispose containers outside the manager lock so unrelated roots can progress independently
- make failed creation retryable and make deactivation safely release in-flight callers
- add concurrency, retry, cleanup, and deactivation coverage
- force the `org.eclipse.m2e.core` qualifier update because the bundle version was already bumped this release cycle

## Why

Container construction can enter Maven settings code while Maven settings processing can acquire a Plexus container. Holding the container cache monitor during construction creates a lock-order inversion and can deadlock Eclipse startup.

The new coordination keeps at most one creator for each Maven root without holding the manager lock across Maven/Plexus calls.

Fixes #1749.
Fixes #2008.

## Verification

- focused `PlexusContainerManagerTest`: 5 tests, 0 failures, 0 errors
- unfiltered `org.eclipse.m2e.core.tests`: 29 tests, 0 failures, 0 errors, 1 skipped
- full unfiltered `mvn clean verify` reached all 46 modules; production bundles and repository passed, but Cocoa UI test processes abort on macOS 27 beta in `SwiftNativeNSArray.swift:78` with `Array index out of range`
- `git diff --check upstream/main...HEAD`

The local CBI macOS signing attempts also return the expected nonfatal 403 outside Eclipse infrastructure.
