### PR TITLE
Run DebugUITools.launch on the UI thread in MavenConsoleLineTracker

### DIFF
--- a/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.launching;singleton:=true
-Bundle-Version: 2.1.200.qualifier
+Bundle-Version: 2.1.300.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.variables,

--- a/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
+++ b/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/MavenConsoleLineTracker.java
@@ -58,6 +58,7 @@ import org.eclipse.debug.ui.console.IConsoleLineTracker;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.IHyperlink;
@@ -329,7 +330,7 @@ public class MavenConsoleLineTracker implements IConsoleLineTracker {
       workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName());
     }
 
-    DebugUITools.launch(workingCopy, ILaunchManager.DEBUG_MODE); //$NON-NLS-1$
+    Display.getDefault().asyncExec(() -> DebugUITools.launch(workingCopy, ILaunchManager.DEBUG_MODE)); //$NON-NLS-1$
   }
 
   /**


### PR DESCRIPTION
Fixes #2218

`MavenConsoleLineTracker.launchRemoteJavaApp` is invoked from `ConsolePatternMatcher$MatchJob`, a non-UI worker thread. `DebugUITools.launch(...)` must run on the SWT UI thread, so calling it directly produces `SWTException: Invalid thread access` and aborts the remote Java debugger auto-attach.

Dispatch the launch to the UI thread with `Display.getDefault().asyncExec(...)`.
