### PR TITLE
Add IMavenProjectFacade#getMojoParameterValue

### DIFF
--- a/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.apt.core;singleton:=true
-Bundle-Version: 2.3.100.qualifier
+Bundle-Version: 2.3.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
@@ -52,7 +52,6 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.apt.internal.utils.ProjectUtils;
-import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
@@ -351,12 +350,8 @@ public abstract class AbstractAptConfiguratorDelegate implements AptConfigurator
       throws CoreException {
     PluginExecution execution = new PluginExecution();
     execution.setConfiguration(mojoExecution.getConfiguration());
-    MavenProject mavenProject = mavenFacade.getMavenProject();
-    return mavenFacade.createExecutionContext().execute(mavenProject, (context, monitor) -> {
-      //TODO provide as part of the execution context? We then probably won't need the project parameter at all?
-      return MavenPlugin.getMaven().getMojoParameterValue(mavenProject, parameter, asType, mojoExecution.getPlugin(),
-          execution, mojoExecution.getGoal(), null);
-    }, null);
+    return mavenFacade.getMojoParameterValue(parameter, asType, mojoExecution.getPlugin(), execution,
+        mojoExecution.getGoal(), null);
   }
 
 }

--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerBuildParticipant.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerBuildParticipant.java
@@ -29,12 +29,9 @@ import org.codehaus.plexus.util.Scanner;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 
 import org.sonatype.plexus.build.incremental.BuildContext;
 
-import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionBuildParticipant;
 
@@ -54,7 +51,6 @@ public class MavenCompilerBuildParticipant extends MojoExecutionBuildParticipant
 
   @Override
   public Set<IProject> build(int kind, IProgressMonitor monitor) throws Exception {
-    IMaven maven = MavenPlugin.getMaven();
     BuildContext buildContext = getBuildContext();
 
     MojoExecution mojoExecution = getMojoExecution();
@@ -63,12 +59,11 @@ public class MavenCompilerBuildParticipant extends MojoExecutionBuildParticipant
 
     //TODO check delta / scan source for *.java
     IMavenProjectFacade mavenProjectFacade = getMavenProjectFacade();
-    MavenProject project = mavenProjectFacade.getMavenProject();
-    String compilerArgument = maven.getMojoParameterValue(project, mojoExecution, "compilerArgument", String.class,
-        null);
+    String compilerArgument = mavenProjectFacade.getMojoParameterValue(mojoExecution, "compilerArgument",
+        String.class, null);
     boolean isAnnotationProcessingEnabled = (compilerArgument == null) || !compilerArgument.contains("-proc:none");
     if(isAnnotationProcessingEnabled) {
-      String proc = maven.getMojoParameterValue(project, mojoExecution, PROC, String.class, null);
+      String proc = mavenProjectFacade.getMojoParameterValue(mojoExecution, PROC, String.class, null);
       isAnnotationProcessingEnabled = !"none".equals(proc);
     }
     if(!isAnnotationProcessingEnabled) {
@@ -112,7 +107,7 @@ public class MavenCompilerBuildParticipant extends MojoExecutionBuildParticipant
     }
 
     // tell m2e builder to refresh generated files
-    File generated = maven.getMojoParameterValue(project, getMojoExecution(),
+    File generated = mavenProjectFacade.getMojoParameterValue(getMojoExecution(),
         MavenCompilerJdtAptDelegate.OUTPUT_DIRECTORY_PARAMETER, File.class, null);
     if(generated != null) {
       buildContext.refresh(generated);

--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerJdtAptDelegate.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/compiler/MavenCompilerJdtAptDelegate.java
@@ -35,7 +35,6 @@ import org.eclipse.osgi.util.NLS;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.apt.internal.AbstractAptConfiguratorDelegate;
 import org.eclipse.m2e.apt.internal.AnnotationProcessorConfiguration;
@@ -45,8 +44,6 @@ import org.eclipse.m2e.apt.internal.Messages;
 import org.eclipse.m2e.apt.internal.processor.MavenProcessorJdtAptDelegate;
 import org.eclipse.m2e.apt.internal.utils.PluginDependencyResolver;
 import org.eclipse.m2e.apt.internal.utils.ProjectUtils;
-import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.markers.IMavenMarkerManager;
 import org.eclipse.m2e.core.internal.markers.MavenProblemInfo;
 import org.eclipse.m2e.core.internal.markers.SourceLocation;
@@ -118,34 +115,32 @@ public class MavenCompilerJdtAptDelegate extends AbstractAptConfiguratorDelegate
   @Override
   protected AnnotationProcessorConfiguration getAnnotationProcessorConfiguration(IProgressMonitor monitor)
       throws CoreException {
-    IMaven maven = MavenPlugin.getMaven();
     markerManager.deleteMarkers(mavenFacade.getProject(), true, IMavenAptConstants.INVALID_ARGUMENT_MARKER_ID);
-    MavenProject mavenProject = mavenFacade.getMavenProject(monitor);
     File generatedTestOutputDirectory = null;
     for(MojoExecution mojoExecution : mavenFacade.getMojoExecutions(COMPILER_PLUGIN_GROUP_ID,
         COMPILER_PLUGIN_ARTIFACT_ID, monitor, GOAL_TEST_COMPILE)) {
-      generatedTestOutputDirectory = maven.getMojoParameterValue(mavenProject, mojoExecution,
+      generatedTestOutputDirectory = mavenFacade.getMojoParameterValue(mojoExecution,
           TEST_OUTPUT_DIRECTORY_PARAMETER, File.class, monitor);
     }
     for(MojoExecution mojoExecution : mavenFacade.getMojoExecutions(COMPILER_PLUGIN_GROUP_ID,
         COMPILER_PLUGIN_ARTIFACT_ID, monitor, GOAL_COMPILE)) {
-      File generatedOutputDirectory = maven.getMojoParameterValue(mavenProject, mojoExecution,
+      File generatedOutputDirectory = mavenFacade.getMojoParameterValue(mojoExecution,
           OUTPUT_DIRECTORY_PARAMETER, File.class, monitor);
 
       Map<String, String> options = new HashMap<>();
 
       @SuppressWarnings("unchecked")
-      Map<String, String> compilerArguments = maven.getMojoParameterValue(mavenProject, mojoExecution,
+      Map<String, String> compilerArguments = mavenFacade.getMojoParameterValue(mojoExecution,
           "compilerArguments", Map.class, monitor);
       options.putAll(extractProcessorOptions(compilerArguments));
 
       // the single compiler argument takes precedence in maven-compiler-plugin
-      String compilerArgument = maven.getMojoParameterValue(mavenProject, mojoExecution, "compilerArgument",
+      String compilerArgument = mavenFacade.getMojoParameterValue(mojoExecution, "compilerArgument",
           String.class, monitor);
       options.putAll(parseProcessorOptions(compilerArgument));
 
       @SuppressWarnings("unchecked")
-      List<String> compilerArgs = maven.getMojoParameterValue(mavenProject, mojoExecution, "compilerArgs", List.class,
+      List<String> compilerArgs = mavenFacade.getMojoParameterValue(mojoExecution, "compilerArgs", List.class,
           monitor);
       options.putAll(ProjectUtils.parseProcessorOptions(compilerArgs));
 
@@ -153,11 +148,11 @@ public class MavenCompilerJdtAptDelegate extends AbstractAptConfiguratorDelegate
 
       boolean isAnnotationProcessingEnabled = (compilerArgument == null) || !compilerArgument.contains("-proc:none");
       if(isAnnotationProcessingEnabled) {
-        String proc = maven.getMojoParameterValue(mavenProject, mojoExecution, "proc", String.class, monitor);
+        String proc = mavenFacade.getMojoParameterValue(mojoExecution, "proc", String.class, monitor);
         isAnnotationProcessingEnabled = !"none".equals(proc);
       }
 
-      Dependency[] annotationProcessorPaths = maven.getMojoParameterValue(mavenProject, mojoExecution,
+      Dependency[] annotationProcessorPaths = mavenFacade.getMojoParameterValue(mojoExecution,
           "annotationProcessorPaths", Dependency[].class, monitor);
 
       boolean hasAnnotationProcessorPaths = annotationProcessorPaths.length > 0;

--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/processor/MavenProcessorBuildParticipant.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/processor/MavenProcessorBuildParticipant.java
@@ -27,12 +27,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.codehaus.plexus.util.Scanner;
 
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 
 import org.sonatype.plexus.build.incremental.BuildContext;
 
-import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionBuildParticipant;
 
@@ -58,11 +55,10 @@ public class MavenProcessorBuildParticipant extends MojoExecutionBuildParticipan
 
     //Modifying the pom triggers a build, otherwise, check for java source modifications
     IMavenProjectFacade mavenFacade = getMavenProjectFacade();
-    MavenProject mavenProject = mavenFacade.getMavenProject();
     if(!buildContext.hasDelta(mavenFacade.getPomFile())) {
 
       // check if any of the java files changed
-      File source = getFileParameter(MavenProcessorJdtAptDelegate.SOURCE_DIRECTORY_PARAMETER, mavenProject);
+      File source = getFileParameter(MavenProcessorJdtAptDelegate.SOURCE_DIRECTORY_PARAMETER, mavenFacade);
       Scanner ds = buildContext.newScanner(source); // delta or full scanner
       ds.scan();
       String[] includedFiles = ds.getIncludedFiles();
@@ -77,9 +73,9 @@ public class MavenProcessorBuildParticipant extends MojoExecutionBuildParticipan
     Set<IProject> result = super.build(kind, monitor);
 
     // tell m2e builder to refresh generated files
-    File generated = getFileParameter(MavenProcessorJdtAptDelegate.OUTPUT_DIRECTORY_PARAMETER, mavenProject);
+    File generated = getFileParameter(MavenProcessorJdtAptDelegate.OUTPUT_DIRECTORY_PARAMETER, mavenFacade);
     if(generated == null) {
-      generated = getFileParameter(MavenProcessorJdtAptDelegate.DEFAULT_OUTPUT_DIRECTORY_PARAMETER, mavenProject);
+      generated = getFileParameter(MavenProcessorJdtAptDelegate.DEFAULT_OUTPUT_DIRECTORY_PARAMETER, mavenFacade);
     }
     if(generated != null) {
       buildContext.refresh(generated);
@@ -88,8 +84,7 @@ public class MavenProcessorBuildParticipant extends MojoExecutionBuildParticipan
     return result;
   }
 
-  private File getFileParameter(String propertyId, MavenProject mavenProject) throws CoreException {
-    IMaven maven = MavenPlugin.getMaven();
-    return maven.getMojoParameterValue(mavenProject, getMojoExecution(), propertyId, File.class, null);
+  private File getFileParameter(String propertyId, IMavenProjectFacade mavenFacade) throws CoreException {
+    return mavenFacade.getMojoParameterValue(getMojoExecution(), propertyId, File.class, null);
   }
 }

--- a/org.eclipse.m2e.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.core;singleton:=true
-Bundle-Version: 2.7.900.qualifier
+Bundle-Version: 2.8.0.qualifier
 Bundle-Activator: org.eclipse.m2e.core.internal.MavenPluginActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -170,13 +170,21 @@ public interface IMaven extends IComponentLookup {
    * @return the parameter value or {@code null} if the parameter with the given name was not found
    * @throws CoreException
    * @since 1.4
+   * @deprecated use
+   *             {@link IMavenProjectFacade#getMojoParameterValue(MojoExecution, String, Class, IProgressMonitor)}
+   *             instead to avoid a direct dependency on {@link MavenProject}
    */
+  @Deprecated
   <T> T getMojoParameterValue(MavenProject project, MojoExecution mojoExecution, String parameter,
       Class<T> asType, IProgressMonitor monitor) throws CoreException;
 
   /**
    * @since 1.4
+   * @deprecated use
+   *             {@link IMavenProjectFacade#getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String, IProgressMonitor)}
+   *             instead to avoid a direct dependency on {@link MavenProject}
    */
+  @Deprecated
   <T> T getMojoParameterValue(MavenProject project, String parameter, Class<T> type, Plugin plugin,
       ConfigurationContainer configuration, String goal, IProgressMonitor monitor) throws CoreException;
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -43,6 +43,8 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.lifecycle.internal.LifecycleExecutionPlanCalculator;
+import org.apache.maven.model.ConfigurationContainer;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
@@ -582,6 +584,21 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
       }
     }
     return result;
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public <T> T getMojoParameterValue(MojoExecution mojoExecution, String parameter, Class<T> asType,
+      IProgressMonitor monitor) throws CoreException {
+    return manager.maven.getMojoParameterValue(getMavenProject(monitor), mojoExecution, parameter, asType, monitor);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public <T> T getMojoParameterValue(String parameter, Class<T> type, Plugin plugin,
+      ConfigurationContainer configuration, String goal, IProgressMonitor monitor) throws CoreException {
+    return manager.maven.getMojoParameterValue(getMavenProject(monitor), parameter, type, plugin, configuration, goal,
+        monitor);
   }
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -26,6 +26,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import org.apache.maven.lifecycle.MavenExecutionPlan;
+import org.apache.maven.model.ConfigurationContainer;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
@@ -173,6 +175,40 @@ public interface IMavenProjectFacade extends IMavenExecutableLocation {
    */
   List<MojoExecution> getMojoExecutions(String groupId, String artifactId, IProgressMonitor monitor,
       String... goals) throws CoreException;
+
+  /**
+   * Resolves a configuration parameter from the given {@code mojoExecution}. It coerces from String to the given type
+   * and considers expressions and default values.
+   *
+   * @param <T>
+   * @param mojoExecution the mojo execution from which to retrieve the configuration value
+   * @param parameter the name of the parameter (may be nested with separating {@code .})
+   * @param asType the type to coerce to
+   * @param monitor the progress monitor
+   * @return the parameter value or {@code null} if the parameter with the given name was not found
+   * @throws CoreException
+   * @since 2.8
+   */
+  <T> T getMojoParameterValue(MojoExecution mojoExecution, String parameter, Class<T> asType,
+      IProgressMonitor monitor) throws CoreException;
+
+  /**
+   * Resolves a configuration parameter for the given {@code plugin}/{@code goal} combination. It coerces from String to
+   * the given type and considers expressions and default values.
+   *
+   * @param <T>
+   * @param parameter the name of the parameter (may be nested with separating {@code .})
+   * @param type the type to coerce to
+   * @param plugin the plugin declaring the parameter
+   * @param configuration the configuration to look up the parameter value in
+   * @param goal the goal of the plugin execution
+   * @param monitor the progress monitor
+   * @return the parameter value or {@code null} if the parameter with the given name was not found
+   * @throws CoreException
+   * @since 2.8
+   */
+  <T> T getMojoParameterValue(String parameter, Class<T> type, Plugin plugin, ConfigurationContainer configuration,
+      String goal, IProgressMonitor monitor) throws CoreException;
 
   // lifecycle mapping
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
@@ -178,12 +178,26 @@ public abstract class AbstractProjectConfigurator implements IExecutableExtensio
 
   /**
    * @since 1.4
+   * @deprecated use {@link #getParameterValue(IMavenProjectFacade, String, Class, MojoExecution, IProgressMonitor)}
+   *             instead to avoid a direct dependency on {@link MavenProject}
    */
+  @Deprecated
   protected <T> T getParameterValue(MavenProject project, String parameter, Class<T> asType,
       MojoExecution mojoExecution, IProgressMonitor monitor) throws CoreException {
     PluginExecution execution = new PluginExecution();
     execution.setConfiguration(mojoExecution.getConfiguration());
     return maven.getMojoParameterValue(project, parameter, asType, mojoExecution.getPlugin(), execution,
+        mojoExecution.getGoal(), monitor);
+  }
+
+  /**
+   * @since 2.8
+   */
+  protected <T> T getParameterValue(IMavenProjectFacade projectFacade, String parameter, Class<T> asType,
+      MojoExecution mojoExecution, IProgressMonitor monitor) throws CoreException {
+    PluginExecution execution = new PluginExecution();
+    execution.setConfiguration(mojoExecution.getConfiguration());
+    return projectFacade.getMojoParameterValue(parameter, asType, mojoExecution.getPlugin(), execution,
         mojoExecution.getGoal(), monitor);
   }
 

--- a/org.eclipse.m2e.feature/feature.xml
+++ b/org.eclipse.m2e.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.feature"
       label="%featureName"
-      version="2.10.300.qualifier"
+      version="2.11.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractSourcesGenerationProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/AbstractSourcesGenerationProjectConfigurator.java
@@ -83,8 +83,8 @@ public abstract class AbstractSourcesGenerationProjectConfigurator extends Abstr
 
   protected File[] getSourceFolders(ProjectConfigurationRequest request, MojoExecution mojoExecution,
       IProgressMonitor monitor) throws CoreException {
-    return new File[] {
-        getParameterValue(request.mavenProject(), getOutputFolderParameterName(), File.class, mojoExecution, monitor)};
+    return new File[] {getParameterValue(request.mavenProjectFacade(), getOutputFolderParameterName(), File.class,
+        mojoExecution, monitor)};
   }
 
   protected String getOutputFolderParameterName() {

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/MavenExecutionJre.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/MavenExecutionJre.java
@@ -32,7 +32,6 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -71,8 +70,7 @@ public class MavenExecutionJre {
     List<MojoExecution> mojoExecutions = project.getMojoExecutions(ENFORCER_PLUGIN_GROUP_ID,
         ENFORCER_PLUGIN_ARTIFACT_ID, monitor, GOAL_ENFORCE);
     for(MojoExecution mojoExecution : mojoExecutions) {
-      Optional<String> version = getRequiredJavaVersionFromEnforcerRule(project.getMavenProject(monitor), mojoExecution,
-          monitor);
+      Optional<String> version = getRequiredJavaVersionFromEnforcerRule(project, mojoExecution, monitor);
       if(version.isPresent()) {
         return version;
       }
@@ -82,13 +80,13 @@ public class MavenExecutionJre {
     return Optional.empty();
   }
 
-  private static Optional<String> getRequiredJavaVersionFromEnforcerRule(MavenProject mavenProject,
+  private static Optional<String> getRequiredJavaVersionFromEnforcerRule(IMavenProjectFacade projectFacade,
       MojoExecution mojoExecution, IProgressMonitor monitor) throws CoreException {
     // https://maven.apache.org/enforcer/enforcer-rules/requireJavaVersion.html
     List<String> parameter = List.of("rules", "requireJavaVersion", "version");
     @SuppressWarnings("restriction")
-    String version = ((org.eclipse.m2e.core.internal.embedder.MavenImpl) MavenPlugin.getMaven())
-        .getMojoParameterValue(mavenProject, mojoExecution, parameter, String.class, monitor);
+    String version = ((org.eclipse.m2e.core.internal.embedder.MavenImpl) MavenPlugin.getMaven()).getMojoParameterValue(
+        projectFacade.getMavenProject(monitor), mojoExecution, parameter, String.class, monitor);
     if(version == null) {
       return Optional.empty();
     }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/AbstractJavaProjectConfigurator.java
@@ -207,12 +207,13 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
       throws CoreException {
     int highest = -1;
     for(MojoExecution compile : getCompilerMojoExecutions(request, monitor)) {
-      Boolean multiReleaseOutput = maven.getMojoParameterValue(request.mavenProject(), compile, MULTI_RELEASE_OUTPUT,
-          Boolean.class, monitor);
+      Boolean multiReleaseOutput = request.mavenProjectFacade().getMojoParameterValue(compile,
+          MULTI_RELEASE_OUTPUT, Boolean.class, monitor);
       if(!Boolean.TRUE.equals(multiReleaseOutput)) {
         continue;
       }
-      String release = maven.getMojoParameterValue(request.mavenProject(), compile, "release", String.class, monitor);
+      String release = request.mavenProjectFacade().getMojoParameterValue(compile, "release", String.class,
+          monitor);
       if(release == null) {
         continue;
       }
@@ -367,17 +368,17 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
 
       List<MojoExecution> executions = getCompilerMojoExecutions(request, mon.newChild(1));
       for(MojoExecution compile : executions) {
-        if(isCompileExecution(compile, mavenProject, options, monitor)) {
-          mainSourceEncoding = maven.getMojoParameterValue(mavenProject, compile, "encoding", String.class, monitor); //$NON-NLS-1$
+        if(isCompileExecution(compile, projectFacade, options, monitor)) {
+          mainSourceEncoding = projectFacade.getMojoParameterValue(compile, "encoding", String.class, monitor); //$NON-NLS-1$
           try {
             inclusion = toPaths(
-                maven.getMojoParameterValue(mavenProject, compile, "includes", String[].class, monitor)); //$NON-NLS-1$
+                projectFacade.getMojoParameterValue(compile, "includes", String[].class, monitor)); //$NON-NLS-1$
           } catch(CoreException ex) {
             log.error("Failed to determine compiler inclusions, assuming defaults", ex);
           }
           try {
             exclusion = toPaths(
-                maven.getMojoParameterValue(mavenProject, compile, "excludes", String[].class, monitor)); //$NON-NLS-1$
+                projectFacade.getMojoParameterValue(compile, "excludes", String[].class, monitor)); //$NON-NLS-1$
           } catch(CoreException ex) {
             log.error("Failed to determine compiler exclusions, assuming defaults", ex);
           }
@@ -385,23 +386,23 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
       }
 
       for(MojoExecution compile : executions) {
-        if(isTestCompileExecution(compile, mavenProject, options, monitor)) {
-          testSourceEncoding = maven.getMojoParameterValue(mavenProject, compile, "encoding", String.class, monitor); //$NON-NLS-1$
+        if(isTestCompileExecution(compile, projectFacade, options, monitor)) {
+          testSourceEncoding = projectFacade.getMojoParameterValue(compile, "encoding", String.class, monitor); //$NON-NLS-1$
           try {
             inclusionTest = toPaths(
-                maven.getMojoParameterValue(mavenProject, compile, "testIncludes", String[].class, monitor)); //$NON-NLS-1$
+                projectFacade.getMojoParameterValue(compile, "testIncludes", String[].class, monitor)); //$NON-NLS-1$
           } catch(CoreException ex) {
             log.error("Failed to determine compiler test inclusions, assuming defaults", ex);
           }
           try {
             exclusionTest = toPaths(
-                maven.getMojoParameterValue(mavenProject, compile, "testExcludes", String[].class, monitor)); //$NON-NLS-1$
+                projectFacade.getMojoParameterValue(compile, "testExcludes", String[].class, monitor)); //$NON-NLS-1$
           } catch(CoreException ex) {
             log.error("Failed to determine compiler test exclusions, assuming defaults", ex);
           }
           try {
             isTestCompilationSkipped
-                .add(maven.getMojoParameterValue(mavenProject, compile, "skip", Boolean.class, monitor));
+                .add(projectFacade.getMojoParameterValue(compile, "skip", Boolean.class, monitor));
           } catch(Exception ex) {
             isTestCompilationSkipped.add(Boolean.FALSE);
           }
@@ -410,15 +411,15 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
 
       for(MojoExecution resources : projectFacade.getMojoExecutions(RESOURCES_PLUGIN_GROUP_ID,
           RESOURCES_PLUGIN_ARTIFACT_ID, mon.newChild(1), GOAL_RESOURCES)) {
-        mainResourcesEncoding = maven.getMojoParameterValue(mavenProject, resources, "encoding", String.class, monitor); //$NON-NLS-1$
+        mainResourcesEncoding = projectFacade.getMojoParameterValue(resources, "encoding", String.class, monitor); //$NON-NLS-1$
       }
 
       for(MojoExecution resources : projectFacade.getMojoExecutions(RESOURCES_PLUGIN_GROUP_ID,
           RESOURCES_PLUGIN_ARTIFACT_ID, mon.newChild(1), GOAL_TESTRESOURCES)) {
-        testResourcesEncoding = maven.getMojoParameterValue(mavenProject, resources, "encoding", String.class, monitor); //$NON-NLS-1$
+        testResourcesEncoding = projectFacade.getMojoParameterValue(resources, "encoding", String.class, monitor); //$NON-NLS-1$
         try {
           isTestResourcesSkipped
-              .add(maven.getMojoParameterValue(mavenProject, resources, "skip", Boolean.class, monitor));
+              .add(projectFacade.getMojoParameterValue(resources, "skip", Boolean.class, monitor));
         } catch(Exception ex) {
           isTestResourcesSkipped.add(Boolean.FALSE);
         }
@@ -432,7 +433,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
           mainResourcesEncoding, mon.newChild(1), false);
 
       // Handle multi-release JAR source folders
-      addMultiReleaseSourceFolders(classpath, project, mavenProject, executions, classes.getFullPath(),
+      addMultiReleaseSourceFolders(classpath, project, projectFacade, executions, classes.getFullPath(),
           mainSourceEncoding, mon.newChild(1));
 
       //If the project properties contain m2e.disableTestClasspathFlag=true, then the test flag must not be set
@@ -450,28 +451,28 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     }
   }
 
-  protected boolean isTestCompileExecution(MojoExecution execution, MavenProject mavenProject,
+  protected boolean isTestCompileExecution(MojoExecution execution, IMavenProjectFacade projectFacade,
       Map<String, String> options, IProgressMonitor monitor) throws CoreException {
-    return GOAL_TESTCOMPILE.equals(execution.getGoal()) && isCompliant(execution, mavenProject, options, monitor);
+    return GOAL_TESTCOMPILE.equals(execution.getGoal()) && isCompliant(execution, projectFacade, options, monitor);
   }
 
-  protected boolean isCompileExecution(MojoExecution execution, MavenProject mavenProject, Map<String, String> options,
-      IProgressMonitor monitor) throws CoreException {
-    return GOAL_COMPILE.equals(execution.getGoal()) && isCompliant(execution, mavenProject, options, monitor);
+  protected boolean isCompileExecution(MojoExecution execution, IMavenProjectFacade projectFacade,
+      Map<String, String> options, IProgressMonitor monitor) throws CoreException {
+    return GOAL_COMPILE.equals(execution.getGoal()) && isCompliant(execution, projectFacade, options, monitor);
   }
 
-  private boolean isCompliant(MojoExecution execution, MavenProject mavenProject, Map<String, String> options,
+  private boolean isCompliant(MojoExecution execution, IMavenProjectFacade projectFacade, Map<String, String> options,
       IProgressMonitor monitor) throws CoreException {
-    String release = maven.getMojoParameterValue(mavenProject, execution, "release", String.class, monitor); //$NON-NLS-1$
+    String release = projectFacade.getMojoParameterValue(execution, "release", String.class, monitor); //$NON-NLS-1$
     if(release != null && !sanitizeJavaVersion(release).equals(options.get(JavaCore.COMPILER_COMPLIANCE))) {
       return false;
     }
     if(release == null) {
-      String source = maven.getMojoParameterValue(mavenProject, execution, "source", String.class, monitor); //$NON-NLS-1$
+      String source = projectFacade.getMojoParameterValue(execution, "source", String.class, monitor); //$NON-NLS-1$
       if(source != null && !sanitizeJavaVersion(source).equals(options.get(JavaCore.COMPILER_SOURCE))) {
         return false;
       }
-      String target = maven.getMojoParameterValue(mavenProject, execution, "target", String.class, monitor); //$NON-NLS-1$
+      String target = projectFacade.getMojoParameterValue(execution, "target", String.class, monitor); //$NON-NLS-1$
       if(target != null
           && !sanitizeJavaVersion(target).equals(options.get(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM))) {
         return false;
@@ -543,7 +544,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
    * 
    * @param classpath the classpath descriptor
    * @param project the Eclipse project
-   * @param mavenProject the Maven project
+   * @param projectFacade the Maven project facade
    * @param executions the compiler plugin executions
    * @param outputPath the base output path for compiled classes
    * @param sourceEncoding the source encoding
@@ -551,23 +552,23 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
    * @throws CoreException if an error occurs
    */
   protected void addMultiReleaseSourceFolders(IClasspathDescriptor classpath, IProject project,
-      MavenProject mavenProject, List<MojoExecution> executions, IPath outputPath, String sourceEncoding,
+      IMavenProjectFacade projectFacade, List<MojoExecution> executions, IPath outputPath, String sourceEncoding,
       IProgressMonitor monitor) throws CoreException {
 
     for(MojoExecution execution : executions) {
       // Check if this execution has multiReleaseOutput enabled
-      Boolean multiReleaseOutput = maven.getMojoParameterValue(mavenProject, execution, MULTI_RELEASE_OUTPUT,
+      Boolean multiReleaseOutput = projectFacade.getMojoParameterValue(execution, MULTI_RELEASE_OUTPUT,
           Boolean.class, monitor);
       if(!Boolean.TRUE.equals(multiReleaseOutput)) {
         continue;
       }
-      String release = maven.getMojoParameterValue(mavenProject, execution, "release", String.class, monitor);
+      String release = projectFacade.getMojoParameterValue(execution, "release", String.class, monitor);
       if(release == null) {
         continue;
       }
       String sanitizedRelease = sanitizeJavaVersion(release);
       @SuppressWarnings("unchecked")
-      List<String> compileSourceRoots = maven.getMojoParameterValue(mavenProject, execution, "compileSourceRoots",
+      List<String> compileSourceRoots = projectFacade.getMojoParameterValue(execution, "compileSourceRoots",
           List.class, monitor);
       if(compileSourceRoots == null || compileSourceRoots.isEmpty()) {
         continue;
@@ -731,15 +732,16 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
   protected void addJavaProjectOptions(Map<String, String> options, ProjectConfigurationRequest request,
       IProgressMonitor monitor) throws CoreException {
     MojoExecution execution = getDefaultCompileExecution(getCompilerMojoExecutions(request, monitor));
-    String release = getCompilerLevel(request.mavenProject(), execution, "release", null, RELEASES, monitor);
+    IMavenProjectFacade projectFacade = request.mavenProjectFacade();
+    String release = getCompilerLevel(projectFacade, execution, "release", null, RELEASES, monitor);
     //XXX ignoring testRelease option, since JDT doesn't support main/test classpath separation - yet
-    String source = getCompilerLevel(request.mavenProject(), execution, "source", null, SOURCES, monitor); //$NON-NLS-1$
-    String target = getCompilerLevel(request.mavenProject(), execution, "target", null, TARGETS, monitor); //$NON-NLS-1$
-    boolean generateParameters = isGenerateParameters(request.mavenProject(), execution, monitor);
-    boolean enablePreviewFeatures = isEnablePreviewFeatures(request.mavenProject(), execution, monitor);
+    String source = getCompilerLevel(projectFacade, execution, "source", null, SOURCES, monitor); //$NON-NLS-1$
+    String target = getCompilerLevel(projectFacade, execution, "target", null, TARGETS, monitor); //$NON-NLS-1$
+    boolean generateParameters = isGenerateParameters(projectFacade, execution, monitor);
+    boolean enablePreviewFeatures = isEnablePreviewFeatures(projectFacade, execution, monitor);
 
     // process -err:+deprecation , -warn:-serial ...
-    List<?> value = maven.getMojoParameterValue(request.mavenProject(), execution, "compilerArgs", List.class, monitor);
+    List<?> value = projectFacade.getMojoParameterValue(execution, "compilerArgs", List.class, monitor);
     if(value != null) {
       for(Object o : value) {
         if(o instanceof String compilerArg) {
@@ -836,11 +838,11 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     };
   }
 
-  private boolean isGenerateParameters(MavenProject mavenProject, MojoExecution execution, IProgressMonitor monitor) {
+  private boolean isGenerateParameters(IMavenProjectFacade projectFacade, MojoExecution execution, IProgressMonitor monitor) {
     Boolean generateParameters = null;
     //1st, check the parameters option
     try {
-      generateParameters = maven.getMojoParameterValue(mavenProject, execution, "parameters", Boolean.class, monitor);//$NON-NLS-1$
+      generateParameters = projectFacade.getMojoParameterValue(execution, "parameters", Boolean.class, monitor);//$NON-NLS-1$
     } catch(Exception ex) {
       //ignore
     }
@@ -848,7 +850,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     //2nd, check the parameters flag in the compilerArgs list
     if(!Boolean.TRUE.equals(generateParameters)) {
       try {
-        List<?> args = maven.getMojoParameterValue(mavenProject, execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
+        List<?> args = projectFacade.getMojoParameterValue(execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
         if(args != null) {
           generateParameters = args.contains(JavaSettingsUtils.PARAMETERS_JVM_FLAG);
         }
@@ -860,7 +862,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     //3rd, check the parameters flag in the compilerArgument String
     if(!Boolean.TRUE.equals(generateParameters)) {
       try {
-        String compilerArgument = maven.getMojoParameterValue(mavenProject, execution, "compilerArgument", String.class, //$NON-NLS-1$
+        String compilerArgument = projectFacade.getMojoParameterValue(execution, "compilerArgument", String.class, //$NON-NLS-1$
             monitor);
         if(compilerArgument != null) {
           generateParameters = compilerArgument.contains(JavaSettingsUtils.PARAMETERS_JVM_FLAG);
@@ -873,11 +875,11 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     return Boolean.TRUE.equals(generateParameters);
   }
 
-  private boolean isEnablePreviewFeatures(MavenProject mavenProject, MojoExecution execution,
+  private boolean isEnablePreviewFeatures(IMavenProjectFacade projectFacade, MojoExecution execution,
       IProgressMonitor monitor) {
     //1st, check the --enable-preview flag in the compilerArgs list
     try {
-      List<?> args = maven.getMojoParameterValue(mavenProject, execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
+      List<?> args = projectFacade.getMojoParameterValue(execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
       if(args != null && args.contains(JavaSettingsUtils.ENABLE_PREVIEW_JVM_FLAG)) {
         return true;
       }
@@ -887,7 +889,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
 
     //2nd, check the --enable-preview flag in the compilerArgument String
     try {
-      String compilerArgument = maven.getMojoParameterValue(mavenProject, execution, "compilerArgument", String.class, //$NON-NLS-1$
+      String compilerArgument = projectFacade.getMojoParameterValue(execution, "compilerArgument", String.class, //$NON-NLS-1$
           monitor);
       if(compilerArgument != null && compilerArgument.contains(JavaSettingsUtils.ENABLE_PREVIEW_JVM_FLAG)) {
         return true;
@@ -898,7 +900,7 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
 
     //3nd, check the --enable-preview flag in the ${maven.compiler.enablePreview}
     try {
-      Boolean enablePreview = maven.getMojoParameterValue(mavenProject, execution, "enablePreview", Boolean.class, //$NON-NLS-1$
+      Boolean enablePreview = projectFacade.getMojoParameterValue(execution, "enablePreview", Boolean.class, //$NON-NLS-1$
           monitor);
       if(Boolean.TRUE.equals(enablePreview)) {
         return true;
@@ -941,10 +943,10 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
         monitor, GOAL_COMPILE, GOAL_TESTCOMPILE);
   }
 
-  private String getCompilerLevel(MavenProject mavenProject, MojoExecution execution, String parameter,
+  private String getCompilerLevel(IMavenProjectFacade projectFacade, MojoExecution execution, String parameter,
       String prevVersion, List<String> supportedVersions, IProgressMonitor monitor) {
     try {
-      String version = maven.getMojoParameterValue(mavenProject, execution, parameter, String.class, monitor);
+      String version = projectFacade.getMojoParameterValue(execution, parameter, String.class, monitor);
       if(version == null) {
         return prevVersion;
       }
@@ -1097,19 +1099,19 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
   /**
    * get all the arguments provided to the compiler for the provided {@link MojoExecution}
    * 
-   * @param mavenProject the current maven project
+   * @param projectFacade the current maven project facade
    * @param execution the plugin execution
    * @param monitor the progress monitor
    * @return the arguments
    */
-  private List<String> getCompilerArguments(MavenProject mavenProject, MojoExecution execution,
+  private List<String> getCompilerArguments(IMavenProjectFacade projectFacade, MojoExecution execution,
       IProgressMonitor monitor) {
 
     List<String> arguments = new ArrayList<>();
 
     //1st, get the arguments in the compilerArgs list
     try {
-      List<?> args = maven.getMojoParameterValue(mavenProject, execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
+      List<?> args = projectFacade.getMojoParameterValue(execution, "compilerArgs", List.class, monitor);//$NON-NLS-1$
       if(args != null) {//$NON-NLS-1$
         args.stream().filter(a -> a != null).forEach(a -> arguments.add(a.toString()));
       }
@@ -1142,13 +1144,11 @@ public abstract class AbstractJavaProjectConfigurator extends AbstractProjectCon
     List<MojoExecution> executions = facade.getMojoExecutions(COMPILER_PLUGIN_GROUP_ID, COMPILER_PLUGIN_ARTIFACT_ID,
         monitor, GOAL_COMPILE, GOAL_TESTCOMPILE);
 
-    MavenProject mavenProject = facade.getMavenProject();
-
     //facade.getProject().get
     for(MojoExecution compile : executions) {
-      if(isCompileExecution(compile, mavenProject, options, monitor)
-          || isTestCompileExecution(compile, mavenProject, options, monitor)) {
-        List<String> args = getCompilerArguments(mavenProject, compile, monitor);
+      if(isCompileExecution(compile, facade, options, monitor)
+          || isTestCompileExecution(compile, facade, options, monitor)) {
+        List<String> args = getCompilerArguments(facade, compile, monitor);
         if(args != null) {
           compilerArgs.addAll(args);
         }

--- a/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/UnitTestSupport.java
+++ b/org.eclipse.m2e.jdt/src/org/eclipse/m2e/jdt/internal/UnitTestSupport.java
@@ -56,7 +56,6 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
 import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.jdt.MavenExecutionJre;
 import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
@@ -345,7 +344,7 @@ public class UnitTestSupport {
       }
       LOG.debug("Using mojo execution {} to populate test launch arguments",
           mostRelevantExecution.get().getExecutionId());
-      return getTestLaunchArguments(mavenProject, mostRelevantExecution.get(), monitor);
+      return getTestLaunchArguments(facade, mavenProject, mostRelevantExecution.get(), monitor);
     }
 
     /**
@@ -457,21 +456,19 @@ public class UnitTestSupport {
      * @return the arguments
      */
     @SuppressWarnings("unchecked")
-    private TestLaunchArguments getTestLaunchArguments(MavenProject mavenProject, MojoExecution execution,
-        IProgressMonitor monitor) {
+    private TestLaunchArguments getTestLaunchArguments(IMavenProjectFacade facade, MavenProject mavenProject,
+        MojoExecution execution, IProgressMonitor monitor) {
       try {
-        IMaven maven = MavenPlugin.getMaven();
-
-        String argLine = maven.getMojoParameterValue(mavenProject, execution, PLUGIN_ARGLINE, String.class, monitor);
+        String argLine = facade.getMojoParameterValue(execution, PLUGIN_ARGLINE, String.class, monitor);
         argLine = resolveDeferredVariables(mavenProject, argLine);
         // resolve all placeholders which were not resolved previously by the empty string
         argLine = removeStandardVariablePlaceholders(argLine);
 
         return new TestLaunchArguments(argLine,
-            maven.getMojoParameterValue(mavenProject, execution, PLUGIN_SYSPROP_VARIABLES, Map.class, monitor),
-            maven.getMojoParameterValue(mavenProject, execution, PLUGIN_ENVIRONMENT_VARIABLES, Map.class, monitor),
-            maven.getMojoParameterValue(mavenProject, execution, PLUGIN_WORKING_DIRECTORY, File.class, monitor),
-            maven.getMojoParameterValue(mavenProject, execution, PLUGIN_ENABLE_ASSERTIONS, Boolean.class, monitor));
+            facade.getMojoParameterValue(execution, PLUGIN_SYSPROP_VARIABLES, Map.class, monitor),
+            facade.getMojoParameterValue(execution, PLUGIN_ENVIRONMENT_VARIABLES, Map.class, monitor),
+            facade.getMojoParameterValue(execution, PLUGIN_WORKING_DIRECTORY, File.class, monitor),
+            facade.getMojoParameterValue(execution, PLUGIN_ENABLE_ASSERTIONS, Boolean.class, monitor));
       } catch(Exception e) {
         LOG.error(e.getMessage(), e);
       }

--- a/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.pde.connector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E PDE Connector
 Bundle-SymbolicName: org.eclipse.m2e.pde.connector;singleton:=true
-Bundle-Version: 2.2.101.qualifier
+Bundle-Version: 2.2.201.qualifier
 Automatic-Module-Name: org.eclipse.m2e.pde.connector
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse.org - m2e

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEMavenBundlePluginConfigurator.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/PDEMavenBundlePluginConfigurator.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -43,9 +42,7 @@ import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
-import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.MavenArtifactIdentifier;
 import org.eclipse.m2e.core.internal.markers.IMavenMarkerManager;
@@ -96,8 +93,7 @@ public class PDEMavenBundlePluginConfigurator extends AbstractProjectConfigurato
 			Plugin plugin = execution.getPlugin();
 			if (isFelix(plugin)) {
 				if (isFelixManifestGoal(execution)) {
-					IMaven maven = MavenPlugin.getMaven();
-					Boolean supportIncremental = maven.getMojoParameterValue(request.mavenProject(), execution,
+					Boolean supportIncremental = request.mavenProjectFacade().getMojoParameterValue(execution,
 							FELIX_PARAM_SUPPORTINCREMENTALBUILD, Boolean.class, monitor);
 					if (supportIncremental == null || !supportIncremental.booleanValue()) {
 						createWarningMarker(request, execution, SourceLocationHelper.CONFIGURATION,
@@ -162,14 +158,12 @@ public class PDEMavenBundlePluginConfigurator extends AbstractProjectConfigurato
 
 	private IPath getMetainfPath(IMavenProjectFacade facade, List<MojoExecution> executions, IProgressMonitor monitor)
 			throws CoreException {
-		IMaven maven = MavenPlugin.getMaven();
 		// TODO: warn on multiple executions and prefer the one without classifier (i.e.
 		// the main artifact or the one for the bnd-process/jar goal??
 		for (MojoExecution execution : executions) {
 			Plugin plugin = execution.getPlugin();
-			MavenProject project = facade.getMavenProject(monitor);
 			String manifestParameter = isBND(plugin) ? BND_PARAM_MANIFESTLOCATION : FELIX_PARAM_MANIFESTLOCATION;
-			File location = maven.getMojoParameterValue(project, execution, manifestParameter, File.class, monitor);
+			File location = facade.getMojoParameterValue(execution, manifestParameter, File.class, monitor);
 			if (location != null) {
 				return facade.getProjectRelativePath(location.getAbsolutePath());
 			}

--- a/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/TychoDSConfigurator.java
+++ b/org.eclipse.m2e.pde.connector/src/org/eclipse/m2e/pde/connector/TychoDSConfigurator.java
@@ -15,7 +15,6 @@ package org.eclipse.m2e.pde.connector;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
@@ -53,15 +52,16 @@ public class TychoDSConfigurator extends AbstractProjectConfigurator {
 			createWarningMarker(request, mojoExecution, "executions", message);
 		}
 		// apply PDE configuration for DS
-		MavenProject project = request.mavenProject();
-		boolean isDsEnabled = maven.getMojoParameterValue(project, mojoExecution, "enabled", Boolean.class, monitor);
+		boolean isDsEnabled = request.mavenProjectFacade().getMojoParameterValue(mojoExecution, "enabled",
+				Boolean.class, monitor);
 		if (isDsEnabled) {
 			IEclipsePreferences prefs = new ProjectScope(request.mavenProjectFacade().getProject())
 					.getNode(org.eclipse.pde.ds.internal.annotations.Activator.PLUGIN_ID);
 
 			prefs.putBoolean(org.eclipse.pde.ds.internal.annotations.Activator.PREF_ENABLED, isDsEnabled);
 
-			String dsVersion = maven.getMojoParameterValue(project, mojoExecution, "dsVersion", String.class, monitor);
+			String dsVersion = request.mavenProjectFacade().getMojoParameterValue(mojoExecution, "dsVersion",
+					String.class, monitor);
 			DSAnnotationVersion version = parseVersion(dsVersion);
 			if (version != null) {
 				prefs.put(org.eclipse.pde.ds.internal.annotations.Activator.PREF_SPEC_VERSION, version.name());
@@ -69,7 +69,8 @@ public class TychoDSConfigurator extends AbstractProjectConfigurator {
 				String message = "Unsupported DS spec version " + dsVersion + " found, using default instead";
 				createWarningMarker(request, mojoExecution, SourceLocationHelper.CONFIGURATION, message);
 			}
-			String path = maven.getMojoParameterValue(project, mojoExecution, "path", String.class, monitor);
+			String path = request.mavenProjectFacade().getMojoParameterValue(mojoExecution, "path",
+					String.class, monitor);
 			prefs.put(org.eclipse.pde.ds.internal.annotations.Activator.PREF_PATH, path);
 			try {
 				prefs.flush();

--- a/org.eclipse.m2e.pde.feature/feature.xml
+++ b/org.eclipse.m2e.pde.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.pde.feature"
       label="%featureName"
-      version="2.3.700.qualifier"
+      version="2.3.800.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.sdk.feature"
       label="%featureName"
-      version="2.11.2.qualifier"
+      version="2.12.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Currently we require consumers to go through IMaven for getting Mojo parameters with a maven project. This is both cumbersome and binds us to the MavenProject API from maven-core what complicates Maven 4 migration.

This removes the roundtrip by adding the methods for getting a mojo parameter directly to the facade what later will allow us to exchange the backing implementation much easier.