### PR TITLE
Simplify getMojoParameterValue usage and remove obsolete Plugin/ConfigurationContainer overload

### DIFF
--- a/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
+++ b/org.eclipse.m2e.apt.core/src/org/eclipse/m2e/apt/internal/AbstractAptConfiguratorDelegate.java
@@ -47,7 +47,6 @@ import org.eclipse.jdt.core.JavaCore;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
@@ -348,10 +347,7 @@ public abstract class AbstractAptConfiguratorDelegate implements AptConfigurator
 
   protected <T> T getParameterValue(String parameter, Class<T> asType, MojoExecution mojoExecution)
       throws CoreException {
-    PluginExecution execution = new PluginExecution();
-    execution.setConfiguration(mojoExecution.getConfiguration());
-    return mavenFacade.getMojoParameterValue(parameter, asType, mojoExecution.getPlugin(), execution,
-        mojoExecution.getGoal(), null);
+    return mavenFacade.getMojoParameterValue(mojoExecution, parameter, asType, null);
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMaven.java
@@ -181,7 +181,7 @@ public interface IMaven extends IComponentLookup {
   /**
    * @since 1.4
    * @deprecated use
-   *             {@link IMavenProjectFacade#getMojoParameterValue(String, Class, Plugin, ConfigurationContainer, String, IProgressMonitor)}
+   *             {@link IMavenProjectFacade#getMojoParameterValue(MojoExecution, String, Class, IProgressMonitor)}
    *             instead to avoid a direct dependency on {@link MavenProject}
    */
   @Deprecated

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade.java
@@ -43,8 +43,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.lifecycle.internal.LifecycleExecutionPlanCalculator;
-import org.apache.maven.model.ConfigurationContainer;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
@@ -591,14 +589,6 @@ public class MavenProjectFacade implements IMavenProjectFacade, Serializable {
   public <T> T getMojoParameterValue(MojoExecution mojoExecution, String parameter, Class<T> asType,
       IProgressMonitor monitor) throws CoreException {
     return manager.maven.getMojoParameterValue(getMavenProject(monitor), mojoExecution, parameter, asType, monitor);
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  public <T> T getMojoParameterValue(String parameter, Class<T> type, Plugin plugin,
-      ConfigurationContainer configuration, String goal, IProgressMonitor monitor) throws CoreException {
-    return manager.maven.getMojoParameterValue(getMavenProject(monitor), parameter, type, plugin, configuration, goal,
-        monitor);
   }
 
   /**

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/IMavenProjectFacade.java
@@ -26,8 +26,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import org.apache.maven.lifecycle.MavenExecutionPlan;
-import org.apache.maven.model.ConfigurationContainer;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
@@ -191,24 +189,6 @@ public interface IMavenProjectFacade extends IMavenExecutableLocation {
    */
   <T> T getMojoParameterValue(MojoExecution mojoExecution, String parameter, Class<T> asType,
       IProgressMonitor monitor) throws CoreException;
-
-  /**
-   * Resolves a configuration parameter for the given {@code plugin}/{@code goal} combination. It coerces from String to
-   * the given type and considers expressions and default values.
-   *
-   * @param <T>
-   * @param parameter the name of the parameter (may be nested with separating {@code .})
-   * @param type the type to coerce to
-   * @param plugin the plugin declaring the parameter
-   * @param configuration the configuration to look up the parameter value in
-   * @param goal the goal of the plugin execution
-   * @param monitor the progress monitor
-   * @return the parameter value or {@code null} if the parameter with the given name was not found
-   * @throws CoreException
-   * @since 2.8
-   */
-  <T> T getMojoParameterValue(String parameter, Class<T> type, Plugin plugin, ConfigurationContainer configuration,
-      String goal, IProgressMonitor monitor) throws CoreException;
 
   // lifecycle mapping
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/project/configurator/AbstractProjectConfigurator.java
@@ -195,10 +195,7 @@ public abstract class AbstractProjectConfigurator implements IExecutableExtensio
    */
   protected <T> T getParameterValue(IMavenProjectFacade projectFacade, String parameter, Class<T> asType,
       MojoExecution mojoExecution, IProgressMonitor monitor) throws CoreException {
-    PluginExecution execution = new PluginExecution();
-    execution.setConfiguration(mojoExecution.getConfiguration());
-    return projectFacade.getMojoParameterValue(parameter, asType, mojoExecution.getPlugin(), execution,
-        mojoExecution.getGoal(), monitor);
+    return projectFacade.getMojoParameterValue(mojoExecution, parameter, asType, monitor);
   }
 
   protected void assertHasNature(IProject project, String natureId) throws CoreException {


### PR DESCRIPTION
There where only two call sites left and both are unwrapping a mojoexecution. Passing the execution directly avoid to resolve it again.

Lets see if this works or if there is any subtile difference between the both here.