### PR TITLE
Add workflow to collect inactive committers

### DIFF
--- a/.github/workflows/inactiveCommitters.yml
+++ b/.github/workflows/inactiveCommitters.yml
@@ -1,0 +1,23 @@
+# This workflow lists the activity of all committers in the Github organization in the specified list of Eclipse projects
+# and summaries inactive committers.
+
+name: List inactive committers
+
+on:
+  workflow_dispatch:
+    inputs:
+      activity-period:
+        description: 'Period in which committers should be active'
+        type: string
+        default: '2 years'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  list-inactive-committers:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/inactiveCommitters.yml@master
+    with:
+      activity-period: ${{ inputs.activity-period }}
+      projects: '["technology.m2e"]'


### PR DESCRIPTION
## What does this PR do?

Add workflow to collect inactive committers by calling the workflow added in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3990

with inputs adjusted for m2e.


## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [x] `mvn clean verify` (add `-Pits` for integration tests) passes locally.
- [x] Bundle versions are bumped where required (see "Version bump" in [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php).
