### PR TITLE
Retry marker assertions after stale marker

### DIFF
--- a/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/WorkspaceHelpersTest.java
+++ b/org.eclipse.m2e.core.tests/src/org/eclipse/m2e/core/WorkspaceHelpersTest.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Tyce Herrman and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.m2e.core;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.m2e.tests.common.WorkspaceHelpers;
+
+@SuppressWarnings("restriction")
+public class WorkspaceHelpersTest {
+
+	private static final String MARKER_TYPE = "test.marker";
+
+	private static final String MARKER_MESSAGE = "expected message";
+
+	private static final int MARKER_LINE = 7;
+
+	private static final String RESOURCE_PATH = "pom.xml";
+
+	@Test
+	public void testAssertMarkerReturnsStableMarker() throws Exception {
+		IMarker marker = marker(MARKER_TYPE, MARKER_MESSAGE, MARKER_LINE);
+		IProject project = mock(IProject.class);
+		when(project.findMarkers(null, true, IResource.DEPTH_INFINITE)).thenReturn(new IMarker[] {marker});
+
+		IMarker result = WorkspaceHelpers.assertMarker(MARKER_TYPE, IMarker.SEVERITY_ERROR, MARKER_MESSAGE,
+				MARKER_LINE, RESOURCE_PATH, project);
+
+		assertSame(marker, result);
+		verify(project).findMarkers(null, true, IResource.DEPTH_INFINITE);
+	}
+
+	@Test
+	public void testAssertMarkerRetriesWhenMarkerDisappears() throws Exception {
+		CoreException staleMarkerException = new CoreException(Status.error("Marker id 1 not found"));
+		IMarker staleMarker = marker(MARKER_TYPE, MARKER_MESSAGE, MARKER_LINE);
+		when(staleMarker.getType()).thenThrow(staleMarkerException);
+		when(staleMarker.exists()).thenReturn(false);
+		IMarker replacementMarker = marker(MARKER_TYPE, MARKER_MESSAGE, MARKER_LINE);
+		IProject project = mock(IProject.class);
+		when(project.findMarkers(null, true, IResource.DEPTH_INFINITE)).thenReturn(new IMarker[] {staleMarker},
+				new IMarker[] {replacementMarker});
+
+		IMarker result = WorkspaceHelpers.assertMarker(MARKER_TYPE, IMarker.SEVERITY_ERROR, MARKER_MESSAGE,
+				MARKER_LINE, RESOURCE_PATH, project);
+
+		assertSame(replacementMarker, result);
+		verify(project, times(2)).findMarkers(null, true, IResource.DEPTH_INFINITE);
+	}
+
+	@Test
+	public void testAssertMarkerDoesNotRetryUnrelatedCoreException() throws Exception {
+		CoreException readException = new CoreException(Status.error("Marker read failed"));
+		IMarker marker = marker(MARKER_TYPE, MARKER_MESSAGE, MARKER_LINE);
+		when(marker.getType()).thenThrow(readException);
+		when(marker.exists()).thenReturn(true);
+		IProject project = mock(IProject.class);
+		when(project.findMarkers(null, true, IResource.DEPTH_INFINITE)).thenReturn(new IMarker[] {marker});
+
+		try {
+			WorkspaceHelpers.assertMarker(MARKER_TYPE, IMarker.SEVERITY_ERROR, MARKER_MESSAGE, MARKER_LINE,
+					RESOURCE_PATH, project);
+			fail("Expected CoreException");
+		} catch(CoreException thrown) {
+			assertSame(readException, thrown);
+		}
+		verify(project).findMarkers(null, true, IResource.DEPTH_INFINITE);
+	}
+
+	@Test
+	public void testAssertMarkerRetriesOnlyOnce() throws Exception {
+		CoreException firstException = new CoreException(Status.error("Marker id 1 not found"));
+		IMarker firstMarker = marker(MARKER_TYPE, MARKER_MESSAGE, MARKER_LINE);
+		when(firstMarker.getType()).thenThrow(firstException);
+		when(firstMarker.exists()).thenReturn(false);
+		CoreException secondException = new CoreException(Status.error("Marker id 2 not found"));
+		IMarker secondMarker = marker(MARKER_TYPE, MARKER_MESSAGE, MARKER_LINE);
+		when(secondMarker.getType()).thenThrow(secondException);
+		when(secondMarker.exists()).thenReturn(false);
+		IProject project = mock(IProject.class);
+		when(project.findMarkers(null, true, IResource.DEPTH_INFINITE)).thenReturn(new IMarker[] {firstMarker},
+				new IMarker[] {secondMarker});
+
+		try {
+			WorkspaceHelpers.assertMarker(MARKER_TYPE, IMarker.SEVERITY_ERROR, MARKER_MESSAGE, MARKER_LINE,
+					RESOURCE_PATH, project);
+			fail("Expected CoreException");
+		} catch(CoreException thrown) {
+			assertSame(secondException, thrown);
+		}
+		verify(project, times(2)).findMarkers(null, true, IResource.DEPTH_INFINITE);
+	}
+
+	@Test
+	public void testAssertMarkerPreservesMissingMarkerDiagnostics() throws Exception {
+		IMarker marker = marker("other.marker", "other message", 11);
+		IProject project = mock(IProject.class);
+		when(project.findMarkers(null, true, IResource.DEPTH_INFINITE)).thenReturn(new IMarker[] {marker});
+
+		AssertionError thrown = null;
+		try {
+			WorkspaceHelpers.assertMarker(MARKER_TYPE, IMarker.SEVERITY_ERROR, MARKER_MESSAGE, MARKER_LINE,
+					RESOURCE_PATH, project);
+		} catch(AssertionError ex) {
+			thrown = ex;
+		}
+
+		assertNotNull("Expected AssertionError", thrown);
+		assertTrue(thrown.getMessage(), thrown.getMessage()
+				.contains("Expected marker not found. Found markers :Type=other.marker:Message=other message:LineNumber=11"));
+		verify(project).findMarkers(null, true, IResource.DEPTH_INFINITE);
+	}
+
+	private static IMarker marker(String type, String message, int lineNumber) throws CoreException {
+		IMarker marker = mock(IMarker.class);
+		when(marker.getType()).thenReturn(type);
+		when(marker.getAttribute(IMarker.SEVERITY, 0)).thenReturn(IMarker.SEVERITY_ERROR);
+		when(marker.getAttribute(IMarker.MESSAGE, "")).thenReturn(message);
+		when(marker.getAttribute(IMarker.MESSAGE)).thenReturn(message);
+		when(marker.getAttribute(IMarker.LINE_NUMBER, -1)).thenReturn(lineNumber);
+		when(marker.getAttribute(IMarker.LINE_NUMBER)).thenReturn(lineNumber);
+		IResource resource = mock(IResource.class);
+		when(resource.getProjectRelativePath()).thenReturn(new Path(RESOURCE_PATH));
+		when(marker.getResource()).thenReturn(resource);
+		when(marker.isSubtypeOf(IMarker.PROBLEM)).thenReturn(true);
+		return marker;
+	}
+}

--- a/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Testing Helpers
 Bundle-SymbolicName: org.eclipse.m2e.tests.common;singleton:=true
-Bundle-Version: 2.1.1.qualifier
+Bundle-Version: 2.1.101.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0",
  org.eclipse.m2e.core;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[3.9.900,4.0.0)",

--- a/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/WorkspaceHelpers.java
+++ b/org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/WorkspaceHelpers.java
@@ -177,33 +177,6 @@ public class WorkspaceHelpers {
     return assertMarker(type, IMarker.SEVERITY_WARNING, message, lineNumber, resourceRelativePath, project);
   }
 
-  private static IMarker findMarker(String type, String message, Integer lineNumber, String resourceRelativePath,
-      List<IMarker> markers) throws Exception {
-    for(IMarker marker : markers) {
-      if(type != null && !type.equals(marker.getType())) {
-        continue;
-      }
-      if(message != null && !marker.getAttribute(IMarker.MESSAGE, "").startsWith(message)) {
-        continue;
-      }
-      if(lineNumber != null && !lineNumber.equals(marker.getAttribute(IMarker.LINE_NUMBER))) {
-        continue;
-      }
-      if(type != null && type.startsWith(IMavenConstants.MARKER_ID)) {
-        Assert.assertEquals("Marker not persistent:" + toString(marker), false, marker.getAttribute(IMarker.TRANSIENT));
-      }
-
-      if(resourceRelativePath == null) {
-        resourceRelativePath = "";
-      }
-      Assert.assertEquals("Marker not on the expected resource:" + toString(marker), resourceRelativePath,
-          marker.getResource().getProjectRelativePath().toString());
-
-      return marker;
-    }
-    return null;
-  }
-
   public static IMarker assertErrorMarker(String type, String message, Integer lineNumber, IProject project)
       throws Exception {
     return assertMarker(type, IMarker.SEVERITY_ERROR, message, lineNumber, "pom.xml", project);
@@ -216,15 +189,47 @@ public class WorkspaceHelpers {
 
   public static IMarker assertMarker(String type, int severity, String message, Integer lineNumber,
       String resourceRelativePath, IProject project) throws Exception {
-    List<IMarker> markers = findMarkers(project, severity);
-    IMarker marker = findMarker(type, message, lineNumber, resourceRelativePath, markers);
-    if(marker == null) {
-      Assert.fail(
-          "Expected marker not found. Found " + (markers.isEmpty() ? "no markers" : "markers :") + toString(markers));
+    List<IMarker> markers = List.of();
+    for(int attempt = 0; attempt < 2; attempt++ ) {
+      markers = findMarkers(project, severity);
+      boolean retry = false;
+      for(IMarker marker : markers) {
+        try {
+          if(type != null && !type.equals(marker.getType())) {
+            continue;
+          }
+          if(message != null && !marker.getAttribute(IMarker.MESSAGE, "").startsWith(message)) {
+            continue;
+          }
+          if(lineNumber != null && !lineNumber.equals(marker.getAttribute(IMarker.LINE_NUMBER))) {
+            continue;
+          }
+          if(type != null && type.startsWith(IMavenConstants.MARKER_ID)) {
+            Assert.assertEquals("Marker not persistent:" + toString(marker), false,
+                marker.getAttribute(IMarker.TRANSIENT));
+          }
+
+          String expectedResourcePath = resourceRelativePath == null ? "" : resourceRelativePath;
+          Assert.assertEquals("Marker not on the expected resource:" + toString(marker), expectedResourcePath,
+              marker.getResource().getProjectRelativePath().toString());
+          Assert.assertTrue("Marker type " + type + " is not a subtype of " + IMarker.PROBLEM,
+              marker.isSubtypeOf(IMarker.PROBLEM));
+          return marker;
+        } catch(CoreException ex) {
+          if(attempt == 0 && !marker.exists()) {
+            retry = true;
+            break;
+          }
+          throw ex;
+        }
+      }
+      if(!retry) {
+        break;
+      }
     }
-    Assert.assertTrue("Marker type " + type + " is not a subtype of " + IMarker.PROBLEM,
-        marker.isSubtypeOf(IMarker.PROBLEM));
-    return marker;
+    Assert.fail(
+        "Expected marker not found. Found " + (markers.isEmpty() ? "no markers" : "markers :") + toString(markers));
+    return null;
   }
 
   public static void assertLifecycleIdErrorMarkerAttributes(IProject project, String lifecycleId) throws CoreException {


### PR DESCRIPTION
## What does this PR do?

Retries `WorkspaceHelpers.assertMarker(...)` once with a fresh marker snapshot when a marker disappears during inspection. Unrelated `CoreException`s continue to propagate, and the existing missing-marker diagnostics are preserved.

Adds focused coverage for stable markers, stale-marker replacement, bounded retry, unrelated failures, and missing-marker diagnostics.

Fixes #2224

## How was this tested?

`mvn -U -B -ntp clean integration-test -am -pl org.eclipse.m2e.core.tests -Dtest=WorkspaceHelpersTest -Dsurefire.failIfNoSpecifiedTests=false -P=-eclipse-sign-jnilibs`

Result: 5 tests, 0 failures, 0 errors, 0 skipped; all 10 reactor modules succeeded.

## AI/GenAI disclosure

- Tool/agent + model/version + mode: Codex, GPT-5, interactive
- [x] I have personally reviewed all code, tests, and text in this PR and understand and stand behind every change, per the [Eclipse GenAI contribution guidelines](https://www.eclipse.org/projects/handbook/#genai).
- [x] I will personally review and confirm any AI-assisted follow-up changes made in response to review comments before pushing them (see [AGENTS.md](../AGENTS.md) rule on reading full thread history).

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [ ] `mvn clean verify` (add `-Pits` for integration tests) passes locally.
- [x] Bundle versions are bumped where required (see "Version bump" in [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php).

<!-- AI-Agent-Disclosure -->
> 🤖 Drafted with Codex, GPT-5, interactive. Reviewed and confirmed by @TyceHerrman before submission.
