### PR TITLE
Add configuration option for MavenProject retention through the initial workspace build

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilder.java
@@ -87,27 +87,36 @@ public class MavenBuilder extends IncrementalProjectBuilder implements DeltaProv
           return null;
         }
 
-        MavenProject mavenProject;
-        try {
-          // make sure projectFacade has MavenProject instance loaded
-          mavenProject = projectFacade.getMavenProject(monitor2);
-        } catch(CoreException ce) {
-          //unable to read the project facade
-          addErrorMarker(project, ce);
-          return null;
-        }
+        boolean releaseRetention = kind != CLEAN_BUILD
+          && builder.hasRelevantDelta(
+              projectFacade,
+              getDelta(projectFacade.getProject())) != MavenBuilderImpl.DeltaType.IRRELEVANT;
 
-        return context2.execute(mavenProject, (context1, monitor1) -> {
-          ILifecycleMapping lifecycleMapping = configurationManager.getLifecycleMapping(projectFacade);
-          if(lifecycleMapping == null) {
+        try {
+          MavenProject mavenProject;
+          try {
+            // make sure projectFacade has MavenProject instance loaded
+            mavenProject = projectFacade.getMavenProject(monitor2);
+          } catch(CoreException ce) {
+            //unable to read the project facade
+            addErrorMarker(project, ce);
             return null;
           }
 
-          Map<MojoExecutionKey, List<AbstractBuildParticipant>> buildParticipantsByMojoExecutionKey = lifecycleMapping
-              .getBuildParticipants(projectFacade, monitor1);
+          return context2.execute(mavenProject, (context1, monitor1) -> {
+            ILifecycleMapping lifecycleMapping = configurationManager.getLifecycleMapping(projectFacade);
+            if(lifecycleMapping == null) {
+              return null;
+            }
 
-          return method(context1, projectFacade, buildParticipantsByMojoExecutionKey, kind, args, monitor1);
-        }, monitor2);
+            Map<MojoExecutionKey, List<AbstractBuildParticipant>> buildParticipantsByMojoExecutionKey = lifecycleMapping
+                .getBuildParticipants(projectFacade, monitor1);
+
+            return method(context1, projectFacade, buildParticipantsByMojoExecutionKey, kind, args, monitor1);
+          }, monitor2);
+        } finally {
+          projectManager.releaseInitialBuildRetention(projectFacade, releaseRetention);
+        }
       }, monitor);
     }
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilderImpl.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/builder/MavenBuilderImpl.java
@@ -86,7 +86,7 @@ public class MavenBuilderImpl {
 
   private final Map<IProject, ProjectBuildState> deltaState = new ConcurrentHashMap<>();
 
-  private enum DeltaType {
+  enum DeltaType {
     INCREMENTAL, IRRELEVANT, FULL_BUILD, UNKOWN;
   }
 
@@ -205,7 +205,7 @@ public class MavenBuilderImpl {
     return dependencies;
   }
 
-  private DeltaType hasRelevantDelta(IMavenProjectFacade projectFacade, IResourceDelta resourceDelta)
+  DeltaType hasRelevantDelta(IMavenProjectFacade projectFacade, IResourceDelta resourceDelta)
       throws CoreException {
     if(resourceDelta == null) {
       return DeltaType.FULL_BUILD;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
@@ -14,15 +14,22 @@ package org.eclipse.m2e.core.internal.project.registry;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 import com.google.common.cache.CacheBuilder;
@@ -58,6 +65,12 @@ public class MavenProjectCache {
 
   private static final int MAX_CACHE_SIZE = Integer.getInteger("m2e.project.cache.size", 50);
 
+  private static final boolean INITIAL_BUILD_RETENTION_ENABLED = Boolean.getBoolean("m2e.project.cache.initialBuildRetention");
+
+  private static final long INITIAL_BUILD_RETENTION_MAX_AGE_MILLIS = Long.getLong(
+    "m2e.project.cache.initialBuildRetention.maxAgeMillis",
+    TimeUnit.MINUTES.toMillis(30));
+
   private static final String CTX_MAVENPROJECTS = MavenProjectCache.class.getName() + "/mavenProjects";
 
   @Reference
@@ -65,18 +78,41 @@ public class MavenProjectCache {
 
   private LoadingCache<CacheKey, CacheLine> loadingCache;
 
+  private ScheduledFuture<?> retentionCleanup;
+
+  private final ConcurrentMap<RetainedProjectKey, RetainedProject> initialBuildRetentions = new ConcurrentHashMap<>();
+
+  private final ScheduledExecutorService retentionCleanupExecutor;
+
+  private final Object retentionCleanupLock = new Object();
 
   public MavenProjectCache() {
+    this.retentionCleanupExecutor = INITIAL_BUILD_RETENTION_ENABLED
+        ? Executors.newSingleThreadScheduledExecutor(runnable -> {
+          Thread thread = new Thread(runnable, "m2e-initial-build-retention-cleanup");
+          thread.setDaemon(true);
+          return thread;
+        })
+        : null;
     this.loadingCache = CacheBuilder.newBuilder() //
         .maximumSize(MAX_CACHE_SIZE) //
         .removalListener((RemovalNotification<CacheKey, CacheLine> removed) -> {
           Map<IMavenProjectFacade, MavenProject> contextProjects = getContextProjectMap();
-          removed.getValue().projects.values().forEach(mavenProject -> {
-            if(!contextProjects.containsValue(mavenProject)) {
+          removed.getValue().projects.forEach((pom, mavenProject) -> {
+            RetainedProject retained = initialBuildRetentions.get(retainedProjectKey(removed.getKey(), pom));
+            if(!(retained != null && retained.mavenProject() == mavenProject)
+                && !contextProjects.containsValue(mavenProject)) {
               flushMavenCaches(mavenProject.getFile(), removed.getKey().artifactKey(), false);
             }
           });
         }).build(CacheLoader.from(CacheLine::new));
+  }
+
+  @Deactivate
+  void deactivate() {
+    if(retentionCleanupExecutor != null) {
+      retentionCleanupExecutor.shutdownNow();
+    }
   }
 
   /**
@@ -85,7 +121,9 @@ public class MavenProjectCache {
    * @param facade the facade to invalidate
    */
   public void invalidateProjectFacade(IMavenProjectFacade facade) {
-    CacheLine cacheLine = loadingCache.getIfPresent(new CacheKey(facade.getArtifactKey(), facade.getConfiguration()));
+    CacheKey cacheKey = cacheKey(facade);
+    initialBuildRetentions.remove(retainedProjectKey(cacheKey, facade.getPomFile()));
+    CacheLine cacheLine = loadingCache.getIfPresent(cacheKey);
     if(cacheLine != null) {
       cacheLine.remove(facade.getPomFile());
     }
@@ -100,8 +138,21 @@ public class MavenProjectCache {
    * @return the project or null
    */
   public MavenProject getMavenProject(IMavenProjectFacade facade, Function<IMavenProjectFacade, MavenProject> projectLoader) {
-    ArtifactKey artifactKey = facade.getArtifactKey();
-    CacheLine cacheLine = loadingCache.getUnchecked(new CacheKey(artifactKey, facade.getConfiguration()));
+    CacheKey cacheKey = cacheKey(facade);
+    CacheLine cacheLine = loadingCache.getUnchecked(cacheKey);
+    File pomFile = facade.getPomFile();
+    MavenProject cachedProject = cacheLine.peekProject(pomFile);
+
+    if(INITIAL_BUILD_RETENTION_ENABLED) {
+      RetainedProject retained = initialBuildRetentions.get(retainedProjectKey(cacheKey, pomFile));
+      if(retained != null) {
+        MavenProject retainedProject = retained.mavenProject();
+        if(cachedProject != retainedProject) {
+          cacheLine.updateProject(facade, retainedProject);
+        }
+        return retainedProject;
+      }
+    }
     return cacheLine.getProject(facade, projectLoader);
   }
 
@@ -116,9 +167,96 @@ public class MavenProjectCache {
       invalidateProjectFacade(facade);
       return;
     }
-    ArtifactKey artifactKey = facade.getArtifactKey();
-    CacheLine cacheLine = loadingCache.getUnchecked(new CacheKey(artifactKey, facade.getConfiguration()));
+    CacheKey cacheKey = cacheKey(facade);
+    if(INITIAL_BUILD_RETENTION_ENABLED) {
+      synchronized(retentionCleanupLock) {
+        long retainedAt = System.currentTimeMillis();
+        initialBuildRetentions.put(
+          retainedProjectKey(cacheKey, facade.getPomFile()),
+          new RetainedProject(mavenProject, retainedAt)
+        );
+        scheduleRetentionCleanupAt(retainedAt + INITIAL_BUILD_RETENTION_MAX_AGE_MILLIS);
+      }
+    }
+    CacheLine cacheLine = loadingCache.getUnchecked(cacheKey);
     cacheLine.updateProject(facade, mavenProject);
+  }
+
+  /**
+   * Releases a project that was temporarily retained for its first relevant builder invocation.
+   *
+   * @param facade the facade for which a project should be released
+   * @param relevant whether the completed builder invocation performed Maven-relevant work and therefore consumes the
+   *          initial-build retention
+   */
+  public void releaseInitialBuildRetention(IMavenProjectFacade facade, boolean relevant) {
+    if(!INITIAL_BUILD_RETENTION_ENABLED || !relevant) {
+      return;
+    }
+    CacheKey cacheKey = cacheKey(facade);
+    RetainedProjectKey retainedKey = retainedProjectKey(cacheKey, facade.getPomFile());
+    RetainedProject retained = initialBuildRetentions.remove(retainedKey);
+    if(retained == null) {
+      return;
+    }
+    onInitialBuildRetentionReleased(retainedKey, retained);
+  }
+
+  private void scheduleRetentionCleanupAt(long cleanupAtMillis) {
+    if(retentionCleanupExecutor == null || cleanupAtMillis == Long.MAX_VALUE) {
+      return;
+    }
+    synchronized(retentionCleanupLock) {
+      if(retentionCleanup == null || retentionCleanup.isDone()) {
+        retentionCleanup = retentionCleanupExecutor.schedule(
+          this::runRetentionCleanup,
+          Math.max(0, cleanupAtMillis - System.currentTimeMillis()),
+          TimeUnit.MILLISECONDS
+        );
+      }
+    }
+  }
+
+  private void runRetentionCleanup() {
+    Map<RetainedProjectKey, RetainedProject> expired = new HashMap<>();
+    synchronized(retentionCleanupLock) {
+      retentionCleanup = null;
+      long now = System.currentTimeMillis();
+      long nextCleanupAt = Long.MAX_VALUE;
+      for(Map.Entry<RetainedProjectKey, RetainedProject> entry : initialBuildRetentions.entrySet()) {
+        RetainedProjectKey key = entry.getKey();
+        RetainedProject retained = entry.getValue();
+        long cleanupAt = retained.retainedAt() + INITIAL_BUILD_RETENTION_MAX_AGE_MILLIS;
+        if(cleanupAt <= now) {
+          if(initialBuildRetentions.remove(key, retained)) {
+            expired.put(key, retained);
+          }
+        } else {
+          nextCleanupAt = Math.min(nextCleanupAt, cleanupAt);
+        }
+      }
+      scheduleRetentionCleanupAt(nextCleanupAt);
+    }
+    expired.forEach(this::onInitialBuildRetentionReleased);
+  }
+
+  /**
+   * Handles removal of an initial-build retention by flushing Maven core caches only when the normal
+   * {@link #loadingCache} no longer contains the same {@link MavenProject} instance.
+   */
+  private void onInitialBuildRetentionReleased(RetainedProjectKey retainedKey, RetainedProject retained) {
+    CacheLine cacheLine = loadingCache.getIfPresent(retainedKey.cacheKey());
+    if(cacheLine == null || cacheLine.peekProject(retainedKey.pomFile()) != retained.mavenProject()) {
+      flushMavenCaches(retained.mavenProject().getFile(), retainedKey.cacheKey().artifactKey(), false);
+    }
+  }
+
+  private static CacheKey cacheKey(IMavenProjectFacade facade) {
+    return new CacheKey(facade.getArtifactKey(), facade.getConfiguration());
+  }
+
+  private static RetainedProjectKey retainedProjectKey(CacheKey cacheKey, File pomFile) {
+    return new RetainedProjectKey(cacheKey, pomFile.getAbsoluteFile());
   }
 
   /**
@@ -174,6 +312,10 @@ public class MavenProjectCache {
       projects.remove(pomFile);
     }
 
+    MavenProject peekProject(File pomFile) {
+      return projects.get(pomFile);
+    }
+
     void updateProject(IMavenProjectFacade facade, MavenProject mavenProject) {
       File pomFile = facade.getPomFile();
       projects.compute(pomFile, (key, current) -> {
@@ -221,6 +363,12 @@ public class MavenProjectCache {
   }
   
   private static final record CacheKey(ArtifactKey artifactKey, IProjectConfiguration configuration) {
+  }
+
+  private static final record RetainedProjectKey(CacheKey cacheKey, File pomFile) {
+  }
+
+  private static final record RetainedProject(MavenProject mavenProject, long retainedAt) {
   }
 
 }

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/MavenProjectCache.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -1140,6 +1140,10 @@ public class ProjectRegistryManager implements ISaveParticipant {
     }
   }
 
+  public void releaseInitialBuildRetention(IMavenProjectFacade facade, boolean relevant) {
+    mavenProjectCache.releaseInitialBuildRetention(facade, relevant);
+  }
+
   private Set<IFile> flushCaches(IMavenProjectFacade facade, boolean forceDependencyUpdate) {
     if(facade != null) {
       ArtifactKey key = facade.getArtifactKey();


### PR DESCRIPTION
<!--
Thanks for contributing to Eclipse m2e! Please fill in the sections below.

If an AI/coding agent is helping you prepare this PR, it MUST have read AGENTS.md
(https://github.com/eclipse-m2e/m2e-core/blob/main/AGENTS.md) and followed its rules, including
disclosure, running its own review/self-critique before submitting, and re-reading the full review
thread history (not just the latest comment) before pushing follow-up commits.
-->

## What does this PR do?

<!-- Concise description of the change and motivation. Prefer a short, focused description over
     generated prose. Link the issue this addresses, e.g. "Fixes #1234". -->

Fixes https://github.com/eclipse-m2e/m2e-core/issues/2229

Added new properties:
- `m2e.project.cache.initialBuildRetention`: enables retention (see proposed solution in https://github.com/eclipse-m2e/m2e-core/issues/2229); default `false`
- `m2e.mavenProjectCache.initialBuildRetention.maxAgeMillis`: Safety timeout for a retained entry; default 30 minutes

## How was this tested?

<!-- New/changed integration test in the m2e-core-tests submodule, unit tests, or manual verification
     steps. -->

Performed a cache-capacity test using the following values: 50, 128, 256, 512, 768, 1024, 1200, 1300, 1400, 1432, 1536, 2048

For every capacity, the runner:
- launched JDT LS against the Quarkus workspace with a fresh data directory
- enabled Maven import and autobuild, disabled Gradle import, and used Maven online
- set `-Xmx8g`
- waited until relevant server jobs were absent, the Java index was idle, and that state remained quiet for 120 seconds

1. **Effective-model rebuilds collapse:** counts fallback-loader calls that reconstruct the effective model and resolve dependencies for `MavenBuilder`, excluding the original model creation during import.

| Mac | Windows |
| --- | --- |
| <img width="480" alt="Mac model builds" src="https://github.com/user-attachments/assets/dacd527d-2eea-4fe6-bf5a-fef01a582927" /> | <img width="480" alt="Windows model builds" src="https://github.com/user-attachments/assets/6980562d-f7ad-48fd-9d3d-b47977c65555" /> |

2. **Effective-model build time drops:** sum of the fallback-loader durations.

| Mac | Windows |
| --- | --- |
| <img width="960" height="560" alt="model_build_seconds" src="https://github.com/user-attachments/assets/a5b4ef52-c885-4d93-a046-ebd0f338e0f8" /> | <img width="960" height="560" alt="model_build_seconds" src="https://github.com/user-attachments/assets/53502def-8cb9-4d01-a443-23c6e3f5aec5" /> |

3. **End-to-end JDT LS settling time improves**

| Mac | Windows |
| --- | --- |
| <img width="960" height="560" alt="quiescence_seconds" src="https://github.com/user-attachments/assets/de37240a-abb1-4acb-80b1-ad01328ded13" /> | <img width="960" height="560" alt="quiescence_seconds" src="https://github.com/user-attachments/assets/135ba185-68f3-46e9-b75f-7b2ec557b6cb" /> |

In summary, retention reduced model rebuilds by 85.7% on Mac and 87.2% on Windows, model-build time by 93.7% and 96.4%, and full quiescence by 29.9% and 59.7%, respectively.

Across the cache-capacity sweep, retention keeps model rebuilds low and full-quiescence time relatively flat. Without retention, both improve mainly as the cache capacity approaches the workspace working-set size.

### Concerns about memory trade-off

A key concern is whether retaining many `MavenProject` objects significantly increases heap usage. In my experiments, the increase was modest.

<img width="920" height="540" alt="peak-heap-vs-xmx" src="https://github.com/user-attachments/assets/c0b22ee4-dc56-4b18-8736-79aa1d267078" />

Retention keeps imported models alive for longer, but avoids rebuilding evicted models and the temporary allocations from model construction and dependency resolution, so peak heap does not necessarily increase significantly.

## AI/GenAI disclosure

<!-- Required if any AI/coding agent was used to draft this PR's code, tests, or description.
     Delete this section only if no AI tool was involved. -->

- Tool/agent + model/version + mode (interactive/autonomous): <!-- e.g. "Copilot CLI, claude-sonnet-5, interactive" -->
- [x] I have personally reviewed all code, tests, and text in this PR and understand and stand behind
      every change, per the [Eclipse GenAI contribution guidelines](https://www.eclipse.org/projects/handbook/#genai).
- [x] I will personally review and confirm any AI-assisted follow-up changes made in response to review
      comments before pushing them (see [AGENTS.md](../AGENTS.md) rule on reading full thread history).

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [x] `mvn clean verify` (add `-Pits` for integration tests) passes locally.
- [x] Bundle versions are bumped where required (see "Version bump" in [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php).
