### PR TITLE
Remove security manager flag from M2E launch configuration

### DIFF
--- a/products/m2e-ide/Eclipse-M2E-IDE.launch
+++ b/products/m2e-ide/Eclipse-M2E-IDE.launch
@@ -31,7 +31,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM --illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED -Djava.security.manager=allow -Dfile.encoding=UTF-8"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM --illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED -Dfile.encoding=UTF-8"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
     <stringAttribute key="productFile" value="\m2e-products\m2e-ide\m2e-ide.product"/>


### PR DESCRIPTION
## What does this PR do?

The `-Djava.security.manager` system property throws the following error when run with Java 24 or higher:

> A command line option has attempted to allow or enable the Security
Manager. Enabling a Security Manager is not supported.

See https://openjdk.org/jeps/486

## How was this tested?

By launching the M2E product with a recent Java version.

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [ ] `mvn clean verify` (add `-Pits` for integration tests) passes locally.
- [x] Bundle versions are bumped where required (see "Version bump" in [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php).
