### PR TITLE
Do not read the Maven settings while activating the m2e UI bundle

### DIFF
--- a/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.core.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.m2e.core.ui;singleton:=true
-Bundle-Version: 2.4.201.qualifier
+Bundle-Version: 2.4.301.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/M2EUIPluginActivator.java
+++ b/org.eclipse.m2e.core.ui/src/org/eclipse/m2e/core/ui/internal/M2EUIPluginActivator.java
@@ -14,11 +14,6 @@
 
 package org.eclipse.m2e.core.ui.internal;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
@@ -27,32 +22,17 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.resource.ResourceLocator;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
-import org.eclipse.ui.progress.UIJob;
-
-import org.codehaus.plexus.util.FileUtils;
 
 import org.eclipse.m2e.core.internal.IMavenConstants;
-import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.jobs.MavenJob;
 import org.eclipse.m2e.core.internal.lifecyclemapping.discovery.IMavenDiscovery;
 import org.eclipse.m2e.core.ui.internal.archetype.ArchetypePlugin;
@@ -109,17 +89,6 @@ public class M2EUIPluginActivator extends AbstractUIPlugin {
     mavenUpdateConfigurationChangeListener = new MavenUpdateConfigurationChangeListener();
     workspace.addResourceChangeListener(mavenUpdateConfigurationChangeListener, IResourceChangeEvent.POST_CHANGE);
 
-    // Automatically delete obsolete caches
-    // TODO: can be removed when some time has passed and it is unlikely old workspaces that need clean-up are used.
-    MavenPluginActivator mavenPlugin = MavenPluginActivator.getDefault();
-    IPath nexusCache = Platform.getStateLocation(mavenPlugin.getBundle()).append("nexus");
-    FileUtils.deleteDirectory(nexusCache.toFile());
-
-    File localRepo = mavenPlugin.getRepositoryRegistry().getLocalRepository().getBasedir();
-    Path m2eCache = localRepo.toPath().resolve(".cache/m2e/");
-    if(Files.isDirectory(m2eCache)) {
-      deleteLegacyCacheDirectory(m2eCache);
-    }
     // use a custom icon in the progress user interface
     PlatformUI.getWorkbench().getProgressService().registerIconForFamily(MavenImages.M2, MavenJob.FAMILY_M2);
   }
@@ -205,50 +174,6 @@ public class M2EUIPluginActivator extends AbstractUIPlugin {
       }
     }
     return this.archetypeManager.getService();
-  }
-
-  private static void deleteLegacyCacheDirectory(Path m2eCache) {
-    Path resolve = m2eCache.resolve("DELETE_ME.txt");
-    if(Files.isRegularFile(resolve) || Boolean.parseBoolean(System.getProperty("m2e.keep.legacy.cache"))) {
-      return;
-    }
-    new UIJob("Delete legacy M2E cache") {
-      @Override
-      public IStatus runInUIThread(IProgressMonitor monitor) {
-        boolean[] askAgain = new boolean[] {true};
-        MessageDialog dialog = new MessageDialog(getDisplay().getActiveShell(), "Delete obsolete M2E cache?", null,
-            "A cache directory used by previous M2E versions was detected:\n\n" + m2eCache + "\n\n"
-                + "It's no longer used by newer M2E versions and, unless older Eclipse installations need it, can be safely deleted.",
-            MessageDialog.QUESTION, 0, "Keep Cache", "Delete Cache") {
-          @Override
-          protected Control createCustomArea(Composite parent) {
-            Button checkbox = new Button(parent, SWT.CHECK);
-            checkbox.setText("Don't ask me again?");
-            checkbox.addSelectionListener(
-                SelectionListener.widgetSelectedAdapter(e -> askAgain[0] = !checkbox.getSelection()));
-            return super.createCustomArea(parent);
-          }
-        };
-        int selection = dialog.open();
-        if(selection == 1) {
-          try {
-            FileUtils.deleteDirectory(m2eCache.toFile());
-          } catch(IOException e) {
-            return Status.error("Failed to delete legacy M2E cache", e);
-          }
-        } else if(!askAgain[0]) {
-          try {
-            Files.writeString(resolve,
-                """
-                    This cache directory was created by a previous Maven2Eclipse 1.x version and is no longer used since M2E 2.0.
-                    Unless older Eclipse installations need it, it can be deleted safely."
-                    """);
-          } catch(IOException ex) { // Ignore
-          }
-        }
-        return Status.OK_STATUS;
-      }
-    }.schedule(10_000);
   }
 
 }


### PR DESCRIPTION
The *Update Project* contribution in the Project menu carries `forcePluginActivation="true"`, so the workbench starts `org.eclipse.m2e.core.ui` on the UI thread while it computes menu visibility during startup. The activator then cleaned up the caches of m2e 1.x, and the `getLocalRepository()` call needed for that entered the Maven settings lock that `RepositoryRegistryUpdateJob` holds while Guice builds the Plexus container. Sampled thread dumps of an SDK startup show the UI thread blocked there for about 600 ms.

The cleanup was added in October 2022 with a TODO to remove it once workspaces that need it are unlikely, which four years later it is. Removing it makes the activation cheap and takes the Maven settings out of the startup path, without changing when the bundle starts.

This is separate from #1749, #2008 and #2217, which address the order in which the two locks are taken rather than who takes them during startup.

`Bundle-Version` is bumped to 2.4.301 because the baseline check asks for it after the inner classes of the deleted job disappear.