### PR TITLE
Avoid unnecessary dependency propagation during phase2 revisits

### DIFF
--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -445,6 +445,7 @@ public class ProjectRegistryManager implements ISaveParticipant {
     context.forcePomFiles(allProcessedPoms);
 
     // phase 2: resolve project dependencies
+    Set<IFile> phase2Visited = new HashSet<>();
     ProjectProcessingTracker tracker = new ProjectProcessingTracker(context);
     do {
       while(!context.isEmpty()) {
@@ -458,6 +459,8 @@ public class ProjectRegistryManager implements ISaveParticipant {
 
         IFile pom = context.pop();
         if(tracker.shouldProcess(pom)) {
+
+          boolean firstVisit = phase2Visited.add(pom);
 
           MavenProjectFacade newFacade = null;
           if(pom.isAccessible() && pom.getProject().hasNature(IMavenConstants.NATURE_ID)) {
@@ -489,11 +492,13 @@ public class ProjectRegistryManager implements ISaveParticipant {
             IProjectConfiguration resolverConfiguration = facade.getConfiguration();
             createExecutionContext(newState, pom, resolverConfiguration).execute(getMavenProject(newFacade),
                 (executionContext, pm) -> {
-                  refreshPhase2(newState, context, originalCapabilities, originalRequirements, pom, facade, pm);
+                  refreshPhase2(newState, context, originalCapabilities, originalRequirements, pom, facade,
+                      firstVisit, pm);
                   return null;
                 }, monitor);
           } else {
-            refreshPhase2(newState, context, originalCapabilities, originalRequirements, pom, newFacade, monitor);
+            refreshPhase2(newState, context, originalCapabilities, originalRequirements, pom, newFacade,
+                firstVisit, monitor);
           }
           monitor.worked(1);
         }
@@ -558,7 +563,7 @@ public class ProjectRegistryManager implements ISaveParticipant {
 
   void refreshPhase2(MutableProjectRegistry newState, DependencyResolutionContext context,
       Map<IFile, Set<Capability>> originalCapabilities, Map<IFile, Set<RequiredCapability>> originalRequirements,
-      IFile pom, MavenProjectFacade newFacade, IProgressMonitor monitor) throws CoreException {
+      IFile pom, MavenProjectFacade newFacade, boolean firstVisit, IProgressMonitor monitor) throws CoreException {
     Set<Capability> capabilities = null;
     Set<RequiredCapability> requirements = null;
     if(newFacade != null) {
@@ -610,10 +615,9 @@ public class ProjectRegistryManager implements ISaveParticipant {
       }
     }
 
-    Set<Capability> oldCapabilities = newState.setCapabilities(pom, capabilities);
-    if(originalCapabilities.containsKey(pom)) {
-      oldCapabilities = originalCapabilities.get(pom);
-    }
+    Set<Capability> previousCapabilities = newState.setCapabilities(pom, capabilities);
+    Set<Capability> oldCapabilities = firstVisit ? originalCapabilities.getOrDefault(pom, previousCapabilities)
+        : previousCapabilities;
     // if our capabilities changed, recalculate everyone who depends on new/changed/removed capabilities
     Set<Capability> changedCapabilities = diff(oldCapabilities, capabilities);
 

--- a/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
+++ b/org.eclipse.m2e.core/src/org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager.java
@@ -634,10 +634,10 @@ public class ProjectRegistryManager implements ISaveParticipant {
           : newState.getDependents(capability, true));
     }
 
-    Set<RequiredCapability> oldRequirements = newState.setRequirements(pom, requirements);
-    if(originalRequirements.containsKey(pom)) {
-      oldRequirements = originalRequirements.get(pom);
-    }
+    Set<RequiredCapability> previousRequirements = newState.setRequirements(pom, requirements);
+    Set<RequiredCapability> oldRequirements = firstVisit
+        ? originalRequirements.getOrDefault(pom, previousRequirements)
+        : previousRequirements;
     // if our dependencies changed, recalculate everyone who depends on us
     // this is needed to deal with transitive dependency resolution in maven
     if(oldCapabilities != null && hasDiff(oldRequirements, requirements)) {


### PR DESCRIPTION
<!--
Thanks for contributing to Eclipse m2e! Please fill in the sections below.

If an AI/coding agent is helping you prepare this PR, it MUST have read AGENTS.md
(https://github.com/eclipse-m2e/m2e-core/blob/main/AGENTS.md) and followed its rules, including
disclosure, running its own review/self-critique before submitting, and re-reading the full review
thread history (not just the latest comment) before pushing follow-up commits.
-->

## What does this PR do?

<!-- Concise description of the change and motivation. Prefer a short, focused description over
     generated prose. Link the issue this addresses, e.g. "Fixes #1234". -->

Related to #123

`ProjectRegistryManager.refresh()` has two phases. Phase1 reads each project and records its pre-refresh capabilities and requirements before replacing them with the information available at that point. Phase2 then resolves dependencies and stores the complete capability and requirement state.

Phase2 may process a project multiple times. Previously, every visit was compared with the pre-refresh state. This was correct for the first visit, but a later visit ignored the result of the preceding visit. As a result, M2E could detect the same change repeatedly, unnecessarily re-enqueue dependent projects, and trigger additional phase2 processing cycles.

This PR uses the pre-refresh state only for the first phase2 visit. Each later visit is compared with the result of the preceding phase2 visit. Dependent projects are therefore re-enqueued when capabilities or requirements actually change, but not when a revisit produces the same result.

## How was this tested?

<!-- New/changed integration test in the m2e-core-tests submodule, unit tests, or manual verification
     steps. -->
Existing tests + manually tested with the Quarkus project with instrumentation (local) that recorded phase2 visits

## AI/GenAI disclosure

<!-- Required if any AI/coding agent was used to draft this PR's code, tests, or description.
     Delete this section only if no AI tool was involved. -->

- Claude Opus 4.6, interactive
- [x] I have personally reviewed all code, tests, and text in this PR and understand and stand behind
      every change, per the [Eclipse GenAI contribution guidelines](https://www.eclipse.org/projects/handbook/#genai).
- [x] I will personally review and confirm any AI-assisted follow-up changes made in response to review
      comments before pushing them (see [AGENTS.md](../AGENTS.md) rule on reading full thread history).

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [x] `mvn clean verify` (add `-Pits` for integration tests) passes locally.
- [x] Bundle versions are bumped where required (see "Version bump" in [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php).
